### PR TITLE
Show message from pod api if there is no pod

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Module.pm
+++ b/lib/MetaCPAN/Web/Controller/Module.pm
@@ -98,6 +98,11 @@ sub path : PathPart('module') : Chained('/') : Args {
             template => 'module.html',
         }
     );
+    unless ($c->stash->{pod}) {
+        $c->stash(
+            pod_error => $reqs->{pod}->{message},
+        );
+    }
 }
 
 1;

--- a/root/module.html
+++ b/root/module.html
@@ -75,6 +75,8 @@
 <div class="pod">
 <% IF pod %>
 <% pod.replace(/<pre><code>/, '<pre class="brush: pl; class-name: \'highlight\'; toolbar: false; gutter: false">').replace(/<\/code><\/pre>/, '</pre>') | none %>
+<% ELSIF pod_error %>
+<p class="pod-error">Error rendering POD for <code><% module.name %></code> - <% pod_error %></p>
 <% ELSE %>
 No pod could be found for <% module.name %>
 <% END %>

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -560,6 +560,11 @@ ul#index, #index ul { list-style-type: none; }
 .nogutter, .pod pre {
     padding-left: 10px;
 }
+.pod p.pod-error {
+    border-left: 1px solid #f32;
+    margin-left: -16px;
+    padding-left: 16px;
+}
 
 #pod-errors {
   margin: 3em 0 0 0 ;


### PR DESCRIPTION
In #602 mo says the size limit is intentional, but that we should display the
message from the api about why there is no POD. This commit does that by stashing
the message if there is any, and outputing this instead of the more general
"No pod could be found".
