### PR TITLE
Add HTML::Restrict to dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,6 +24,7 @@ Gravatar::URL = 0
 Hash::AsObject = 0
 Hash::Merge = 0
 HTML::Tree = 0
+HTML::Restrict = 0
 HTTP::Request::Common = 0
 JSON::XS = 0
 Module::Find = 0


### PR DESCRIPTION
Add HTML::Restrict to dependencies, since lib/MetaCPAN/Web/Controller/Module.pm uses it.
