### PR TITLE
Removes extraneous </div>

### DIFF
--- a/root/pod.html
+++ b/root/pod.html
@@ -42,4 +42,3 @@
 <p class="pod-error">Error rendering POD for <code><% module.name %></code> - <% pod_error %></p>
 <% END %>
 </div>
-</div>


### PR DESCRIPTION
There seems to be one too many `</div>` in the template.

Validation results: http://validator.w3.org/check?verbose=1&uri=https%3A%2F%2Fmetacpan.org%2Fpod%2FTest%3A%3AMore#menu

Disaster happening with `Dist::Zilla::Plugin::Pod::Spiffy`: http://i.imgur.com/0xylvqj.png

This pull fixes the issue.
