### PR TITLE
Implement DuckDuckGo-like ! (or \\) syntax for IFL

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Search.pm
+++ b/lib/MetaCPAN/Web/Controller/Search.pm
@@ -23,7 +23,10 @@ sub index : Path {
 
     my $model = $c->model('API::Module');
     my $from  = ( $req->page - 1 ) * 20;
-    if ( $req->parameters->{lucky} ) {
+    if ( $req->parameters->{lucky} or
+         # DuckDuckGo-like syntax for bangs that redirect to the first
+         # result.
+         $query =~ s[^ (?: \\ | ! ) ][]x) {
         my $module = $model->first($query)->recv;
         $c->detach('/not_found') unless ($module);
         $c->res->redirect("/module/$module");


### PR DESCRIPTION
Inspired by "[Adding ! redirect for duckduckgo](https://github.com/CPAN-API/metacpan-web/pull/269)", see
that discussion for the previous flamewar.

Instead of having to pass lucky=1 as a GET parameter you can now enter
a search term beginning with "!" or "\" to have MetaCPAN return the
first result to you.

E.g. searching for "!Plack" or "\Plack" will redirect you to
/module/Plack.

This is an alternative to pressing Shift+Enter on the site to go to
the first result, but the real value is being able to use
e.g. DuckDuckGo to search for "!cpan !Plack" to go to the first
MetaCPAN result.

See-Also: https://github.com/CPAN-API/metacpan-web/pull/269
