### PR TITLE
don't blow up on invalid author website URLs 

### DIFF
--- a/lib/MetaCPAN/Web/View/HTML.pm
+++ b/lib/MetaCPAN/Web/View/HTML.pm
@@ -86,7 +86,12 @@ Template::Alloy->define_vmethod(
 Template::Alloy->define_vmethod(
     'text',
     decode_punycode => sub {
-        URI->new(shift)->ihost;
+        my $url_string = shift;
+        my $uri = URI->new($url_string);
+        if(!$uri->scheme){
+            $uri = URI->new("http://$url_string"); # default to http:// if no scheme in original...
+        }
+        return $uri->ihost;
     }
 );
 


### PR DESCRIPTION
be more lenient with how URIs are acted upon (in case they don't have a scheme)

Default to http:// if the original URL has no scheme

(this time without the typo)
