### PR TITLE
set default tab width to 8

### DIFF
--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -55,6 +55,7 @@ function toggleTOC() {
 
 $(document).ready(function() {
     SyntaxHighlighter.defaults['quick-code'] = false;
+    SyntaxHighlighter.defaults['tab-size'] = 8;
 
     var source = $("#source");
     // if this is a source-code view with destination anchor


### PR DESCRIPTION
A followup on https://github.com/CPAN-API/metacpan-web/pull/951
Now hopefully patched in the right place. http://0:5001/source/GAAS/Encode-Locale-1.03/lib/Encode/Locale.pm looks OK now on my machine with the patch.
