### PR TITLE
fix slidepanel toggle

### DIFF
--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -76,7 +76,7 @@
                 <ul class="nav navbar-nav">
             <%- UNLESS req.uri.path == "/" %>
                 <li class="visible-xs">
-                <a data-toggle="slidepanel" data-target=".slidepanel">
+                <a href="#" data-toggle="slidepanel" data-target=".slidepanel">
                   <i class="fa fa-bars fa-2x icon-slidepanel"></i>
                   <span class="icon-bar"></span>
                   <span class="icon-bar"></span>


### PR DESCRIPTION
The slidepanel toggle button doesn't work correctly on my iPhone5 Safari.
This pull request would fix it.
