### PR TITLE
set title in source.html

### DIFF
--- a/root/source.html
+++ b/root/source.html
@@ -1,4 +1,5 @@
 <%- rss = 'distribution/' _ module.distribution %>
+<%- title = module.path %>
 <strong><big>
     <a href="/source/<% base = [module.author, module.release].join("/"); base %>"><% [module.author, module.release].join(" / ") %></a>
   <% FOREACH part IN module.path.split("/"); base = base _ "/" _ part -%>


### PR DESCRIPTION
More informative html title for all /source pages.
Title for `/source/DOY/Moose-2.0205/lib/Moose/Role.pm` page, for example, will be `lib/Moose/Role.pm - metacpan.org` instead of the default `Search the CPAN - metacpan.org`.
