### PR TITLE
Links to matrix.cpantesters.org

### DIFF
--- a/root/inc/release-info.html
+++ b/root/inc/release-info.html
@@ -27,7 +27,7 @@
       <li>
           <a href="http://www.cpantesters.org/distro/<% release.distribution.chunk(1).0.uc     %>/<% release.distribution %>.html#<% release.name %>" title="(pass / fail / na)">Test results</a>
           <% IF release.tests.size %>(<span style="color: #090"><% release.tests.pass %></span> / <span style="color: #900"><% release.tests.fail %></span> / <% release.tests.na %>)<% END %>
-          <a href="http://matrix.cpantesters.org/?dist=<% release.name %>" title="Matrix"><img src="/static/icons/grid.png" width="16" height="16" style="vertical-align: bottom; padding: 1px"></a>
+          <a href="http://matrix.cpantesters.org/?dist=<% release.distribution %>+<% release.version %>" title="Matrix"><img src="/static/icons/grid.png" width="16" height="16" style="vertical-align: bottom; padding: 1px"></a>
       </li>
       <li><a href="http://cpants.charsbar.org/dist/overview/<% release.distribution %>">CPANTS</a></li>
       <% IF release.license %><li>License: <% release.license.join(', ') %></li><% END %>

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -144,7 +144,7 @@ foreach my $test ( @tests ) {
 
         $tx->is(
             '//a[@title="Matrix"]/@href',
-            "http://matrix.cpantesters.org/?dist=$release-$version",
+            "http://matrix.cpantesters.org/?dist=$release+$version",
             'link to test matrix'
         );
 


### PR DESCRIPTION
links should be in the form

```
"...?dist=Module+Version" (with a URI escaped space)
```

and not

```
"...?dist=Module-Version"
```

Most of the time, using a dash as a separator works, but not always. See for example http://matrix.cpantesters.org/?dist=CPAN-2.00-TRIAL which is showing an error page. The link
http://matrix.cpantesters.org/?dist=CPAN+2.00-TRIAL works.

search.cpan.org is also using the space here.

Regards,
    Slaven
