### PR TITLE
format <code> blocks as normal monospace text

### DIFF
--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -21,7 +21,7 @@
 }
 
 .pod code {
-    font-family: monospace
+    color: inherit;
 }
 
 #permalink {


### PR DESCRIPTION
I don't think `<code>` blocks (C<> formatting codes) should be formatted any different from normal text, except for them being monospace.
