### PR TITLE
separate nav icons from text with css, not spaces

### DIFF
--- a/root/inc/release-tools.html
+++ b/root/inc/release-tools.html
@@ -1,22 +1,22 @@
 <li class="nav-header">Tools</li>
 <li>
   <a href="<% release.download_url.replace('cpan\.cpantesters\.org', 'cpan.metacpan.org') %>">
-    <i class="icon-download-alt"></i> Download (<% release.stat.size | format_bytes %>b)
+    <i class="icon-download-alt"></i>Download (<% release.stat.size | format_bytes %>b)
   </a>
 </li>
 <%- IF module %>
 <li>
-  <a href="#" onclick="return toggleTOC()"><i class="icon-list"></i> Toggle Table of Contents</a>
+  <a href="#" onclick="return toggleTOC()"><i class="icon-list"></i>Toggle Table of Contents</a>
 </li>
 <%- END %>
 <li>
 <a href="http://explorer.metacpan.org/?url=/<% module ? ['module', module.author, module.release, module.path].join("/") : ['release', release.author, release.name].join("/") %>">
-    <i class="icon-list-alt"></i> MetaCPAN Explorer
+    <i class="icon-list-alt"></i>MetaCPAN Explorer
   </a>
 </li>
 <li>
   <a href="<% 'http://cpanratings.perl.org/rate/?distribution=' _ release.distribution %>">
-    <i class="icon-star"></i> Rate this distribution
+    <i class="icon-star"></i>Rate this distribution
   </a>
 </li>
 <li>

--- a/root/static/less/bootstrap/navs.less
+++ b/root/static/less/bootstrap/navs.less
@@ -77,7 +77,7 @@
 }
 .nav-list [class^="icon-"],
 .nav-list [class*=" icon-"] {
-  margin-right: 2px;
+  margin-right: 5px;
 }
 // Dividers (basically an hr) within the dropdown
 .nav-list .divider {


### PR DESCRIPTION
This eliminates the ugly extra underline between the icon and the text
on hover.

Fixes #1055.
