### PR TITLE
use version specific release links for non-latest releases

### DIFF
--- a/root/inc/breadcrumbs.html
+++ b/root/inc/breadcrumbs.html
@@ -37,7 +37,7 @@ END %>
     <span class="dropdown"><b class="caret"></b></span>
     <select class="<% module ? "" : "extend" %>" onchange="document.location.href=this.value"><% PROCESS version_dropdown %></select>
     <% IF module %>
-    <a data-keyboard-shortcut="g d" class="release-name" href="/release/<% IF permalinks; [module.author, module.release].join('/'); ELSE; release.distribution; END %>"><% release.name %></a>
+    <a data-keyboard-shortcut="g d" class="release-name" href="/release/<% IF permalinks || release.status != 'latest'; [module.author, module.release].join('/'); ELSE; release.distribution; END %>"><% release.name %></a>
     <% ELSE %>
       <span class="release-name"><% release.name %></span>
     <% END %>


### PR DESCRIPTION
It is possible for a module to be listed as latest, while the dist it is
in is not.  While this indicates a bug in the indexing process, we
should still be presenting working links.