### PR TITLE
change signature on request to allow query params

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Login.pm
+++ b/lib/MetaCPAN/Web/Controller/Login.pm
@@ -8,13 +8,15 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
     if ( my $code = $c->req->parameters->{code} ) {
-        my $data
-            = $c->model('API')
-            ->request( '/oauth2/access_token?client_id='
-                . $c->config->{consumer_key}
-                . '&client_secret='
-                . $c->config->{consumer_secret}
-                . "&code=$code" )->recv;
+        my $data = $c->model('API')->request(
+            '/oauth2/access_token',
+            undef,
+            {
+                client_id     => $c->config->{consumer_key},
+                client_secret => $c->config->{consumer_secret},
+                code          => $code,
+            },
+        )->recv;
         $c->req->session->set( token => $data->{access_token} );
         $c->authenticate( { token => $data->{access_token} } );
         my $state = $c->req->params->{state} || q{};

--- a/lib/MetaCPAN/Web/Model/API.pm
+++ b/lib/MetaCPAN/Web/Model/API.pm
@@ -61,9 +61,8 @@ sub model {
 }
 
 sub request {
-    my ( $self, $path, $search, $params ) = @_;
+    my ( $self, $path, $search, $params, $method ) = @_;
 
-    my ( $token, $method ) = @$params{qw(token method)};
     my $req = $self->cv;
 
     my $url = $self->api_secure->clone;
@@ -71,11 +70,18 @@ sub request {
     # the order of the following 2 lines matters
     # `path_query` is destructive
     $url->path_query($path);
-    $url->query_param( access_token => $token ) if $token;
+    for my $param ( keys %{ $params || {} } ) {
+        $url->query_param( $param => $params->{$param} );
+    }
 
     my $request = HTTP::Request->new(
-        $method ? $method : $search ? 'POST' : 'GET',
-        $url, [ 'Content-type' => 'application/json' ],
+        (
+              $method ? $method
+            : $search ? 'POST'
+            :           'GET',
+        ),
+        $url,
+        ( $search ? [ 'Content-type' => 'application/json' ] : () ),
     );
 
     # encode_json returns an octet string

--- a/lib/MetaCPAN/Web/Model/API/Module.pm
+++ b/lib/MetaCPAN/Web/Model/API/Module.pm
@@ -49,7 +49,8 @@ sub _not_rogue {
 sub autocomplete {
     my ( $self, $query ) = @_;
     my $cv = $self->cv;
-    $self->request("/search/autocomplete?q=$query&size=20")->cb(
+    $self->request( "/search/autocomplete", undef,
+        { q => $query, size => 20 } )->cb(
         sub {
             my $data = shift->recv;
             $cv->send(
@@ -60,7 +61,7 @@ sub autocomplete {
                 }
             );
         }
-    );
+        );
     return $cv;
 }
 

--- a/lib/MetaCPAN/Web/Model/API/User.pm
+++ b/lib/MetaCPAN/Web/Model/API/User.pm
@@ -6,43 +6,45 @@ extends 'MetaCPAN::Web::Model::API';
 
 sub get {
     my ( $self, $token ) = @_;
-    $self->request( '/user', undef, { token => $token } );
+    $self->request( '/user', undef, { access_token => $token } );
 }
 
 sub delete_identity {
     my ( $self, $identity, $token ) = @_;
-    $self->request( "/user/identity/$identity", undef,
-        { method => 'DELETE', token => $token } );
+    $self->request(
+        "/user/identity/$identity", undef,
+        { access_token => $token }, 'DELETE'
+    );
 }
 
 sub update_profile {
     my ( $self, $data, $token ) = @_;
     $self->request( '/user/profile', $data,
-        { method => 'PUT', token => $token } );
+        { access_token => $token }, 'PUT' );
 }
 
 sub get_profile {
     my ( $self, $token ) = @_;
-    $self->request( '/user/profile', undef, { token => $token } );
+    $self->request( '/user/profile', undef, { access_token => $token } );
 }
 
 sub add_favorite {
     my ( $self, $data, $token ) = @_;
-    $self->request( '/user/favorite', $data, { token => $token } );
+    $self->request( '/user/favorite', $data, { access_token => $token } );
 }
 
 sub remove_favorite {
     my ( $self, $data, $token ) = @_;
     $self->request( '/user/favorite/' . $data->{distribution},
-        undef, { method => 'DELETE', token => $token } );
+        undef, { access_token => $token }, 'DELETE' );
 }
 
 sub turing {
     my ( $self, $challenge, $answer, $token ) = @_;
     $self->request(
         '/user/turing',
-        { challenge => $challenge, answer => $answer },
-        { token     => $token }
+        { challenge    => $challenge, answer => $answer },
+        { access_token => $token }
     );
 }
 

--- a/t/encoding.t
+++ b/t/encoding.t
@@ -180,7 +180,7 @@ subtest 'check requests sent to the api' => sub {
         'PUT json with character string',
         [
             '/whats/this' => { mistletoe => '1F384 🎄 CHRISTMAS TREE' },
-            { method => 'PUT', token => 'nightmare' },
+            { access_token => 'nightmare' }, 'PUT',
         ],
         {
             content =>


### PR DESCRIPTION
API->request accepted a hashref of parameters, and in some places they
were used as if they were URL params.  Instead, they only accepted a
method and an access token to use.

Change request to use the parameters as URL query parameters, and use a
separate parameter for the URL.