### PR TITLE
Make the dist name more easily selectable

### DIFF
--- a/root/module.html
+++ b/root/module.html
@@ -4,7 +4,7 @@
   &nbsp;/&nbsp;
   <a href="/release/<% IF release.status == 'latest'; release.distribution; ELSE; [module.author, module.release].join('/'); END %>"><% module.release %></a>
   &nbsp;/&nbsp;
-  <% module.documentation %>
+  <span class="select-text"><% module.documentation %></span>
   </big></strong>
   <% INCLUDE inc/favorite.html module = module %>
   <% IF release.status != 'latest' %><div style="float: right"><strong><big><% IF release.maturity == 'developer'; 'dev release, '; END %></big><a href="/module/<% module.documentation %>"><big>go to latest</big></a></strong></div><% END %><br><br>

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -631,6 +631,12 @@ ul {
     color: #999;
     font-size: 0.8em;
 }
+.select-text {
+    -moz-user-select: all;
+    -ms-user-select: all;
+    -webkit-user-select: all;
+    user-select: all;
+}
 
 .box-right {
     float: right;


### PR DESCRIPTION
This just makes it easier to select the distname when viewing a module, for instance to copy paste and install via cpanm. The CSS-class can be applied to any element where such behavior is wanted. It only works in IE and FF I think, but I figured thats better than none :)
