### PR TITLE
Adding ! redirect for duckduckgo

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Search.pm
+++ b/lib/MetaCPAN/Web/Controller/Search.pm
@@ -3,6 +3,8 @@ use strict;
 use warnings;
 use base 'MetaCPAN::Web::Controller';
 use Plack::Response;
+use URI;
+use URI::QueryParam;
 
 sub index : Path {
     my ( $self, $c ) = @_;
@@ -19,7 +21,14 @@ sub index : Path {
 
     my $model = $c->model('API::Module');
     my $from  = ( $req->page - 1 ) * 20;
-    if ( $req->parameters->{lucky} ) {
+    if ( $query =~ m/^!/ ) {
+        $query =~ s/^! //;
+        my $ddg_uri = URI->new("http://duckduckgo.com/");
+        $ddg_uri->query_param( q => $query );
+        $c->res->redirect($ddg_uri->as_string);
+        $c->detach;
+    }
+    elsif ( $req->parameters->{lucky} ) {
         my $module = $model->first($query)->recv;
         $c->detach('/not_found') unless ($module);
         $c->res->redirect("/module/$module");


### PR DESCRIPTION
This patch enables on metacpan that a query starting with ! will go to duckduckgo. If the query starts with "! " then the "! " will be removed before redirect, so "! test" will search for test on duckduckgo (that could be probably later replaced with a DIRECT integration of the ZeroClickInfo), and everything else untouched. This way people have all the redirect bangs that are available via DuckDuckGo also in metacpan. This feature is for people who mostly search on metacpan but still want access to all other search engines via their default search engine, which could be metacpan then.
