### PR TITLE
use args or captures to pick search terms on 404

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Root.pm
+++ b/lib/MetaCPAN/Web/Controller/Root.pm
@@ -54,7 +54,12 @@ sub default : Path {
 
 sub not_found : Private {
     my ( $self, $c ) = @_;
-    $c->stash( { template => 'not_found.html' } );
+    $c->stash(
+        {
+            template => 'not_found.html',
+            search   => [ @{ $c->req->args }, @{ $c->req->captures } ],
+        }
+    );
     $c->response->status(404);
 }
 

--- a/root/not_found.html
+++ b/root/not_found.html
@@ -19,14 +19,11 @@
     <% END %>
 
     <%
-        # FIXME: this drops the first two url components and suggests a search
-        # for the rest (which makes fragile assumptions).
-        q = req.path.split('/');
-        IF q.size > 2;
-            q = q.splice(2, 99).join(" ");
+        IF search and search.size;
+            q = search.join(" ");
     %>
         <p>
-            Search the CPAN for <a href="/search?q=<% q %>"><% q %></a>
+            Search the CPAN for <a href="/search?q=<% q | url %>"><% q %></a>
         </p>
     <% END %>
     </p>


### PR DESCRIPTION
Rather than cutting off two path segments and using the rest to pick
suggested search terms, use all of the arguments or captures from the
last action.

Fixes #1248.
