### PR TITLE
Stay on the release page when jumping between release versions

### DIFF
--- a/root/inc/release-tools.html
+++ b/root/inc/release-tools.html
@@ -28,7 +28,7 @@
 </li>
 <%- IF versions.size > 1 %>
 <li>
-    <select onchange="document.location.href='/module/'+this.value">
+    <select onchange="document.location.href='/<% IF module; "module"; ELSE; "release"; END %>/'+this.value">
         <option>Jump to version</option>
         <%- PROCESS version_options %>
     </select>


### PR DESCRIPTION
Always using the /module endpoint caused release pages to jump to file
listings (after requesting /module/AUTHOR/Foo-Bar-1.23/ and being
redirected to /source/...).

Jumping between module versions was unaffected.
