### PR TITLE
Force the name column in the file browser to have a width

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -726,7 +726,7 @@ div.qtip-github table th {
     font-weight: bold;
 }
 
-.release-table .name {
+.file-table .name, .release-table .name {
     width: 266px;
 }
 


### PR DESCRIPTION
Fixes issue #629.
