### PR TITLE
Fix for OpenSearch on firefox 4

### DIFF
--- a/templates/wrapper.html
+++ b/templates/wrapper.html
@@ -30,7 +30,7 @@
   <link href="/static/css/shCore.css?1" rel="stylesheet" type="text/css">
   <link href="/static/css/shThemeDefault.css?1" rel="stylesheet" type="text/css">
   <link href="/static/style.css?2" rel="stylesheet" type="text/css">
-  <link rel="search" href="/static/opensearch.xml" type="application/opensearchdescription+xml">
+  <link rel="search" href="/static/opensearch.xml" type="application/opensearchdescription+xml" title="MetaCPAN">
   <script src="/static/js/jquery.min.js?1" type="text/javascript"></script>
   <script src="/static/js/jquery.cookie.js?1" type="text/javascript"></script>
   <script src="/static/js/jquery.relatize_date.js?1" type="text/javascript"></script>


### PR DESCRIPTION
This makes Firefox 4 display it as a choice in the search box.
(Technically the spec says this isn't required as it's only a 'may'.)

I put this as a comment in issue 21, but don't seem to be able to reopen that pull request, so here it is.
