### PR TITLE
fix latest changes when dist version is unparsable

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -30,12 +30,17 @@ sub last_version {
     }
     return [] unless $releases && @$releases;
 
+    my $version = $release->{version};
+    eval { $version = version->parse($version) };
+
     my @releases = sort { $b->[0] <=> $a->[0] }
         map {
         my $v   = $_->{version} =~ s/-TRIAL$//r;
         my $dev = $_->{version} =~ /_|-TRIAL$/
             || $_->{note} && $_->{note} =~ /\bTRIAL\b/;
-        [ version->parse($v), $v, $dev, $_ ];
+        my $ver = ( ref $version && length $v && eval { version->parse($v) } )
+            || $v;
+        [ $ver, $v, $dev, $_ ];
         } @$releases;
 
     my @changelogs;
@@ -49,7 +54,7 @@ sub last_version {
                 last;
             }
         }
-        elsif ( $r->[0] eq $release->{version} ) {
+        elsif ( $r->[0] eq $version ) {
             push @changelogs, $r->[3];
             $found = 1;
         }


### PR DESCRIPTION
If the dist version is not parsable as a version, just do string
comparisons against the versions found in the change log.

Fixes 500 errors on https://metacpan.org/release/WHITEWIND/neverbounce_0_02