### PR TITLE
Adjust regex for issue linker in latest changes

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -89,9 +89,12 @@ sub _rt_cpan {
 
     my $u = '<a href="https://rt.cpan.org/Ticket/Display.html?id=';
     # Stricter regex for -:
-    $line =~ s{\b(RT[-:])(\d+)\b}{$u$2">$1$2</a>}gx;
+    $line =~ s{\b(RT[-:]?)(\d+)\b}{$u$2">$1$2</a>}gix;
     # A bit more relaxed here?
     $line =~ s{\b((?:RT)(?:\s*)[#])(\d+)\b}{$u$2">$1$2</a>}gx;
+
+    # Some other cases
+    $line =~ s{\b(bug\s+\#)(\d+)\b}{$u$2">$1$2</a>}gxi;
 
     return $line;
 }
@@ -99,7 +102,7 @@ sub _rt_cpan {
 sub _gh {
     my ($self, $line, $bt) = @_;
     $bt =~ s|/$||;
-    $line =~ s{((?:GH|)[#:-])(\d+)\b}{<a href="$bt/$2">$1$2</a>}gx;
+    $line =~ s{((?:GH|)[#:-])(\d+)\b}{<a href="$bt/$2">$1$2</a>}gxi;
     return $line;
 }
 1;

--- a/t/model/changes.t
+++ b/t/model/changes.t
@@ -20,6 +20,10 @@ subtest "RT ticket linking" => sub {
         # We don't want to link the time in this one..
         # See ticket #914
         'Revision 2.15 2001/01/30 11:46:48 rbowen' => 'Revision 2.15 2001/01/30 11:46:48 rbowen',
+        'Fix bad parsing of HH:mm:ss -> 24:00:00, rt87550 (reported by Gonzalo Mateo)' =>
+        'id=87550">rt87550',
+        'Fix bug #87801 where excluded tags were ANDed instead of ORed. Stefan Corneliu Petrea.' =>
+        'id=87801">bug #87801',
     );
 
     while (my ($in, $out) = each %rt_tests) {
@@ -35,6 +39,7 @@ subtest "GH issue linking" => sub {
         'Fixed GH-1013'  => 'issues/1013">GH-1013',
         'Fixed GH:1013'  => 'issues/1013">GH:1013',
         'Fixed GH #1013' => 'issues/1013">#1013',
+        'Add HTTP logger (gh-16; thanks djzort!)' => 'issues/16">gh-16',
     );
     while (my ($in, $out) = each %gh_tests) {
         like(Changes->_gh($in, $u), qr/$out/, "$in found");


### PR DESCRIPTION
Just supporting and fixing some of the regexes based on looking at some of the
"Recent" dists on metacpan.
