### PR TITLE
Cleanup contributors list CSS

### DIFF
--- a/root/inc/contributors.html
+++ b/root/inc/contributors.html
@@ -9,7 +9,7 @@
     </div>
     <ul style="display: none">
     <% FOREACH contributor IN contributors %>
-        <li style="text-align: left; padding-left: 22px;">
+        <li class="contributor<% ' cpan' IF contributor.pauseid %>">
         <% IF contributor.pauseid %>
         <a href="<% contributor.url %>" 
            class="cpan_author" 

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -1021,3 +1021,21 @@ div.qtip-github table th {
 .leader_board_top_rest .leader_board_count {
     float: right;
 }
+
+
+/* Contributors list on release pages
+ * see /release/Plack for example
+ */
+
+#contributors .contributor {
+    position: relative;
+    text-align: left;
+    padding-left: 22px;
+}
+#contributors .contributor.gravatar img {
+    left: 0;
+    position: absolute;
+}
+#contributors .contributor * {
+    vertical-align: top;
+}

--- a/root/static/js/contributors.js
+++ b/root/static/js/contributors.js
@@ -22,9 +22,8 @@ $(function(){
             var $img = $('<img />').attr( 'src', gravatar )
                 .attr( 'width', 20 )
                 .attr( 'height', 20 );
-            $anchor.css( 'margin-left', '1px' );
-            $anchor.parent().css( 'padding-left', '1px' );
             $anchor.text( data.name );
+            $anchor.parent().addClass('gravatar');
             $anchor.before( $img );
         });
     });


### PR DESCRIPTION
This removes inline styles, instead using classes and defining the styles
in the css file. It also centers the text alongside the gravatar, and uses
a slightly different way of positioning it

Before:
![Before](https://f.cloud.github.com/assets/23787/389752/36892f9a-a71d-11e2-8c70-bafb85bad9fa.png)

After:
![After](https://f.cloud.github.com/assets/23787/389753/3708c4c6-a71d-11e2-9610-e4ee1460800b.png)
