### PR TITLE
Add page title on Not found page

### DIFF
--- a/root/not_found.html
+++ b/root/not_found.html
@@ -1,3 +1,4 @@
+<%- title = "Error 404 - Page not found" %>
 <div id="not-found">
     <h1>Not Found</h1>
 


### PR DESCRIPTION
I've known that setting page title on 404 page that will be better on SEO, so the engine will know this is Not found and don't index it. 
