### PR TITLE
always use as_string on URI objects in templates

### DIFF
--- a/root/account/identities.html
+++ b/root/account/identities.html
@@ -10,13 +10,13 @@
         <td><big><% identity %></big></td>
         <td>
             <%- IF found.size %>
-                <form action="<% c.uri_for("/account/identities") %>" method="POST">
+                <form action="<% c.uri_for("/account/identities").as_string %>" method="POST">
                     <input type="hidden" name="delete" value="<% identity.lower %>" />
                     <button type="submit" class="btn btn-block btn-danger"><span class="fa fa-times"></span> Disconnect</button>
                 </form>
             <%- ELSE %>
                 <%- IF identity == 'OpenID' %>
-                    <a class="btn btn-block btn-success" href="<% c.uri_for("/login/openid") %>"><span class="fa fa-external-link"></span> Connect</a>
+                    <a class="btn btn-block btn-success" href="<% c.uri_for("/login/openid").as_string %>"><span class="fa fa-external-link"></span> Connect</a>
                 <%- ELSE %>
                     <a class="btn btn-block btn-success" href="<% oauth_prefix %>&amp;choice=<% identity.lower %>" onclick="return logInPAUSE(this)"><span class="fa fa-external-link"></span> Connect</a>
                 <% END %>

--- a/root/account/turing.html
+++ b/root/account/turing.html
@@ -17,9 +17,9 @@
         <script>
         var RecaptchaOptions = { theme : 'white' };
         </script>
-        <form action="<% c.req.uri %>" method="POST">
+        <form action="<% c.req.uri.as_string %>" method="POST">
         <% captcha | none %>
-        <input type="hidden" name="r" value="<% referer || c.req.referer || c.uri_for('/') %>" />
+        <input type="hidden" name="r" value="<% referer || c.req.referer || c.uri_for('/').as_string %>" />
         </form>
     </fieldset>
     <% END %>

--- a/root/inc/pager.html
+++ b/root/inc/pager.html
@@ -2,17 +2,17 @@
 <div class="text-center">
   <ul class="pagination">
     <li<% UNLESS pager.previous_page %> class="disabled"<% END %>>
-      <a href="<% c.req.uri_with( p = pager.previous_page ) %>">«</a>
+      <a href="<% c.req.uri_with( p = pager.previous_page ).as_string %>">«</a>
     </li>
 <%-
 FOREACH p IN [page - 10 .. [page + 10, pager.last_page].nsort.0 ];
   IF p < 1; NEXT; END; %>
     <li<% IF p == page %> class="active"<% END %>>
-      <a href="<% c.req.uri_with( p = p ) %>"><% p %></a>
+      <a href="<% c.req.uri_with( p = p ).as_string %>"><% p %></a>
     </li>
 <%- END %>
     <li<% UNLESS pager.next_page %> class="disabled"<% END %>>
-      <a href="<% c.req.uri_with( p = pager.next_page ) %>">»</a>
+      <a href="<% c.req.uri_with( p = pager.next_page ).as_string %>">»</a>
     </li>
   </ul>
 </div>
@@ -23,7 +23,7 @@ FOREACH p IN [page - 10 .. [page + 10, pager.last_page].nsort.0 ];
        <li class="disabled"><a>Results per page:</a></li>
     <% FOREACH page_size IN [10, 20, 50, 100, 200, 500] %>
       <li <% IF page_size == size %> class="active"<% END %>>
-        <a href="<% c.req.uri_with( p = page, size = page_size ) %>"><% page_size %></a>
+        <a href="<% c.req.uri_with( p = page, size = page_size ).as_string %>"><% page_size %></a>
       </li>
     <% END %>
   </ul>
@@ -33,15 +33,15 @@ FOREACH p IN [page - 10 .. [page + 10, pager.last_page].nsort.0 ];
 
 <div class="text-center">
 <ul class="pagination">
