### PR TITLE
perltidy was complaining about .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-*.sw*
 *.bak
+*.sw*
 .DS_Store
 .carton
 .includepath


### PR DESCRIPTION
This change satisfies perltidy. Should we skip .gitignore when checking with perlticy?
