### PR TITLE
Stricter munging of special query terms

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Search.pm
+++ b/lib/MetaCPAN/Web/Controller/Search.pm
@@ -42,9 +42,12 @@ sub index : Path {
     else {
         my $user = $c->user_exists ? $c->user->id : undef;
 
-        $query =~ s{author:([a-zA-Z]*)}{author:\U$1\E}g;
-        $query =~ s/dist(ribution)?:(\w+)/file.distribution:$2/g;
-        $query =~ s/module:(\w[\w:]*)/module.name.analyzed:$1/g;
+        # these would be nicer if we had variable-length lookbehinds...
+        $query =~ s{(^|\s)author:([a-zA-Z]+)(?=\s|$)}{$1author:\U$2\E}g;
+        $query
+            =~ s/(^|\s)dist(ribution)?:([\w-]+)(?=\s|$)/$1file.distribution:$3/g;
+        $query
+            =~ s/(^|\s)module:(\w[\w:]*)(?=\s|$)/$1module.name.analyzed:$2/g;
 
         my $results
             = $query =~ /(distribution|module\.name\S*):/


### PR DESCRIPTION
As noted by @rwstauner:

```
14:26 <@rwstauner> as a side effect, you can't search for "module::metadata" (though you can
                   search for "Module::Metadata")
14:27 <@trs> rwstauner: that can be fixed with a regex change. nice catch!
```
