### PR TITLE
Stop trimming HTML in highlighter

### DIFF
--- a/root/static/js/shCore.js
+++ b/root/static/js/shCore.js
@@ -1461,7 +1461,7 @@ sh.Highlighter.prototype = {
 	 */
 	getCodeLinesHtml: function(html, lineNumbers)
 	{
-		html = trim(html);
+		//html = trim(html);
 		
 		var lines = splitLines(html),
 			padLength = this.getParam('pad-line-numbers'),


### PR DESCRIPTION
Issues #657 and #626 both mention a problem of stripping leading whitespace on the
first line of a verbatim block. This change fixes that.

I do not know this code well enough to know if this will have other adverse effects

My rationale is that at this point the sh code has already stripped empty lines at
beginning and end, and unindented the code, so I would assume any left over white-
space to be important.
