### PR TITLE
add class "img-responsive" to <img> tag in pod

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -168,7 +168,7 @@ sub view : Private {
         },
         replace_img => sub {
             my ( $tagname, $attrs, $text ) = @_;
-            my $tag = '<img';
+            my $tag = '<img class="img-responsive"';
             for my $attr (qw( alt border height width src title)) {
                 next
                     unless exists $attrs->{$attr};


### PR DESCRIPTION
Now style attributes for `<img>` tags are not allowed (cf #1844).

Then `<img>` can be bigger than the parent element.
See, for example, https://metacpan.org/pod/release/SKAJI/Parallel-Pipes-0.002/lib/Parallel/Pipes.pm

This pull request adds class "img-responsive" to `<img>` tag in pod so that images are made responsive-friendly.
See also http://getbootstrap.com/css/#images