### PR TITLE
adds links to pod headings that show on hover

### DIFF
--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -206,6 +206,12 @@ $(document).ready(function () {
       });
     });
 
+    $('.pod').find('h1,h2,h3,h4,h5,h6,dt').each(function () {
+      if (this.id) {
+        $(this).prepend('<a href="#'+this.id+'" class="anchor"><i class="icon-bookmark"></i></a>');
+      }
+    });
+
     var module_source_href = $('#source-link').attr('href');
     if(module_source_href) {
         $('#pod-error-detail dt').each(function() {

--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -222,4 +222,24 @@ body {
   padding-right: 20px;
 }
 
+.pod {
+  a.anchor {
+    padding-left: 8px;
+    padding-right: 4px;
+    margin-left: -26px;
+    cursor: pointer;
+    position: relative;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+
+    i {
+      visibility: hidden;
+    }
+  }
+  *:hover > a.anchor i {
+    visibility: visible;
+  }
+}
+
 @import "responsive.less";


### PR DESCRIPTION
Icons appear to the left of h1-h6 and dt elements, linking to the
element itself.  This is meant to aid in sharing links.  Currently using
the bookmark icon, for lack of any better options in the current
sprites.
