### PR TITLE
breadcrumbs: fix minimum backpan count

### DIFF
--- a/root/inc/breadcrumbs.html
+++ b/root/inc/breadcrumbs.html
@@ -18,7 +18,7 @@ FOREACH version IN versions;
     END;
         breadcrumb_link(version) | none;
 END;
-    IF backpan.size > 1 %>
+    IF backpan.size >= 1 %>
         <optgroup label="BackPAN">
           <% FOREACH version IN backpan; breadcrumb_link(version) | none; END %>
         </optgroup>


### PR DESCRIPTION
don't see a reason why we don't show single backpan items, pretty sure it's a bug.
will merge once all tests pass.