### PR TITLE
Remove inline-block on an authors-results

### DIFF
--- a/root/static/less/author.less
+++ b/root/static/less/author.less
@@ -16,7 +16,6 @@
 
 .author-results {
 	ul  {
-	    display: inline-block;
 	    margin: 10px 0;
 	}
 


### PR DESCRIPTION
The inline-block makes it align to baseline in a bad way. I can se no reason for
the inline-block.

The page was broken in firefox (excessive whitespace above the authors list)
