### PR TITLE
Use "protocol relative url".

### DIFF
--- a/root/inc/dependencies-graph.html
+++ b/root/inc/dependencies-graph.html
@@ -1,3 +1,3 @@
 <div class="modal fade" id="dependencies-graph" style="width:720px; margin-left:-360px">
-  <iframe src="http://widgets.stratopan.com/wheel?q=<% release.name %>" frameborder="0" width="720" height="620"></iframe>
+  <iframe src="//widgets.stratopan.com/wheel?q=<% release.name %>" frameborder="0" width="720" height="620"></iframe>
 </div>


### PR DESCRIPTION
Some browsers refuse (or just warn) when mixing secure and
insecure content.

So now the graph iframe will be loaded with either http or https,
depending on what the parent page is using.