-<li class="previous <% UNLESS pageset.previous_page %>disabled<% END %>"><a href="<% c.req.uri_with( p = pageset.previous_page ) %>">&laquo; Previous page</a></li>
+<li class="previous <% UNLESS pageset.previous_page %>disabled<% END %>"><a href="<% c.req.uri_with( p = pageset.previous_page ).as_string %>">&laquo; Previous page</a></li>
 
 <% FOREACH page_num IN pageset.pages_in_set %>
 <li <% IF page_num == pageset.current_page %> class="active"<% END %>>
-  <a href="<% c.req.uri_with( p = page_num ) %>"><% page_num %></a>
+  <a href="<% c.req.uri_with( p = page_num ).as_string %>"><% page_num %></a>
 </li>
 <% END %>
 
-<li class="next <% UNLESS pageset.next_page %>disabled<% END %>"><a href="<% c.req.uri_with( p = pageset.next_page ) %>">Next page &raquo;</a></li>
+<li class="next <% UNLESS pageset.next_page %>disabled<% END %>"><a href="<% c.req.uri_with( p = pageset.next_page ).as_string %>">Next page &raquo;</a></li>
 
 </ul>
 </div>

--- a/root/inc/recent-bar.html
+++ b/root/inc/recent-bar.html
@@ -5,7 +5,7 @@
     <li class="nav-header">Activity</li>
     <li><% INCLUDE inc/activity.html query = 'f=' _ c.req.params.f || 'l' %></li>
     <li class="nav-header">Filter</li>
-    <form action="<% c.uri_for('/recent') %>" method="get" onchange="this.form.submit()">
+    <form action="<% c.uri_for('/recent').as_string %>" method="get" onchange="this.form.submit()">
           <%-
           filter = { l = 'Latest releases', n = 'New distributions', a = 'Including BackPAN' };
           IF c.req.uri == "/recent"; c.req.params.f ||= 'l'; END;

--- a/root/inc/twitter/author.html
+++ b/root/inc/twitter/author.html
@@ -1,5 +1,5 @@
 <meta name="twitter:card"           content="summary" />
-<meta name="twitter:url"            content="<% c.req.uri %>" />
+<meta name="twitter:url"            content="<% c.req.uri.as_string %>" />
 <meta name="twitter:title"          content="<% author.name %>" />
 <meta name="twitter:description"    content="CPAN Author" />
 <meta name="twitter:site"           content="metacpan" />

--- a/root/inc/twitter/module.html
+++ b/root/inc/twitter/module.html
@@ -1,5 +1,5 @@
 <meta name="twitter:card"        content="summary" />
-<meta name="twitter:url"         content="<% c.req.uri %>" />
+<meta name="twitter:url"         content="<% c.req.uri.as_string %>" />
 <meta name="twitter:title"       content="<% module.documentation %>" />
-<meta name="twitter:description" content="<% module.abstract | html_entity %>" />
+<meta name="twitter:description" content="<% module.abstract %>" />
 <meta name="twitter:site"        content="metacpan" />

--- a/root/inc/twitter/release.html
+++ b/root/inc/twitter/release.html
@@ -1,5 +1,5 @@
 <meta name="twitter:card"        content="summary" />
-<meta name="twitter:url"         content="<% c.req.uri %>" />
+<meta name="twitter:url"         content="<% c.req.uri.as_string %>" />
 <meta name="twitter:title"       content="<% release.metadata.name %>" />
-<meta name="twitter:description" content="<% release.abstract | html_entity %>" />
+<meta name="twitter:description" content="<% release.abstract %>" />
 <meta name="twitter:site"        content="metacpan" />

--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -135,7 +135,7 @@
                     <%- END %>
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
-                    <form action="<% c.uri_for("/account/logout") %>" method="POST" id="metacpan-logout"></form>
+                    <form action="<% c.uri_for("/account/logout").as_string %>" method="POST" id="metacpan-logout"></form>
                     <li class="dropdown logged_in" style="display: none;">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                         Account


### PR DESCRIPTION
Template::Alloy silently ignores filters applied to objects, including
those with "" overloads like URI.  This means that the AUTO_FILTER html
filter won't be applied, and can open up XSS attacks.  Where we use URI
objects in our templates, use .as_string on them so they will be
properly processed as text and have filters applied.