### PR TITLE
Search only by module name when a term is prefixed with "module:"

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Search.pm
+++ b/lib/MetaCPAN/Web/Controller/Search.pm
@@ -44,10 +44,11 @@ sub index : Path {
 
         $query =~ s{author:([a-zA-Z]*)}{author:\U$1\E}g;
         $query =~ s/dist(ribution)?:(\w+)/file.distribution:$2/g;
+        $query =~ s/module:([\w:]+)/module.name.analyzed:$1/g;
 
         my $results
-            = $query =~ /distribution:/
-            ? $model->search_distribution( $query, $from, $user )
+            = $query =~ /(distribution|module\.name\S*):/
+            ? $model->search_expanded( $query, $from, $user )
             : $model->search_collapsed( $query, $from, $user );
 
         my @dists = $query =~ /distribution:(\S+)/g;

--- a/lib/MetaCPAN/Web/Model/API/Module.pm
+++ b/lib/MetaCPAN/Web/Model/API/Module.pm
@@ -61,10 +61,11 @@ sub autocomplete {
     return $cv;
 }
 
-sub search_distribution {
+sub search_expanded {
     my ( $self, $query, $from, $user ) = @_;
 
-    # the distribution is included in the query and ES does the right thing
+    # When used for a distribution or module search, the limit is included in
+    # the query and ES does the right thing.
     my $cv = $self->cv;
     my ( $data, $total );
     $data = $self->search(


### PR DESCRIPTION
The expanded search (previously only used for searches within specific
distributions) is used so that modules are not collapsed under their
distributions.  Someone searching for a list of modules doesn't want
some of the modules elided from the results.

Sorting of results is unchanged, but may want to be reconsidered later
for module: searches after comparing, for example, the vast difference
between module:MooseX::Types and module:MooseX::Type.

While colons are special characters in Lucene's query syntax [1], I
don't think we need to escape them in this case because the query term
contains no spaces.  Similarly, we don't seem to need to escape other
special characters like hyphens in distribution names.

[1] http://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters
