### PR TITLE
Update news about suggestion on no result and redirect to one result mod...

### DIFF
--- a/News.md
+++ b/News.md
@@ -1,3 +1,15 @@
+Title: Suggestion on incorrect number of colons
+------------------------------
+Date: 2014-06-09T08:15:00
+
+Perl module name should contain only 2 colons, some common mistakes are we underuse or overuse it. Now, suggestion on no result page available when search with missing colon such as [Test:More](https://metacpan.org/search?q=Test%3AMore) or too much colons like [DBIx:::Class::::ResultSet](https://metacpan.org/search?q=DBIx%3A%3A%3AClass%3A%3A%3A%3AResultSet).
+ 
+Title: Redirect to the module on 1 search result
+------------------------------
+Date: 2014-06-09T08:15:00
+
+If there's only 1 result return from a search, it will take you that module automatically. For example search for ['ctx_request'](https://metacpan.org/search?q=ctx_request), you'll see Catalyst::Test module page instead of result page.
+
 Title: Table sorting is now persistent
 ------------------------------
 Date: 2014-05-19T10:50:12
@@ -8,7 +20,7 @@ it will remember your last preference.  This is saved on a per table basis
 (for example, author releases, author favorites, and reverse dependency releases).
 No need to set it every time when accessing that page in the same browser.
 
-Title: Details of (++)plussers displayed.
+Title: Details of (++)plussers displayed
 ------------------------------
 Date: 2014-05-12T18:40:17
 


### PR DESCRIPTION
Update changes from PR #1210, the news about Task::Kensho link I think I will add when PR #1219 has been merged I want the feature about Task::Kensho is completely done (in no result and home page) before update news about that. 
