### PR TITLE
Add anchors to news, FAQ (and other about pages)

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -65,6 +65,7 @@ requires 'Template::Alloy';
 requires 'Template::Plugin::DateTime';
 requires 'Template::Plugin::JSON';
 requires 'Template::Plugin::Markdown';
+requires 'Template::Plugin::MultiMarkdown';
 requires 'Template::Plugin::Number::Format';
 requires 'Template::Plugin::Page';
 requires 'Try::Tiny', '0.09';

--- a/root/about.html
+++ b/root/about.html
@@ -1,7 +1,7 @@
 <% PROCESS inc/about-bar.html %>
-<div class="content about">
-<% USE Markdown -%>
-<% FILTER markdown %>
+<div class="content about anchors">
+<% USE MultiMarkdown(heading_ids => 1) -%>
+<% FILTER multimarkdown %>
 # About MetaCPAN
 
 MetaCPAN is an open source search engine for the Comprehensive Perl Archive

--- a/root/about/development.html
+++ b/root/about/development.html
@@ -1,7 +1,7 @@
 <% PROCESS inc/about-bar.html %>
-<div class="content about-resources">
-<% USE Markdown -%>
-<% FILTER markdown %>
+<div class="content about-resources anchors">
+<% USE MultiMarkdown(heading_ids => 1) -%>
+<% FILTER multimarkdown %>
 # Development
 
 

--- a/root/about/faq.html
+++ b/root/about/faq.html
@@ -1,7 +1,7 @@
 <% PROCESS inc/about-bar.html %>
-<div class="content about-resources">
-<% USE Markdown -%>
-<% FILTER markdown %>
+<div class="content about-resources anchors">
+<% USE MultiMarkdown(heading_ids => 1) -%>
+<% FILTER multimarkdown %>
 # FAQ's answered
 
 ## Why can't I find a specific module?

--- a/root/about/missing_modules.html
+++ b/root/about/missing_modules.html
@@ -1,7 +1,7 @@
 <% PROCESS inc/about-bar.html %>
-<div class="content about-resources">
-<% USE Markdown -%>
-<% FILTER markdown %>
+<div class="content about-resources anchors">
+<% USE MultiMarkdown(heading_ids => 1) -%>
+<% FILTER multimarkdown %>
 # Missing module ? - why can I not find a specific module?
 
 ## Is it in the index?

--- a/root/about/resources.html
+++ b/root/about/resources.html
@@ -1,7 +1,7 @@
 <% PROCESS inc/about-bar.html %>
-<div class="content about about-resources">
-<% USE Markdown -%>
-<% FILTER markdown %>
+<div class="content about about-resources anchors">
+<% USE MultiMarkdown(heading_ids => 1) -%>
+<% FILTER multimarkdown %>
 # Contact
 
 ## Twitter

--- a/root/news.html
+++ b/root/news.html
@@ -1,6 +1,6 @@
-<div class="content">
-<% USE Markdown -%>
-<% FILTER markdown %>
+<div class="content anchors">
+<% USE MultiMarkdown(heading_ids => 1) -%>
+<% FILTER multimarkdown %>
 
 <% news %>
 

--- a/root/pod.html
+++ b/root/pod.html
@@ -36,7 +36,7 @@
 </div>
 <% IF req.cookies.hideTOC.value %><style>#index { display:none}</style><% END %>
 <a name="___pod"></a>
-<div class="pod content">
+<div class="pod content anchors">
 <% IF pod %>
 <% pod.replace(/<pre><code>/, '<pre class="brush: pl; class-name: \'highlight\'; toolbar: false; gutter: false; metacpan-verbatim">').replace(/<\/code><\/pre>/, '</pre>') | none %>
 <% ELSIF pod_error %>

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -208,7 +208,7 @@ $(document).ready(function () {
         }
     }
 
-    $('.pod').find('h1,h2,h3,h4,h5,h6,dt').each(function () {
+    $('.anchors').find('h1,h2,h3,h4,h5,h6,dt').each(function () {
       if (this.id) {
         $(this).prepend('<a href="#'+this.id+'" class="anchor"><i class="icon-bookmark"></i></a>');
       }

--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -1,4 +1,4 @@
-.pod {
+.anchors {
   a.anchor {
     padding-left: 8px;
     padding-right: 4px;
@@ -12,6 +12,13 @@
   *:hover > a.anchor i,
   a.anchor:focus i {
     visibility: visible;
+  }
+  &.about-resources {
+      h1 .anchor {
+          display: block;
+          position: absolute;
+          margin-top: 3px;
+      }
   }
 }
 


### PR DESCRIPTION
This is achieved by switching to MultiMarkdown, which has an option called
`heading_ids`, which auto-generated id tags for headings.

Secondly we re-use the anchors stuff from the POD pages, by changing to a shared
css class `anchors`, since the `pod` class changed text layout a lot.

Lastly, adjust some of the anchor CSS for the large H1 headings on about pages.

The CSS could probably be tweaked more, but it got messy real quick :(
