### PR TITLE
Only show changes if we find the right version

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -27,9 +27,20 @@ sub last_version {
     my @releases = $changes->releases;
     return unless scalar @releases;
 
-    return $self->filter_release_changes($releases[-1], $release);
+    # Ok, lets make sure we get the right release..
+    my $changelog = $self->find_changelog($release->{version}, \@releases);
+
+    return unless $changelog;
+    return $self->filter_release_changes($changelog, $release);
 }
 
+sub find_changelog {
+    my ($self, $version, $releases) = @_;;
+
+    foreach my $rel (@$releases) {
+        return $rel if ($rel->version eq $version);
+    }
+}
 
 sub filter_release_changes {
     my ($self, $changelog, $release) = @_;

--- a/t/controller/release.t
+++ b/t/controller/release.t
@@ -74,13 +74,19 @@ test_psgi app, sub {
     );
 
     ok( $res = $cb->( GET '/release/ANDREMAR/WWW-Curl-Simple-0.100187' ) );
-    my $tx_cc = tx( $res );
+    $tx_cc = tx( $res );
     is (
         $tx_cc->find_value('//a[@href="https://github.com/omega/www-curl-simple/issues/8"]'),
         '#8',
         "link to github issues is there"
     );
 
+
+    # Test that we don't show changes for unrelated version, check issue #914
+    # for original bug report.
+    ok( $res = $cb->( GET '/release/SHLOMIF/Config-IniFiles-2.81/' ) );
+    $tx_cc = tx( $res );
+    $tx_cc->not_ok( '//div[@class="content"]/strong[following-sibling::div[@class="last-changes"]]');
 };
 
 done_testing;

--- a/t/model/changes.t
+++ b/t/model/changes.t
@@ -2,6 +2,8 @@ use strict;
 use warnings;
 
 use Test::More;
+use aliased 'CPAN::Changes::Release';
+
 use aliased 'MetaCPAN::Web::Model::API::Changes';
 
 subtest "RT ticket linking" => sub {
@@ -35,6 +37,16 @@ subtest "GH issue linking" => sub {
     }
 };
 
+subtest 'find changelog' => sub {
+    my $releases = [
+        Release->new(version => 0.01),
+        Release->new(version => 12314),
+    ];
+
+    my $latest = Changes->find_changelog(0.01, $releases);
+    is($latest->version, "0.01", "found the version we wanted..");
+
+};
 
 
 done_testing;


### PR DESCRIPTION
If we cannot find the version of the release we are looking at in the 
parsed CPAN::Changes, we won't show anything. This should prevent some 
of the broken changes seen in issue #914
