### PR TITLE
Adjust CSS for pod index uls

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -496,7 +496,7 @@ button.favorite:hover, button.favorite.active, a.favorite.active, a.favorite:hov
     margin-left: 20px;
     padding-left: 2em;
 }
-.pod ul#index {
+.pod ul#index, .pod ul#index ul {
     padding-left: 0;
 }
 .pod ul li {


### PR DESCRIPTION
There was a mistake made in #930 where nested index items had too much padding.
This fixes that problem
