### PR TITLE
Correct capitalization of "GitHub".

### DIFF
--- a/root/about/contributors.html
+++ b/root/about/contributors.html
@@ -38,7 +38,7 @@
           });
           $.each(rows, function(idx, row) {
             el.append(
-               '<li><a href="https://github.com/'+ row.login +'" title="Github profile of '+ row.login +'"><img src="'+ row.avatar_url +'" class="author-img" />'
+               '<li><a href="https://github.com/'+ row.login +'" title="GitHub profile of '+ row.login +'"><img src="'+ row.avatar_url +'" class="author-img" />'
               +'<strong>'+ row.login +'</strong></a>'
               +'('+ row.contributions +' '+ (row.contributions === 1 ? 'commit' : 'commits') +')</li>'
             );

--- a/root/about/development.html
+++ b/root/about/development.html
@@ -10,8 +10,8 @@
 Our code base is based on current best practices and modern web technologies.
 Our stack includes Catalyst, Plack, ElasticSearch, jQuery, Bootstrap and nginx.
 We also use Puppet for deployment and Vagrant + VirtualBox for development VMs.
-We have integration with Twitter, Github, PAUSE, Facebook and Google.  All code
-is managed on Github and we have an active channel (#metacpan) on irc.perl.org.
+We have integration with Twitter, GitHub, PAUSE, Facebook and Google.  All code
+is managed on GitHub and we have an active channel (#metacpan) on irc.perl.org.
 Try the <a href="http://widget01.mibbit.com/?autoConnect=true&server=irc.perl.org&channel=%23metacpan&nick=">mibbit web client</a> to access the channel.
 The IRC channel has an <a href="http://irclog.perlgeek.de/metacpan/">archive</a> as well.
 

--- a/root/inc/keyboard_shortcuts.html
+++ b/root/inc/keyboard_shortcuts.html
@@ -26,7 +26,7 @@
     <thead>
       <tr>
         <th></th>
-        <th>Github</th>
+        <th>GitHub</th>
       </tr>
     </thead>
     <tbody>

--- a/root/preprocess.html
+++ b/root/preprocess.html
@@ -19,7 +19,7 @@ profiles = {
   friendfeed = { name = 'FriendFeed', url = 'http://friendfeed.com/%s' },
   geeklist = { name = 'geekli.st', url = 'http://geekli.st/%s' },
   github = { name = 'GitHub', url = 'https://github.com/%s' },
-  'github-meets-cpan' = { name = 'Github Meets CPAN', url = 'http://gh.metacpan.org/user/%s' },
+  'github-meets-cpan' = { name = 'GitHub Meets CPAN', url = 'http://gh.metacpan.org/user/%s' },
   gitorious = { name = 'Gitorious', url = 'https://gitorious.org/~%s' },
   gittip = { name = 'Gratipay', url = 'https://gratipay.com/%s' },
   googleplus = { name = 'Google+', url = 'http://plus.google.com/%s' },

--- a/root/static/js/github.js
+++ b/root/static/js/github.js
@@ -5,12 +5,12 @@
     // to the same github repo.  If you mouse over both the requests are made
     // twice.  It would be nice to share the responses between both.
 
-    function GithubUrl(item) {
+    function GitHubUrl(item) {
         this.item = $(item);
         this.href = this.item.attr('href');
     }
 
-    GithubUrl.match = function(a){
+    GitHubUrl.match = function(a){
         if ($(a).length == 0) return;
 
         return $(a).attr('href').indexOf('github') >= 0;
@@ -18,7 +18,7 @@
 
     // anchor patterns and check for www. or no subdomain to avoid user wikis, blogs, etc
 
-    $.extend(GithubUrl.prototype, {
+    $.extend(GitHubUrl.prototype, {
         config: {
 
             // Release info
@@ -244,15 +244,15 @@
 
 $(document).ready(function() {
     $('.nav-list a:not(.nopopup)').each(function() {
-        if( GithubUrl.match(this) ) {
-            (new GithubUrl(this)).createPopup();
+        if( GitHubUrl.match(this) ) {
+            (new GitHubUrl(this)).createPopup();
 
         }
     });
 
     var repository = $('a[data-keyboard-shortcut="g r"]');
 
-    if( GithubUrl.match(repository) ) {
+    if( GitHubUrl.match(repository) ) {
         Mousetrap.bind('g p', function() {
             // we haven't hit the github api at this point, so we cheat for the url
             var pull_request_url = repository.attr('href') + '/pulls';

--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -15,7 +15,7 @@
     icon = "question",
     },
     {
-    title = "Github Issues",
+    title = "GitHub Issues",
     path = ["https://github.com/metacpan/metacpan-web/issues"],
     class = 'hidden-xs',
     icon = "github-alt",


### PR DESCRIPTION
Hi all!

This pull-req corrects the capitalisation of "GitHub". It was not tested locally, so please merge after testing or CI. Hacktoberfest was part of my motivation for it, but I bookmarked the typo earlier.
