### PR TITLE
Set -webkit-text-size-adjust to 100% for code

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -554,6 +554,7 @@ ul#index, #index ul { list-style-type: none; }
     overflow-y: hidden !important;
     background-color: #fafafa;
     padding: 10px;
+    -webkit-text-size-adjust: 100%; /* for iPhone <code>, issue #107 */
 }
 
 .nogutter, .pod pre {


### PR DESCRIPTION
This fixes issue #107, where code and line numbers don't align on iphone.
