### PR TITLE
Hide #dependencies-graph on ESC

### DIFF
--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -296,6 +296,6 @@ function favDistribution(form) {
 $(document).on('keydown', function (e) {
         if (e.keyCode === 27) { 
             $( "#dependencies-graph" ).hide(); 
-            $( " .modal-backdrop" ).hide();
+            $( ".modal-backdrop" ).hide();
         } 
 });


### PR DESCRIPTION
If user presses ESC key, the dependencies graph widget should close.
