### PR TITLE
Pretty sharing release page on twitter

### DIFF
--- a/root/inc/twitter/release.html
+++ b/root/inc/twitter/release.html
@@ -3,3 +3,6 @@
 <meta name="twitter:title"       content="<% release.metadata.name %>" />
 <meta name="twitter:description" content="<% release.abstract %>" />
 <meta name="twitter:site"        content="metacpan" />
+<% IF author.gravatar_url -%>
+<meta name="twitter:image" content="<% author.gravatar_url %>" />
+<%- END %>


### PR DESCRIPTION
There is a great twitter bot https://twitter.com/cpan_new (here is a source code for this bot https://github.com/punytan/cpan_new )

The `cpan_new` bot uses metacpan api to find out new releases and creates tweets with the links to that releases on metacpan.

But now its tweets are a bit ugly:

![screen shot 2017-03-11 at 17 02 10](https://cloud.githubusercontent.com/assets/47263/23823868/89201f94-067c-11e7-9a8e-27981dac32a8.png)

This change added author image to the twitter snippet for the release page.

Several examples:

This release page https://metacpan.org/release/ABELTJE/fixedtime-0.05_01 will get:
```
<meta name="twitter:image" content="https://secure.gravatar.com/avatar/8f05c96f651946263df3a55332b80e64?s=130&amp;d=identicon" />
```

This release page https://metacpan.org/release/ATHREEF/Glib-FindMinVersion-0.003 will get such header:

```
<meta name="twitter:image" content="https://avatars2.githubusercontent.com/u/5204368?v=3&amp;s=460" />
```

Some other example: https://metacpan.org/release/MATTIASH/HTTP-Cache-Transparent-1.3 It gets such header:
```
<meta name="twitter:image" content="https://secure.gravatar.com/avatar/2683ee4820d55dddb34a9587568b3c1a?s=130&amp;d=identicon" />
```

Urls in first 2 examples creates correct image. But the third example creates default gravatar image insted of identicon. This is because there is `&amp;` in url instead of `&`.