### PR TITLE
Remove 'ssh://' from github ssh_url

### DIFF
--- a/root/static/js/github.js
+++ b/root/static/js/github.js
@@ -58,7 +58,7 @@ function Github() {
                             +'  <tr><th>Clone URL:</th><td><a href="'+ data.clone_url +'">'+ data.clone_url +'</a></td></tr>'
                             +'  <tr><th>Git URL:</th><td><a href="'+ data.git_url +'">'+ data.git_url +'</a></td></tr>'
                             +'  <tr><th>Github URL:</th><td><a href="'+ data.html_url +'">'+ data.html_url +'</a></td></tr>'
-                            +'  <tr><th>SSH URL:</th><td><a href="ssh://'+ data.ssh_url +'">'+ data.ssh_url +'</a></td></tr>'
+                            +'  <tr><th>SSH URL:</th><td><a href="'+ data.ssh_url +'">'+ data.ssh_url +'</a></td></tr>'
                             +'  <tr><th>Last Commit:</th><td><span class="relatize">'+ data.pushed_at +'</span></td></tr>'
                             +'</table>';
                 },


### PR DESCRIPTION
git-clone does not work if 'ssh://' is prepended:

```
$ git clone ssh://git@github.com:libwww-perl/libwww-perl.git
Cloning into libwww-perl...
ssh: Could not resolve hostname github.com:libwww-perl: Name or service not known
fatal: The remote end hung up unexpectedly
```

Just using the ssh_url as it comes from api.github.com works:

```
$ git clone git@github.com:libwww-perl/libwww-perl.git
Cloning into libwww-perl...
(works)
```
