### PR TITLE
Make header font bolder and increase line height

### DIFF
--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -82,6 +82,10 @@
     font-size: 1.1em;
 }
 
+.pod h1, .pod h2, .pod h3, .pod h4 {
+    font-weight: bold;
+}
+
 .pod p, .pod dt {
     font-size: 1.1em;
 }


### PR DESCRIPTION
another side effect from Bootstrap upgrading, as @tsibley's suggestion on 

> 10:38:51 PM trs: the bootstrap3 headers are much harder to distinguish from normal text.
> 10:39:42 PM trs: see https://metacpan.org/pod/Catalyst::Delta for example
> 10:39:43 PM dipsy: [ Catalyst::Delta - Overview of changes between versions of Catalyst - metacpan.org ] 
> 10:39:55 PM trs: even just h1, h2, h3, h4 { font-weight: bold } makes it better
> 11:10:08 PM oiami: trs:  do you have example of which line you mean to ? 
> 11:21:24 PM trs: oiami: look at any of the headings under VERSION 5.90060+
> 11:21:46 PM trs: for example: "Support passing Body filehandles directly to your Plack server."
> 11:22:25 PM trs: it appears that none of the headings use bold, and rely on font-size alone.
> 11:22:34 PM trs: which doesn't really work all that well.
> 11:22:40 PM oiami: I see, I can't remember if it was bigger before 
> 11:25:41 PM trs: it was bold before
> 11:26:54 PM oiami: ok, I can fix that :D

I think {font-weight: bold} is too bold, how about {font-weight: 500} I think it nicer from my point of view, could you check ?
