### PR TITLE
Fix initial load of dep graph to display:none;

### DIFF
--- a/root/inc/dependencies-graph.html
+++ b/root/inc/dependencies-graph.html
@@ -1,3 +1,3 @@
-<div class="modal fade" id="dependencies-graph" style="width:720px; margin-left:-360px">
+<div class="modal fade" id="dependencies-graph" style="width:720px; margin-left:-360px; display: none;">
   <iframe src="//widgets.stratopan.com/wheel?q=<% release.name %>" frameborder="0" width="720" height="620"></iframe>
 </div>


### PR DESCRIPTION
On initial load the dep graph ifram and div was overlaying everything, intercepting
clicks and scrolls (At least in firefox). After opening and dismissing it, it worked
and the only difference was that after dismissal, the style had changed to
`display: none;`. Applying `display: none` on initial load fixes the problem.
