### PR TITLE
Reinstate outline on focused elements

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -75,9 +75,6 @@ blockquote, q { quotes: "" ""; }
 /* Remove annoying border on linked images. */
 a img { border: none; }
 
-/* Remember to define your own focus styles! */
-:focus { outline: 0; }
-
 button, body {
 font-family: Arial,Helvetica,sans-serif;
 }


### PR DESCRIPTION
Otherwise keyboard navigation is completely useless, since you can't
see which element is focused.
