### PR TITLE
Removed the <a href="#___pod"> link from headers

### DIFF
--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -200,12 +200,6 @@ $(document).ready(function () {
         }
     }
 
-    $('.pod').find('h1,h2,h3,h4,h5,h6').each(function () {
-      $(this).wrapInner(function() {
-        return '<a href="#___pod"></a>';
-      });
-    });
-
     var module_source_href = $('#source-link').attr('href');
     if(module_source_href) {
         $('#pod-error-detail dt').each(function() {


### PR DESCRIPTION
All headers were getting an `<a href="#___pod">` anchor wrapped around them.
This provided a link to the TOC, but also had the side effect of making
all headers blue. This caused a visual distraction with very little
interaction benefit for the end-user.
