### PR TITLE
Adding Catalyst::Action::RenderView as a prereq

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,6 +13,7 @@ Catalyst::Authentication::Store::Proxy = 0.0.1
 Catalyst::Controller::ActionRole = 0
 Catalyst::Plugin::Authentication = 0
 Catalyst::Plugin::ConfigLoader = 0
+Catalyst::Action::RenderView = 0
 Catalyst::Plugin::Static::Simple = 0
 Catalyst::Plugin::Unicode::Encoding = 0
 Catalyst::TraitFor::Request::REST::ForBrowsers = 0


### PR DESCRIPTION
This should add Catalyst::Action::RenderView as a prereq. It didn't appear when I did `dzil listdeps --missing` but starting it with `plackup -p 5001 -r` complained about it missing.
