### PR TITLE
Add about page for custom metadata MetaCPAN supports

### DIFF
--- a/lib/MetaCPAN/Web/Controller/About.pm
+++ b/lib/MetaCPAN/Web/Controller/About.pm
@@ -39,4 +39,9 @@ sub faq : Local {
     $c->stash( template => 'about/faq.html' );
 }
 
+sub metadata : Local {
+    my ( $self, $c ) = @_;
+    $c->stash( template => 'about/metadata.html' );
+}
+
 1;

--- a/root/about/metadata.html
+++ b/root/about/metadata.html
@@ -1,0 +1,92 @@
+<% title = 'MetaCPAN Metadata' %>
+<% PROCESS inc/about-bar.html %>
+<div class="content about anchors">
+<% USE MultiMarkdown(heading_ids => 1) -%>
+<% FILTER multimarkdown %>
+## Metadata
+
+MetaCPAN uses the [CPAN::Meta spec](/pod/CPAN::Meta::Spec) for much of the
+information about a distribution.  It also supports some custom meta fields.
+
+### Contributors
+
+Distributions can provide a list of contributors using the `x_contributors`
+field in the `META.json` or `META.yml` file.  The list will be presented below
+the releaser and authors on the right sidebar.  If possible, the list should
+include an email address either linked to the user on MetaCPAN or listed in
+PAUSE.
+
+In `META.yml`:
+
+    ...
+    x_contributors:
+      - The First Contributor <contrib1@cpan.org>
+      - The Second Contributor <second_contrib@cpan.org>
+      - Yet Another Contributor <yacontrib@cpan.org>
+    ...
+
+In `META.json`:
+
+    ...
+    "x_contributors" : [
+      "The First Contributor <contrib1@cpan.org>",
+      "The Second Contributor <second_contrib@cpan.org>",
+      "Yet Another Contributor <yacontrib@cpan.org>"
+    ],
+    ...
+
+[Dist::Zilla](/pod/Dist::Zilla) users can automate adding this using the
+[Dist::Zilla::Plugin::Git::Contributors](/pod/Dist::Zilla::Plugin::Git::Contributors)
+plugin.
+
+### IRC
+
+A link to an IRC channel can be provided using the `x_IRC` (or `IRC` in
+`META.yml`) resource field.  This link should use the irc:// protocol.
+MetaCPAN will automatically transform this into a web chat link to use on the
+left sidebar.  Alternatively, `x_IRC` can be specified as a hash using `url`
+and `web` keys.  The `url` key is intended to contain an irc:// link, while the
+`web` key should have a link to join the chat room directly in the browser.
+If no web link is provided, it will be generated for you.
+
+In `META.yml`:
+
+    ...
+    resources:
+      ...
+      x_IRC: irc://irc.perl.org/#metacpan
+    ...
+
+In `META.json`:
+
+    ...
+    "resources" : {
+      ...
+      "x_IRC" : "irc://irc.perl.org/#metacpan"
+    },
+    ...
+
+Or:
+
+    ...
+    "resources" : {
+      ...
+      "x_IRC" : {
+        "url" : "irc://irc.perl.org/#metacpan",
+        "web" : "https://chat.mibbit.com/?channel=%23metacpan&server=irc.perl.org"
+      }
+    },
+    ...
+
+## Files
+
+### Change Logs
+
+MetaCPAN will look for change logs in the following files: `CHANGES`, `Changes`,
+`ChangeLog`, `Changelog`, `CHANGELOG`, and `NEWS`.  These will be shown when
+using the Changes link on the sidebar.  If the change log follows the
+[CPAN::Changes::Spec](/pod/CPAN::Changes::Spec), the release page will include
+the entries for the release.
+
+<% END %>
+</div>

--- a/root/inc/about-bar.html
+++ b/root/inc/about-bar.html
@@ -25,5 +25,8 @@
     <li<% IF req.action == 'about/missing_modules' %> class="active"<% END %>>
         <a href="/about/missing_modules">Missing Modules</a>
     </li>
+    <li<% IF req.action == 'about/metadata' %> class="active"<% END %>>
+        <a href="/about/metadata">Distribution Metadata</a>
+    </li>
     </ul>
 </div>


### PR DESCRIPTION
This adds an about page listing the custom metadata fields that MetaCPAN supports.  Currently, this includes x_contributors and x_IRC.  I've also listed information about the handling of change logs, linking to the currently nonexistent CPAN::Changelog module.

I'd be interested in feedback on the current text or for things to add to this document.
