### PR TITLE
use https for all cpan.metacpan.org links

### DIFF
--- a/root/about/missing_modules.html
+++ b/root/about/missing_modules.html
@@ -7,7 +7,7 @@
 ## Is it in the index?
 
 MetaCPAN uses the [PAUSE](http://pause.perl.org/) generated
-[02packages.details.txt](http://cpan.metacpan.org/modules/02packages.details.txt)
+[02packages.details.txt](https://cpan.metacpan.org/modules/02packages.details.txt)
 file. If it's not in there, then the module author will need to fix this.
 (Authors are usually emailed about this when they upload a distribution).
 

--- a/root/author.html
+++ b/root/author.html
@@ -139,7 +139,7 @@
     </li>
     <li>
         <div>
-            <a href="http://cpan.metacpan.org/authors/id/<% author.pauseid.substr(0,1) %>/<% author.pauseid.substr(0,2) %>/<% author.pauseid %>">Browse CPAN directory</a>
+            <a href="https://cpan.metacpan.org/authors/id/<% author.pauseid.substr(0,1) %>/<% author.pauseid.substr(0,2) %>/<% author.pauseid %>/">Browse CPAN directory</a>
         </div>
     </li>
 </ul>

--- a/root/inc/release-tools.html
+++ b/root/inc/release-tools.html
@@ -1,6 +1,6 @@
 <li class="nav-header">Tools</li>
 <li>
-    <a href="<% release.download_url.replace('cpan\.cpantesters\.org', 'cpan.metacpan.org') %>">
+    <a href="<% release.download_url.replace('cpan\.cpantesters\.org', 'cpan.metacpan.org').replace('^http://', 'https://') %>">
     <i class="fa fa-download fa-fw black"></i>Download (<% release.stat.size | format_bytes %>b)
     </a>
 </li>


### PR DESCRIPTION
Addresses CPAN-API/metacpan-web#1272 in front end.
