### PR TITLE
button to toggle right aligned TOC

### DIFF
--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -340,11 +340,21 @@ $(document).ready(function () {
         index.before(
             '<div id="index-header"><b>Contents</b>'
             + ' [<button class="btn-link toggle-index"><span class="toggle-show">show</span><span class="toggle-hide">hide</span></button>]'
+            + ' <button class="btn-link toggle-index-right"><i class="fa fa-toggle-right"></i><i class="fa fa-toggle-left"></i></button>'
             + '</div>');
 
         $('.toggle-index').on('click', function (e) { e.preventDefault(); toggleTOC(); });
         if (index_hidden) {
             container.addClass("hide-index");
+        }
+
+        $('.toggle-index-right').on('click', function (e) {
+            e.preventDefault();
+            localStorage.setItem('rightTOC', container.hasClass('pull-right') ? 0 : 1);
+            container.toggleClass('pull-right');
+        });
+        if (localStorage.getItem('rightTOC') == 1) {
+            container.addClass("pull-right");
         }
     }
 

--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -94,6 +94,31 @@ ul#index, #index ul { list-style-type: none; }
             height: 0;
         }
     }
+
+    .toggle-index-right {
+        color: #000;
+        float: right;
+        border: 0;
+        margin: -4px 2px 0 -1em;
+    }
+
+    .fa-toggle-left {
+        display: none;
+    }
+
+    &.pull-right {
+        margin-left: 5px;
+        overflow-x: auto;
+        max-width: 225px;
+
+        .fa-toggle-right {
+            display: none;
+            visibility: collapse;
+        }
+        .fa-toggle-left {
+            display: inline-block;
+        }
+    }
 }
 
 #index-header {


### PR DESCRIPTION
For a long time I've been using a user style to float the table of contents to the right.  It can interfere with the layout in many places though, so this implements it as an option that can be toggled.

![moo_-_minimalist_object_orientation_ with_moose_compatibility _-_metacpan org_-_2014-09-15_09 51 50](https://cloud.githubusercontent.com/assets/50029/4272154/a0d3b484-3cdf-11e4-8e41-991c79fa0d8a.png)
