### PR TITLE
Add Image element to OpenSearch document

### DIFF
--- a/root/static/opensearch.xml
+++ b/root/static/opensearch.xml
@@ -8,6 +8,7 @@
   <AdultContent>false</AdultContent>
   <Language>en-us</Language>
   <SyndicationRight>open</SyndicationRight>
-  <Url type="text/html" template="http://metacpan.org/search?q={searchTerms}" />
+  <Image height="16" width="16" type="image/x-icon">https://metacpan.org/static/icons/favicon.ico</Image>
+  <Url type="text/html" template="https://metacpan.org/search?q={searchTerms}" />
   <Tags>CPAN MetaCPAN Perl</Tags>
 </OpenSearchDescription>


### PR DESCRIPTION
I couldn't test it locally, when I try to add MetaCPAN as default search engine on FF, I still get the data from production with missing image. So I just added Image element as http://www.opensearch.org/Specifications/OpenSearch/1.1#The_.22Image.22_element suggested. 
