### PR TITLE
Show module version on documentation page

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -168,6 +168,7 @@ sub view : Private {
             release           => $release,
             template          => 'pod.html',
             canonical         => $canonical,
+            documented_module => $documented_module,
         }
     );
     unless ( $reqs->{pod}->{raw} ) {

--- a/root/pod.html
+++ b/root/pod.html
@@ -12,6 +12,13 @@
     </form>
   </li>
   <li class="nav-header"><span class="relatize"><% module.date.dt_http %></span></li>
+  <% IF documented_module.version %>
+  <li>
+    <div>
+      Module version: <% documented_module.version | html %>
+    </div>
+  </li>
+  <% END %>
   <li>
     <div>
       <a href="/source/<% module.author %>/<% module.release %>/<% module.path %>">Source</a>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/79913/3433716/1485a684-0082-11e4-9297-917eba421dc3.png)

It's only shown when there is a version, and is always shown if there is (even if it matches the distro version).
