### PR TITLE
Use correctly sized gravatars when possible

### DIFF
--- a/lib/MetaCPAN/Web/View/HTML.pm
+++ b/lib/MetaCPAN/Web/View/HTML.pm
@@ -8,6 +8,7 @@ use mro;
 use Digest::MD5 qw(md5_hex);
 use Digest::SHA1;
 use URI;
+use URI::QueryParam;
 use JSON;
 use Gravatar::URL;
 use Regexp::Common qw(time);
@@ -172,6 +173,26 @@ Template::Alloy->define_vmethod(
         $digest =~ tr/[+\/]/-_/;
         return $digest;
     }
+);
+
+Template::Alloy->define_vmethod(
+    'text',
+    gravatar_fixup => sub {
+        my ( $url, $size ) = @_;
+        if ( $url =~ m{^https?://(secure|www)\.gravatar\.com/avatar/} ) {
+            my $url = URI->new($url);
+            $url->scheme('https');
+            $url->host('secure.gravatar.com');
+            if ($size) {
+                $url->query_param( s => $size );
+            }
+            else {
+                $url->query_param_delete('s');
+            }
+            return $url->as_string;
+        }
+        return $url;
+    },
 );
 
 1;

--- a/root/inc/author-pic.html
+++ b/root/inc/author-pic.html
@@ -1,10 +1,7 @@
 <div class="author-pic">
-<%-
-	IF author.gravatar_url;
-	author.gravatar_url = author.gravatar_url.replace("^http://(www\.)?gravatar.com/", "https://secure.gravatar.com/");
-%>
+<%- IF author.gravatar_url %>
 <a href="/author/<% author.pauseid %>">
-	<img src="<% author.gravatar_url %>">
+	<img src="<% author.gravatar_url.gravatar_fixup(130) %>">
 </a>
 <% END %>
 <strong>

--- a/root/inc/breadcrumbs.html
+++ b/root/inc/breadcrumbs.html
@@ -57,7 +57,7 @@ END %>
 <%# display the gravatar url for each pause plusser alongwith their author page as a link. %>
 <% FOREACH plusser IN plusser_authors%>
 
-<a class="display-all" href="/author/<% plusser.id %>"><img src="<% plusser.pic || '/static/icons/user.png' %>" title="<% plusser.id %>" alt="<% plusser.id %>"></a>
+<a class="display-all" href="/author/<% plusser.id %>"><img src="<% plusser.pic.gravatar_fixup(20) || '/static/icons/user.png' %>" title="<% plusser.id %>" alt="<% plusser.id %>"></a>
 
 <% IF loop.count%35 == 0 %>
 <!--To display 35 plussers in one row. -->

--- a/root/recent/topuploaders.html
+++ b/root/recent/topuploaders.html
@@ -4,10 +4,10 @@
 <div class="content toplists">
 <% FOREACH author IN authors %>
 <div class="entry">
-    <%- IF author.gravatar_url; author.gravatar_url = author.gravatar_url.replace("^http://(www\.)?gravatar.com/", "https://secure.gravatar.com/") %>
+    <%- IF author.gravatar_url %>
     <div class="gravatar">
         <a href="/author/<% author.pauseid %>">
-            <img src="<% author.gravatar_url %>" class="author-img" style="width: 75px; height: 75px">
+            <img src="<% author.gravatar_url.gravatar_fixup(75) %>" class="author-img" style="width: 75px; height: 75px">
         </a>
     </div>
     <%- END %>

--- a/root/search.html
+++ b/root/search.html
@@ -28,7 +28,7 @@
         <li>
           <a href="/author/<% author.id %>" title="Author page for <% author.name | html %>">
             <%- IF author.gravatar_url %>
-              <img src="<% author.gravatar_url %>">
+              <img src="<% author.gravatar_url.gravatar_fixup(30) %>">
             <%- END %>
             <% author.name | html %> (<% author.pauseid %>)
           </a>


### PR DESCRIPTION
Provides a gravatar_fixup vmethod that accepts a pixel size to set on
gravatar URLs.  It also adjusts them to use HTTPS, replacing the
existing repeated templated code.
