### PR TITLE
add rel=author links to Google+ to pod and release pages 

### DIFF
--- a/root/inc/author-pic.html
+++ b/root/inc/author-pic.html
@@ -11,5 +11,10 @@
              width="110" height="20"
              src="https://api.coderwall.com/<% p.id %>/endorsecount.png" /></a></div>
 <% END %>
+<% IF p.name == "googleplus" %>
+  <a rel="author" href="<% profiles.${p.name}.url.replace('%s', p.id) %>?rel=author" target="_blank" title="<% p.name %> - <% p.id%>">
+    <img src="/static/images/profile/<% p.name %>.png" width=16 height=16 alt="<% p.name %>">
+  </a>
+<% END %>
 <% END %>
 </div>


### PR DESCRIPTION
In regular Google searches some results have a avatar next to them. This makes those hits more personal.

In order to have those two things need to be done:
1) There has to be a link to the Google+ profile with ?rel=author added at the end
2) The author needs to tell Google+ they are contributing to metacpan.com
See https://support.google.com/webmasters/answer/1408986?hl=en

This patch adds the 1) part.

If implemented, I think this will improve the standing of MetaCPAN for people searching on Google.
