### PR TITLE
Create scoreboard dir if it doesn't exist.

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -14,6 +14,7 @@ BEGIN {
 
 use FindBin;
 use lib "$FindBin::RealBin/lib";
+use File::Path ();
 use MetaCPAN::Web;
 use Plack::App::File;
 use Plack::App::URLMap;
@@ -30,11 +31,15 @@ $app->map( '/static/' => Plack::App::File->new( root => 'root/static' ) );
 $app->map( '/favicon.ico' =>
         Plack::App::File->new( file => 'root/static/icons/favicon.ico' ) );
 $app->map( '/' => sub { MetaCPAN::Web->run(@_) } );
+my $scoreboard = "$FindBin::RealBin/var/tmp/scoreboard";
+unless (-d $scoreboard) {
+    File::Path::make_path($scoreboard) or die "Can't make_path $scoreboard: $!";
+}
 $app = Plack::Middleware::ServerStatus::Lite->wrap(
    $app,
    path       => '/server-status',
    allow      => ['127.0.0.1'],
-   scoreboard => "$FindBin::RealBin/var/tmp/scoreboard"
+   scoreboard => $scoreboard,
 ) unless $0 =~ /\.t$/;
 $app = Plack::Middleware::Runtime->wrap($app);
 $app = Plack::Middleware::Assets->wrap( $app,

--- a/dist.ini
+++ b/dist.ini
@@ -21,6 +21,7 @@ Config::General = 0
 DateTime::Format::HTTP = 0
 DateTime::Format::ISO8601 = 0
 Encode = 2.10
+File::Path = 0
 Gravatar::URL = 0
 Hash::AsObject = 0
 Hash::Merge = 0


### PR DESCRIPTION
I was getting errors when var/tmp/\* didn't exist.  This is a small patch to fix that.
