### PR TITLE
fix syntaxhighlighter lines and line numbers lining up

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -260,6 +260,13 @@ ul#index, #index ul { list-style-type: none; }
     -webkit-text-size-adjust: 100%; /* for iPhone <code>, issue #107 */
 }
 
+/* work around incompatibility between bootstrap and syntaxhighlighter
+ * https://github.com/alexgorbatchev/syntaxhighlighter/issues/275 */
+.syntaxhighlighter .container:before,
+.syntaxhighlighter .container:after {
+    content: none !important;
+}
+
 .nogutter, .pod pre {
     padding-left: 10px;
 }


### PR DESCRIPTION
This is caused by an incompatiblity between bootstrap and
syntaxhighlighter.  Override bootstrap's style to work around it.

https://github.com/alexgorbatchev/syntaxhighlighter/issues/275
