### PR TITLE
fix links on release pages not using /pod/$module

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -125,8 +125,7 @@ sub view : Private {
     $c->stash( $c->model('API::Favorite')->find_plussers($distribution) );
 
     # Simplify the file data we pass to the template.
-    my @view_files = map { single_valued_arrayref_to_scalar($_) }
-        map +{ %{ $_->{fields} }, %{ $_->{_source} }, },
+    my @view_files = map +{ %{ $_->{fields} }, %{ $_->{_source} }, },
         @{ $modules->{hits}->{hits} };
 
     my $categories = $self->_files_to_categories( $out, \@view_files );


### PR DESCRIPTION
modules is an arrayref that will commonly only have one element.
Flattening it to a single value is incorrect.  The code that determines
how to link modules is expecting an arrayref.

Removing the flattenning doesn't seem to cause any issues, and the
hashref that results doesn't have any arrayrefs where it should have
single values.