### PR TITLE
add datacenters for mirrors.cpan.org to use

### DIFF
--- a/lib/MetaCPAN/Web/Controller/SysAdmin/DataCenters.pm
+++ b/lib/MetaCPAN/Web/Controller/SysAdmin/DataCenters.pm
@@ -1,0 +1,27 @@
+package MetaCPAN::Web::Controller::SysAdmin::DataCenters;
+
+use MetaCPAN::Moose;
+
+BEGIN { extends 'MetaCPAN::Web::Controller' }
+
+# This is used by http://mirrors.cpan.org/ fetch our
+# datacenters and update the official CPAN list
+
+sub list_datacenters : Path('list') : Args(0) GET {
+    my ( $self, $c ) = @_;
+
+    # Fetch the data center info from fastly
+    # XXX: will not work unless you have the credentials
+    my $datacenters = $c->datacenters;
+
+    $c->add_surrogate_key('datacenters');
+    $c->cdn_cache_ttl( $c->cdn_times->{one_day} );
+    $c->res->header(
+        'Cache-Control' => 'max-age=' . $c->cdn_times->{one_day} );
+    $c->stash( { success => $datacenters } );
+    $c->detach( $c->view('JSON') );
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/MetaCPAN/Web/Role/Fastly.pm
+++ b/lib/MetaCPAN/Web/Role/Fastly.pm
@@ -86,6 +86,17 @@ has 'cdn_times' => (
     lazy_build => 1,
 );
 
+sub datacenters {
+    my ($c) = @_;
+    my $net_fastly = $c->_net_fastly();
+    return unless $net_fastly;
+
+    # Uses the private interface as fastly client doesn't
+    # have this end point yet
+    my $datacenters = $net_fastly->client->_get('/datacenters');
+    return $datacenters;
+}
+
 sub _build_cdn_times {
     return {
         one_hour => 3600,


### PR DESCRIPTION
This will allow mirrors.cpan.org to get an up-to-date list of Fastly servers so that they can all be geo-located and spread around the world.

Also added to the CPAN list, which cpan.metacpan.org isn't at the moment!