### PR TITLE
Fix undefined deref in author email

### DIFF
--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -82,8 +82,10 @@ sub groom_contributors {
     $authors = [ grep { $_ ne 'unknown' } @$authors ];
 
     my $author_info = {
-        email =>
-            [ lc "$release->{author}\@cpan.org", @{ $author->{email} }, ],
+        email => [
+            lc "$release->{author}\@cpan.org",
+            @{ $author->{email} || [] },
+        ],
         name => $author->{name},
     };
     my %seen = map { $_ => $author_info }


### PR DESCRIPTION
When an author is missing an email, don't die, seed as an empty list.