### PR TITLE
Sort order of the releases on the author page changed to reverse chronological.

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Author.pm
+++ b/lib/MetaCPAN/Web/Controller/Author.pm
@@ -23,7 +23,8 @@ sub index : Path : Args(1) {
                 }
             },
             sort => [
-                'distribution', { 'version_numified' => { reverse => \1 } }
+                { date => "desc" },
+                { 'version_numified' => { reverse => \1 } },
             ],
             fields => [qw(author distribution name status abstract date)],
             size   => 1000,


### PR DESCRIPTION
Usually when i look at an author page i want to see what they've been up to recently. I never had a reason for looking at an alphabetical listing there and honestly cannot even think of a use case for that. As such i think reverse chronological order by default would be an improvement.
