### PR TITLE
profiles links underline

### DIFF
--- a/root/author.html
+++ b/root/author.html
@@ -10,14 +10,15 @@
   <a href="<% author.website.0 %>" title="<% author.website.0 %>" target="_blank"><% author.website.0.decode_punycode %></a><br><% END %>
 <%
 IF author.profile.size -%>
-<strong>Profiles</strong><br>
+<strong>Profiles</strong>
+<div class='user-profiles'>
 <%-
 FOREACH profile IN author.profile.sort('name');
 IF profiles.${profile.name} %>
 <a href="<% profiles.${profile.name}.url.replace('%s', profile.id) %>" target="_blank">
   <img src="/static/images/profile/<% profile.name %>.png" width=16 height=16 alt="<% profile.name %>" title="<% profile.name %> - <% profile.id%>">
 </a>
-<% END; END %><br><% END %>
+<% END; END %></div><% END %>
 <% IF author.country || author.city || author.region %>
 <strong>Location</strong><br>
 <% IF author.country %>

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -277,6 +277,10 @@ input.g-button:active, button.g-button:active, a.g-button:active {
     visibility: visible
 }
 
+.user-profiles > a {
+    text-decoration: none;
+}
+
 .account-bar a {
     display: block;
     padding: 6px;


### PR DESCRIPTION
In Chromium (12.0) profile links have 'text-decoration: underline', which shows annoying underline glitch on mouseover:

![alt](http://korshak.name/tmp/metacpanXf6U.gif)

Firefox doesn't suffer from this though.
