### PR TITLE
Set max-width to 42em on text blocks

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -527,6 +527,7 @@ button.favorite:hover, button.favorite.active, a.favorite.active, a.favorite:hov
 
 .pod p, .pod dt {
     font-size: 1.1em;
+    max-width: 42em;
 }
 
 .pod dt {
@@ -767,6 +768,7 @@ div.qtip-github table th {
     color: #999;
     max-height:3em;
     overflow:hidden;
+    max-width: 42em;
 }
 
 .rating-00, .rating-05, .rating-10, .rating-15, .rating-20, .rating-25, .rating-30, .rating-35, .rating-40, .rating-45, .rating-50 {


### PR DESCRIPTION
This makes it easier to read, as the scan back to the next line is shorter.
This becomes very aparent in todays wide screen display era. The number 42 is
picked more or less at random, so feel free to adjust that if you want :)

After:
![After](https://dl.dropboxusercontent.com/s/dg9h1hlgl336hre/Screen%20Shot%202013-07-14%20at%2010.28.04%20AM.png)

Before:
![Before](https://dl.dropboxusercontent.com/s/7snnsskjwlg1x8o/Screen%20Shot%202013-07-14%20at%2010.28.46%20AM.png)
