### PR TITLE
improve issue links

### DIFF
--- a/t/model/changes.t
+++ b/t/model/changes.t
@@ -6,10 +6,10 @@ use aliased 'CPAN::Changes::Release';
 
 use aliased 'MetaCPAN::Web::Model::API::Changes';
 
+my $rt = "https://rt.cpan.org/Ticket/Display.html?id=";
+my $gh = 'https://github.com/CPAN-API/metacpan-web/issues/';
+
 subtest "RT ticket linking" => sub {
-
-    my $u = "https://rt.cpan.org/Ticket/Display.html?id=";
-
     my %rt_tests = (
         'Fixed RT#1013'  => 'id=1013">RT#1013',
         'Fixed RT #1013' => 'id=1013">RT #1013',
@@ -24,39 +24,37 @@ subtest "RT ticket linking" => sub {
         'Revision 2.15 2001/01/30 11:46:48 rbowen' =>
             'Revision 2.15 2001/01/30 11:46:48 rbowen',
         'Fix bad parsing of HH:mm:ss -> 24:00:00, rt87550 (reported by Gonzalo Mateo)'
-            => 'id=87550">rt87550',
+          => 'id=87550">rt87550',
         'Fix bug #87801 where excluded tags were ANDed instead of ORed. Stefan Corneliu Petrea.'
-            => 'id=87801">bug #87801',
-        'Blah blah [rt.cpan.org #231] fixed' =>
-            'id=231">[rt.cpan.org #231]</a>',
-        'Blah blah rt.cpan.org #231 fixed' => 'id=231">rt.cpan.org #231</a>',
+          => 'id=87801">bug #87801',
+        'Blah blah [rt.cpan.org #231] fixed' => 'id=231">rt.cpan.org #231</a>',
+        'Blah blah rt.cpan.org #231 fixed'   => 'id=231">rt.cpan.org #231</a>',
     );
 
-    while ( my ( $in, $out ) = each %rt_tests ) {
-        like( Changes->_rt_cpan($in), qr/\Q$out\E/, "$in found" );
+    while ( my ($in, $out) = each %rt_tests ) {
+        like( Changes->_link_issues($in, $gh, $rt), qr/\Q$out\E/, "$in found" );
     }
 };
 
 subtest "GH issue linking" => sub {
-    my $u        = 'https://github.com/CPAN-API/metacpan-web/issues/';
     my %gh_tests = (
         'Fixed #1013'                             => 'issues/1013">#1013',
         'Fixed GH#1013'                           => 'issues/1013">GH#1013',
         'Fixed GH-1013'                           => 'issues/1013">GH-1013',
         'Fixed GH:1013'                           => 'issues/1013">GH:1013',
-        'Fixed GH #1013'                          => 'issues/1013">#1013',
+        'Fixed GH #1013'                          => 'issues/1013">GH #1013',
         'Add HTTP logger (gh-16; thanks djzort!)' => 'issues/16">gh-16',
         'Merged PR#1013 -- thanks' => 'issues/1013">PR#1013</a>',
         'Merged PR:1013 -- thanks' => 'issues/1013">PR:1013</a>',
         'Merged PR-1013 -- thanks' => 'issues/1013">PR-1013</a>',
     );
-    while ( my ( $in, $out ) = each %gh_tests ) {
-        like( Changes->_gh( $in, $u ), qr/\Q$out\E/, "$in found" );
+    while ( my ($in, $out) = each %gh_tests ) {
+        like( Changes->_link_issues($in, $gh, $rt), qr/\Q$out\E/, "$in found" );
     }
     my @no_links_tests
         = ('I wash my hands of this library forever -- rjbs, 2013-10-15');
     foreach my $in (@no_links_tests) {
-        is( Changes->_gh( $in, $u ), $in, "Didn't change '$in'" );
+        is( Changes->_link_issues($in, $gh, $rt), $in, "Didn't change '$in'" );
     }
 };
 


### PR DESCRIPTION
This is an attempt to improve issue linking in changes and to fix #1045.

It tries to handle links to rt.cpan.org, rt.perl.org, and github issues, and switches between them on a per-link basis.  The github URL is taken from both the bugtracker and repository.  For ambiguous links, it guesses based on the issue number.  Anything below 10000 is assumed to be a github issue and anything above is RT.
