### PR TITLE
Watchers/forks count on github info page incorrect

### DIFF
--- a/root/static/js/github.js
+++ b/root/static/js/github.js
@@ -48,8 +48,8 @@ function Github() {
 
                             // with v3 api the number under 'watchers' is actually the number of stargazers
                             // in the v4 api this will be corrected. see https://github.com/CPAN-API/metacpan-web/issues/975
-                            +'  <tr><th><a href="'+ data.html_url +'/stargazers">Stars</a>:</th><td>'+ data.watchers +'</td></tr>'
-                            +'  <tr><th><a href="'+ data.html_url +'/network">Forks</a>:</th><td>'+ data.forks +'</td></tr>'
+                            +'  <tr><th>Stars:</th><td><a href="'+ data.html_url +'/stargazers">'+ data.watchers +'</a></td></tr>'
+                            +'  <tr><th>Forks:</th><td><a href="'+ data.html_url +'/network">'+ data.forks +'</a></td></tr>'
 
                             +( data.has_issues
                             ?'  <tr><th>Open <a href="'+ data.html_url +'/issues">Issues</a>:</th><td>'+ data.open_issues +'</td></tr>'


### PR DESCRIPTION
I found for the libnet module the watchers/forks count is incorrect.

I tried some other modules, randomly (DBD::mysql and DBI) and there the count seems to be OK, only what is displayed in Metacpan as 'watchers' is the # stars on Github.

Note that it _could_ be the number of forks on mc.o is displayed incorrectly because this repository is in itself a fork of a different repository.

![libnet-metacpan](https://f.cloud.github.com/assets/659504/1390795/333745be-3bf3-11e3-8197-dfbc078a38ab.png)
![libnet-github](https://f.cloud.github.com/assets/659504/1390798/39186fc6-3bf3-11e3-9faa-a92f2996e684.png)
