### PR TITLE
stop using columns on plussers page

### DIFF
--- a/root/plussers.html
+++ b/root/plussers.html
@@ -17,7 +17,12 @@
 <div class ="plussers_disp">
 <% FOREACH plusser IN plusser_authors%>
 
-<a href="/author/<% plusser.id %>"><img src="<% plusser.pic.gravatar_fixup(70) || '/static/icons/user.png' %>" title="<% plusser.id %>" alt="<% plusser.id %>" width ="75" height ="75"><% plusser.id %></a>
+<div class="plusser">
+    <a href="/author/<% plusser.id %>">
+        <img src="<% plusser.pic.gravatar_fixup(75) || '/static/icons/user.png' %>" title="<% plusser.id %>" alt="" width="75" height="75">
+        <% plusser.id %>
+    </a>
+</div>
 
 <% END %>
 </div>

--- a/root/static/less/plusser.less
+++ b/root/static/less/plusser.less
@@ -7,35 +7,20 @@ body {
 }
 
 .plussers_disp {
-    font-size: 0;
     margin: 30px 0px;
+    font-size: 12pt;
+    text-align: center;
 
-    -moz-column-count: 5;
-    -webkit-column-count: 5;
-    -o-column-count: 5;
-    -ms-column-count: 5;
-    column-count: 5;
-
-    -moz-column-width: 120px;
-    -webkit-column-width: 120px;
-    -o-column-width: 120px;
-    -ms-column-width: 120px;
-    column-width: 120px;
-
-    a {
-        margin-bottom: 50px;
-        border: 4px solid transparent;
-        display: block;
-        -webkit-border-radius: 12px;
-        border-radius: 12px;
-        font-size: 12pt;
-        overflow: hidden;
+    div.plusser {
+        display: inline-block;
+        margin: 0 30px 50px 30px;
+        width: 100px;
     }
+
     img {
-        -webkit-border-radius: 9px;
+        margin: 0 auto;
         border-radius: 9px;
         display: block;
-        margin: 0 auto;
         height: 75px;
         width: 75px;
     }


### PR DESCRIPTION
The column layout makes the ordering of people on the page confusing,
and there were some bugs with its implementation.  Remove it and just
use items with a specified width, letting them wrap as needed.

Fixes #1304
