### PR TITLE
enable <img title="..." >

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Module.pm
+++ b/lib/MetaCPAN/Web/Controller/Module.pm
@@ -68,7 +68,7 @@ sub path : PathPart('module') : Chained('/') : Args {
             h5      => ['id'],
             h6      => ['id'],
             i       => [],
-            img     => [qw( alt border height width src style / )],
+            img     => [qw( alt border height width src style title / )],
             li      => ['id'],
             ol      => [],
             p       => [qw(class style)],


### PR DESCRIPTION
The "title" attribute is used for tooltips -- I am making use of it here, to add additional information about authors: https://metacpan.org/source/ETHER/Acme-CPANAuthors-Nonhuman-0.007/lib/Acme/CPANAuthors/Nonhuman.pm#L91

(pretty please? :) I don't think this is a security risk to allow this.)
