### PR TITLE
Use localStorage for Google Analytics - not ready for merge

### DIFF
--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -61,6 +61,15 @@
           ga('create', 'UA-27829474-1', {'storage': 'none', 'clientId': localStorage.getItem('gaClientId')});
           ga(function (t) { localStorage.setItem('gaClientId', t.get('clientId')); });
           ga('send', 'pageview');
+
+          ga(function() {
+            var cookies=['__utma', '__utmb', '__utmc', '__utmv', '__utmz', '_gat'];
+            for (var i = cookies.length; i--; ) {
+              var cookie = cookies[i]+"=; expires="+(new Date(0)).toGMTString()+"; path=/";
+              document.cookie = cookie;
+              document.cookie = cookie + '; domain=.'+document.domain;
+            }
+          });
         </script>
         <% IF twitter_card_inc %>
         <% INCLUDE $twitter_card_inc %>


### PR DESCRIPTION
This makes Google Analytics use the newer Universal Analytics code, which allows it to store IDs using localStorage rather than cookies.

This can't be merged until the Google Analytics account is upgraded to Universal Analytics.
