### PR TITLE
link split pod/pm files as single entry

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -89,6 +89,10 @@ sub view : Private {
         }
         grep { $_->{associated_pod} } @{ $data->{module} || [] };
     $data->{documentation} = $documentation if $documentation;
+    if ( $pod && $pod ne "$data->{author}/$data->{release}/$data->{path}" ) {
+        $data->{pod_path}
+            = $pod =~ s{^\Q$data->{author}/$data->{release}/}{}r;
+    }
 
     $c->detach('/not_found') unless ( $data->{name} );
 

--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -177,7 +177,29 @@ sub _files_to_categories {
         modules           => [],
     };
 
+    my %skip;
+
+    for my $f (@$files) {
+        next if $f->{documentation};
+        for my $module ( @{ $f->{module} || [] } ) {
+            my $assoc = $module->{associated_pod} or next;
+            $assoc =~ s{^\Q$f->{author}/$f->{release}/}{};
+            if (   $assoc ne $f->{path}
+                && $assoc eq $f->{path} =~ s{\.pm$}{\.pod}r )
+            {
+                my ($assoc_file) = grep $_->{path} eq $assoc, @$files;
+                $f->{$_} ||= $assoc_file->{$_} for qw(
+                    abstract
+                    documentation
+                );
+                $skip{$assoc}++;
+            }
+        }
+    }
+
     for my $f ( @{$files} ) {
+        next
+            if $skip{ $f->{path} };
         my %info = (
             status  => $f->{status},
             path    => $f->{path},

--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -181,14 +181,11 @@ sub _files_to_categories {
         my %info = (
             status  => $f->{status},
             path    => $f->{path},
-            release => $release->{name},
-            author  => $release->{author},
+            release => $f->{release},
+            author  => $f->{author},
         );
 
-        my @modules
-            = is_arrayref( $f->{module} ) ? @{ $f->{module} }
-            : defined $f->{module}        ? $f->{module}
-            :                               ();
+        my @modules = @{ $f->{module} || [] };
 
         if ( $f->{documentation} and @modules ) {
             push @{ $ret->{modules} }, $f;

--- a/root/pod.html
+++ b/root/pod.html
@@ -27,6 +27,12 @@
       <a data-keyboard-shortcut="g s" href="/source/<% module.author %>/<% module.release %>/<% module.path %>"><i class="fa fa-fw fa-file-code-o black"></i>Source</a>
       (<a href="<% source_host %>/source/<% module.author %>/<% module.release %>/<% module.path %>">raw</a>)
     </li>
+    <% IF module.pod_path %>
+    <li>
+      <a data-keyboard-shortcut="g p" href="/source/<% module.author %>/<% module.release %>/<% module.pod_path %>"><i class="fa fa-fw fa-file-code-o black"></i>Pod Source</a>
+      (<a href="<% source_host %>/source/<% module.author %>/<% module.release %>/<% module.pod_path %>">raw</a>)
+    </li>
+    <% END %>
     <li>
       <a data-keyboard-shortcut="g b" href="/source/<% module.author %>/<% module.release %>/<% module.path.split("/").splice(0,-1).join("/") %>"><i class="fa fa-fw fa-folder-open black"></i>Browse</a>
       (<a href="<% source_host %>/source/<% module.author %>/<% module.release %>/">raw</a>)


### PR DESCRIPTION
On the release page, link a split pod/pm file as a single module entry, rather than an entry in provides and an entry in documentation.

Also adds a pod source link to the pod page for cases like this.