### PR TITLE
Fix media-queries to work on firefox

### DIFF
--- a/root/static/css/style.css
+++ b/root/static/css/style.css
@@ -85,9 +85,12 @@ label input[type="text"], label select {
 }
 
 @media (-webkit-min-device-pixel-ratio: 2),
-       (-moz-min-device-pixel-ratio: 2),
+       (min--moz-device-pixel-ratio: 2),
        (-o-min-device-pixel-ratio: 2/1),
-       (min-device-pixel-ratio: 2) {
+       (min-device-pixel-ratio: 2),
+       (min-resolution: 2dppx),
+       (min-resolution: 192dpi)
+       {
 
     .big-logo, .small-logo {
         background-image: url('/static/images/metacpan-logo@2x.png');

--- a/root/static/less/responsive.less
+++ b/root/static/less/responsive.less
@@ -149,9 +149,12 @@
     }
 
     @media (-webkit-min-device-pixel-ratio: 2),
-          (-moz-min-device-pixel-ratio: 2),
+          (min--moz-device-pixel-ratio: 2),
           (-o-min-device-pixel-ratio: 2/1),
-          (min-device-pixel-ratio: 2) {
+          (min-device-pixel-ratio: 2),
+          (min-resolution: 2dppx),
+          (min-resolution: 192dpi)
+          {
 
         .big-logo {
             background-image: url('/static/images/metacpan-logo@2x.png');


### PR DESCRIPTION
as per https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Media_queries#-moz-device-pixel-ratio,
the `min` is infront on firefix, and is deprecated since gecko version 16 (current is
30ish), so also adding the standard one which is `min-resolution`.
