### PR TITLE
fall back to first indexed module name in the absense of a NAME section

### DIFF
--- a/root/inc/breadcrumbs.html
+++ b/root/inc/breadcrumbs.html
@@ -47,6 +47,6 @@ END %>
   <div class="inline"><%- INCLUDE inc/favorite.html module = module || release %></div>
   <%- IF module %>
   <span>&nbsp;/&nbsp;
-  <% module.documentation %></span>
+  <% module.documentation or module.module.0.name %></span>
   <%- END %>
 </div>

--- a/root/pod.html
+++ b/root/pod.html
@@ -1,7 +1,12 @@
 <% twitter_card_inc = 'inc/twitter/module.html' %>
 <%# NOTE: canonical set in controller %>
 <% meta_description = module.abstract %>
-<% title = module.documentation _ (module.abstract ? ' - ' _ module.abstract : ''); rss = 'distribution/' _ module.distribution %>
+<%
+  title =
+    (module.documentation or module.module.0.name ) _
+    (module.abstract ? ' - ' _ module.abstract : '');
+  rss = 'distribution/' _ module.distribution
+%>
 
 <% INCLUDE inc/breadcrumbs.html plussers_div = plusser_authors%>
 


### PR DESCRIPTION
If there is no NAME section, we don't know what to call the current POD
page.  Using the name of the first module in the file (if possible) is
better than displaying nothing at all.

Fixes #1261.
