### PR TITLE
Prevent Github popup from firing when 'Homepage' link contains 'github.com'

### DIFF
--- a/root/inc/release-info.html
+++ b/root/inc/release-info.html
@@ -1,4 +1,4 @@
-      <% IF release.resources.homepage %><li><a href="<% release.resources.homepage %>">Homepage</a></li><% END %>
+      <% IF release.resources.homepage %><li><a class="nopopup" href="<% release.resources.homepage %>">Homepage</a></li><% END %>
       <% IF release.resources.repository %>
       <li>
         <% IF release.resources.repository.web %>

--- a/root/static/js/github.js
+++ b/root/static/js/github.js
@@ -195,8 +195,8 @@ function Github() {
 };
 
 $(document).ready(function() {
-    $('.search-bar a').each(function() {
-        var github = new Github();
-        github.createPopup(this);
+    $('.search-bar a:not(.nopopup)').each(function() {
+          var github = new Github();
+          github.createPopup(this);
     });
 });


### PR DESCRIPTION
Fixes issue #561
