### PR TITLE
handle arbitrary sized headers in diffs.

### DIFF
--- a/root/diff.html
+++ b/root/diff.html
@@ -54,7 +54,7 @@ file.path = parts.join("/"); END -%>
         <div class="diff-header">
             <a href="/source/<% diff.target %>/<% file.path %>"><% file.path %></a>
         </div>
-        <pre class="brush: diff; class-name: 'highlight'; toolbar: false; gutter: false" id="source"><% parts = file.diff.split("\n"); FOREACH i IN [1,2,3,4]; foo = parts.shift; END; parts.join("\n") %></pre>
+        <pre class="brush: diff; class-name: 'highlight'; toolbar: false; gutter: false" id="source"><% parts = file.diff.split("\n"); WHILE parts; line = parts.shift; LAST IF line.match( '^\+' ); END; parts.join("\n") %></pre>
     </div>
 <% END %>
 </div>


### PR DESCRIPTION
When I was browsing the diff for Geo-Coder-Google [1], I noticed that not all of the diffs started with the "@@" marker. As it turns out the template assumed that only the first four lines were to be removed.

I've patched the template to remove header lines until we hit the "+++" line.

[1] https://metacpan.org/diff/release/MIYAGAWA/Geo-Coder-Google-0.06/ARCANEZ/Geo-Coder-Google-0.07
