### PR TITLE
Allow class/style attrs in table,tr,and td in POD

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Module.pm
+++ b/lib/MetaCPAN/Web/Controller/Module.pm
@@ -66,10 +66,10 @@ sub index : PathPart('module') : Chained('/') : Args {
             strong  => [],
             sub     => [],
             sup     => [],
-            table   => [qw( style border cellspacing cellpadding align )],
+            table   => [qw( style class border cellspacing cellpadding align )],
             tbody   => [],
-            td      => [],
-            tr      => [],
+            td      => [ qw(style class) ],
+            tr      => [ qw(style class) ],
             u       => [],
             ul      => ['id'],
         }


### PR DESCRIPTION
This commit allows HTML paragraphs in the POD to contain table, tr, and td tags with "class" and "style" tags
