### PR TITLE
Not show favorites table if no favorites

### DIFF
--- a/root/inc/favorite-table.html
+++ b/root/inc/favorite-table.html
@@ -1,3 +1,4 @@
+<% IF favorites.size %>
 <table class="table table-condensed table-striped table-favorites<% IF tablesorter %> tablesorter<% END %>">
   <thead>
     <tr>
@@ -28,3 +29,4 @@
 <% END %>
 </tbody>
 </table>
+<% END %>


### PR DESCRIPTION
This fixes #1061 since tablesorter barfs on empty tables. I also think the page
looks nicer without the header row showing up with no data.
