### PR TITLE
Split _rt_cpan in two regular expressions

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -74,7 +74,11 @@ sub filter_release_changes {
 sub _rt_cpan {
     my ($self, $line) = @_;
 
-    $line =~ s{\b((?:RT)?(?:\s)?[#:-])(\d+)\b}{<a href="https://rt.cpan.org/Ticket/Display.html?id=$2">$1$2</a>}gx;
+    my $u = '<a href="https://rt.cpan.org/Ticket/Display.html?id=';
+    # Stricter regex for -:
+    $line =~ s{\b(RT[-:])(\d+)\b}{$u$2">$1$2</a>}gx;
+    # A bit more relaxed here?
+    $line =~ s{\b((?:RT)(?:\s*)[#])(\d+)\b}{$u$2">$1$2</a>}gx;
 
     return $line;
 }

--- a/t/model/changes.t
+++ b/t/model/changes.t
@@ -12,8 +12,12 @@ subtest "RT ticket linking" => sub {
         'Fixed RT#1013'  => 'id=1013">RT#1013',
         'Fixed RT #1013' => 'id=1013">RT #1013',
         'Fixed RT-1013'  => 'id=1013">RT-1013',
-        'Fixed #1013'    => 'id=1013"> #1013',
+        # This one is too broad for now?, see ticker #914
+        # 'Fixed #1013'    => 'id=1013"> #1013',
         'Fixed RT:1013'  => 'id=1013">RT:1013',
+        # We don't want to link the time in this one..
+        # See ticket #914
+        'Revision 2.15 2001/01/30 11:46:48 rbowen' => 'Revision 2.15 2001/01/30 11:46:48 rbowen',
     );
 
     while (my ($in, $out) = each %rt_tests) {


### PR DESCRIPTION
This allows finer grain of control (and quite frankly, makes it a bit 
easier to read). 
- Fix #914 by requiring RT for - and : separators (RT-1, RT:1), and no
  spaces
- Fix #914 other half by needing RT for # as well for now. If issue
  tracker is github, we still allow without prefix. RT is default
  tracker, so we cannot make broad assumptions here.
