### PR TITLE
Update "About MetaCPAN" text to mention the view and mirror of CPAN

### DIFF
--- a/root/about.html
+++ b/root/about.html
@@ -10,11 +10,11 @@ documentation for the Perl programming language.  This includes a
 comfortable web-based view and a first class mirror of the canonical
 CPAN content.
 
-We are a relatively young
-open source project.  In November 2013, MetaCPAN will be 3 years old.  It's old
-enough to have become an important and well utilized part of the Perl world,
-but it's also young enough to have lots of room to evolve. As you will see we
-have many ideas and encourage more suggestions.
+We are a relatively young open source project.  In November 2013, MetaCPAN
+will be 3 years old.  It's old enough to have become an important and well
+utilized part of the Perl world, but it's also young enough to have lots of
+room to evolve. As you will see we have many ideas and encourage more
+suggestions.
 
 MetaCPAN has two parts:
 


### PR DESCRIPTION
Sparked by a discussion on IRC (#debian-perl on OFTC) about if MetaCPAN is a canonical view of CPAN or not, it has been noticed that "About MetaCPAN" just mentions that MetaCPAN is a search engine but not that it's actually more than a search engine. I missed the "view" part which displays CPAN distribution content and @shadowcat-mst suggested to also mention its CPAN mirror.

The attached patches add mentions of these previously unmentioned parts of MetaCPAN and split the first paragraph into two paragraphs.
