### PR TITLE
add section if help is wanted

### DIFF
--- a/root/release.html
+++ b/root/release.html
@@ -35,6 +35,15 @@
   </ul>
   <hr>
   <% INCLUDE inc/activity.html query = 'distribution=' _ release.distribution %>
+<% IF release.metadata.x_help_wanted %>
+   <hr>
+   <strong>Help Wanted</strong> 
+   <ul>
+<% FOREACH position IN release.metadata.x_help_wanted %>
+    <li><% position %></li>
+<% END %>    
+   </ul>
+<% END %>
   <hr>
   <strong>Permalinks</strong>
   <ul>


### PR DESCRIPTION
The whole motivation for the patch is at http://babyl.dyndns.org/techblog/entry/help-wanted

In a nutshell: add a sidebar item on the release webpage if the x_help_wanted element is set in the META information.
