### PR TITLE
fix diff syntax highlighting

### DIFF
--- a/root/static/js/shBrushDiff.js
+++ b/root/static/js/shBrushDiff.js
@@ -22,12 +22,12 @@
 	function Brush()
 	{
 		this.regexList = [
-			{ regex: /^\+\+\+.*$/gm,		css: 'color2' },
-			{ regex: /^\-\-\-.*$/gm,		css: 'color2' },
-			{ regex: /^\s.*$/gm,			css: 'color1' },
-			{ regex: /^@@.*@@.*/gm,			css: 'variable' },
-			{ regex: /^\+[^\+]{1}.*$/gm,	css: 'string' },
-			{ regex: /^\-[^\-]{1}.*$/gm,	css: 'comments' }
+			{ regex: /^\+\+\+.*$/gm,        css: 'color2' },
+			{ regex: /^---.*$/gm,           css: 'color2' },
+			{ regex: /^(?=\s).*$/gm,        css: 'color1' },
+			{ regex: /^@@.*@@.*/gm,         css: 'variable' },
+			{ regex: /^\+(?!\+).*$/gm,      css: 'string' },
+			{ regex: /^-(?!-).*$/gm,        css: 'comments' }
 			];
 	};
 


### PR DESCRIPTION
An empty line could cause highlighting to bleed into the next line.
