### PR TITLE
Move toplists from inline styles to less-file

### DIFF
--- a/root/recent/topuploaders.html
+++ b/root/recent/topuploaders.html
@@ -1,24 +1,21 @@
 <%- title = "CPAN Top Uploaders" %>
 <%- INCLUDE inc/recent-bar.html %>
 
-<div class="content">
+<div class="content toplists">
 <% FOREACH author IN authors %>
-<div style="float:left; width: 300px; height: 100px; overflow: hidden">
+<div class="entry">
     <%- IF author.gravatar_url; author.gravatar_url = author.gravatar_url.replace("^http://(www\.)?gravatar.com/", "https://secure.gravatar.com/") %>
-    <div style="float: left; text-align: center; padding: 10px;">
+    <div class="gravatar">
         <a href="/author/<% author.pauseid %>">
             <img src="<% author.gravatar_url %>" class="author-img" style="width: 75px; height: 75px">
         </a>
     </div>
     <%- END %>
-    <div style="padding: 10px; white-space: nowrap">
-        <strong>
-            <a rel="author" href="/author/<% author.pauseid %>"><% author.pauseid %></a>
-        </strong><br>
-        <span title="<% author.asciiname %>"><% author.name %></span>
-        <br><br>
-        <strong><% author.releases %> release<% IF author.releases > 1 %>s<% END %></strong>
-    </div>
+    <strong class="pauseid">
+        <a rel="author" href="/author/<% author.pauseid %>"><% author.pauseid %></a>
+    </strong>
+    <span class="name" title="<% author.asciiname %>"><% author.name %></span>
+    <strong class="count"><% author.releases %> release<% IF author.releases > 1 %>s<% END %></strong>
 </div>
 <% END %>
 </div>

--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -4,6 +4,7 @@
 @import "search.less";
 @import "table.less";
 @import "author.less";
+@import "toplists.less";
 
 @iconSpritePath:          "/static/icons/glyphicons-halflings.png";
 @iconWhiteSpritePath:     "/static/icons/glyphicons-halflings-white.png";

--- a/root/static/less/toplists.less
+++ b/root/static/less/toplists.less
@@ -1,0 +1,21 @@
+.toplists {
+    .entry {
+        position: relative;
+        float: left;
+        width: 190px;
+        height: 80px;
+        padding-left: 80px;
+        margin-bottom: 20px;
+        .pauseid, .name, .count {
+            display: block;
+        }
+        .count {
+            position: absolute;
+            bottom: 0;
+        }
+        .gravatar {
+            position: absolute;
+            left: 0;
+        }
+    }
+}


### PR DESCRIPTION
Also align people without gravatars similar to people with gravatars, hopefully
to address marcus's feedback from a while back :) The page has a little bit less
air, but it fits better on a portrait ipad resolution, with two items on each line.

This hopefully addresses the concerns in #392

![New layout for no-gravatar](https://dl.dropboxusercontent.com/s/ee7tlmwq58io752/Screen%20Shot%202014-02-04%20at%2011.52.13.png)
