### PR TITLE
Move the ++ (favorite) button next to the distribution/release

### DIFF
--- a/root/pod.html
+++ b/root/pod.html
@@ -14,10 +14,10 @@
     </span>
     &nbsp;/&nbsp;
   <a href="/release/<% IF release.status == 'latest'; release.distribution; ELSE; [module.author, module.release].join('/'); END %>"><% module.release %></a>
+  </big></strong><% INCLUDE inc/favorite.html module = module %><strong><big>
   &nbsp;/&nbsp;
   <span class="select-text" itemprop="name"><% module.documentation %></span>
   </big></strong>
-  <% INCLUDE inc/favorite.html module = module %>
   <% IF release.status != 'latest' %><div style="float: right"><strong><big><% IF release.maturity == 'developer'; 'dev release, '; END %></big><a href="<% canonical %>"><big>go to latest</big></a></strong></div><% END %><br><br>
 
 <div class="search-bar">

--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -337,7 +337,7 @@ input.g-button:active, button.g-button:active, a.g-button:active {
 
 button.favorite, a.favorite {
     padding: 1px 3px;
-    margin-left: 10px;
+    margin-left: 5px;
     font-size: 0.9em;
     background-color: #fff;
     opacity: 0.5;


### PR DESCRIPTION
When on a module's documentation page, the former placement was often
confused as ++ing the module itself instead of the containing
distribution.

Closes GH cpan-api/cpan-api#254.
