### PR TITLE
convert deprecated query elements

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Activity.pm
+++ b/lib/MetaCPAN/Web/Controller/Activity.pm
@@ -43,14 +43,17 @@ sub index : Path : Args(0) {
             aggregations => {
                 histo => {
                     filter => {
-                        and => [
-                            {
-                                range => {
-                                    date => { from => $start->epoch . '000' }
-                                }
-                            },
-                            @$q
-                        ]
+                        bool => {
+                            must => [
+                                {
+                                    range => {
+                                        date =>
+                                            { from => $start->epoch . '000' }
+                                    }
+                                },
+                                @$q
+                            ]
+                        }
                     },
                     aggregations => {
                         entries => {

--- a/lib/MetaCPAN/Web/Model/API/Author.pm
+++ b/lib/MetaCPAN/Web/Model/API/Author.pm
@@ -98,9 +98,7 @@ sub by_user {
     my $query = return $self->request(
         '/author/_search',
         {
-            query => { match_all => {} },
-            filter =>
-                { or => [ map { { term => { user => $_ } } } @{$users} ] },
+            query  => { terms => { user => $users } },
             fields => [qw(user pauseid)],
             size   => 100
         }

--- a/lib/MetaCPAN/Web/Model/API/Favorite.pm
+++ b/lib/MetaCPAN/Web/Model/API/Favorite.pm
@@ -26,15 +26,7 @@ sub get {
         {
             size  => 0,
             query => {
-                filtered => {
-                    query  => { match_all => {} },
-                    filter => {
-                        or => [
-                            map { { term => { 'distribution' => $_ } } }
-                                @distributions
-                        ]
-                    }
-                }
+                terms => { 'distribution' => \@distributions }
             },
             aggregations => {
                 favorites => {
@@ -177,12 +169,7 @@ sub by_dist {
     return $self->request(
         '/favorite/_search',
         {
-            query => {
-                filtered => {
-                    query => { match_all => {} },
-                    filter => { term => { distribution => $distribution }, },
-                }
-            },
+            query   => { term => { distribution => $distribution } },
             _source => "user",
             size    => 1000,
         }

--- a/lib/MetaCPAN/Web/Model/API/Favorite.pm
+++ b/lib/MetaCPAN/Web/Model/API/Favorite.pm
@@ -182,9 +182,7 @@ sub plusser_by_id {
     return $self->request(
         '/author/_search',
         {
-            query => { match_all => {} },
-            filter =>
-                { or => [ map { { term => { user => $_ } } } @{$users} ] },
+            query => { terms => { user => $users } },
             _source => { includes => [qw(pauseid gravatar_url)] },
             size    => 1000,
             sort    => ['pauseid']

--- a/lib/MetaCPAN/Web/Model/API/File.pm
+++ b/lib/MetaCPAN/Web/Model/API/File.pm
@@ -18,21 +18,18 @@ sub dir {
         '/file/_search',
         {
             query => {
-                filtered => {
-                    query  => { match_all => {}, },
-                    filter => {
-                        and => [
-                            { term => { 'level'   => scalar @path } },
-                            { term => { 'author'  => $author } },
-                            { term => { 'release' => $release } },
-                            {
-                                prefix => {
-                                    'path' => join( q{/}, @path, q{} )
-                                }
-                            },
-                        ]
-                    },
-                }
+                bool => {
+                    must => [
+                        { term => { 'level'   => scalar @path } },
+                        { term => { 'author'  => $author } },
+                        { term => { 'release' => $release } },
+                        {
+                            prefix => {
+                                'path' => join( q{/}, @path, q{} )
+                            }
+                        },
+                    ]
+                },
             },
             size   => 999,
             fields => [

--- a/lib/MetaCPAN/Web/Model/API/Lab.pm
+++ b/lib/MetaCPAN/Web/Model/API/Lab.pm
@@ -87,12 +87,9 @@ sub fetch_latest_distros {
         '/release/_search',
         {
             query => {
-                filtered => {
-                    query  => { match_all => {} },
-                    filter => {
-                        and => \@filter,
-                    },
-                },
+                bool => {
+                    must => \@filter,
+                }
             },
             sort => [
                 'distribution', { 'version_numified' => { reverse => 1 } }

--- a/lib/MetaCPAN/Web/Model/API/Lab.pm
+++ b/lib/MetaCPAN/Web/Model/API/Lab.pm
@@ -75,20 +75,18 @@ sub _handle_module {
 sub fetch_latest_distros {
     my ( $self, $size, $pauseid ) = @_;
 
-# status can have all kinds of values, cpan is an attempt to find the ones that are on cpan but
-# are not authorized. Maybe it also includes ones that were superseeded by releases of other people
-    my @filter = ( { not => { term => { status => 'backpan' } } } );
-    if ($pauseid) {
-        push @filter, { term => { author => $pauseid } };
-    }
-
     my $cv = $self->cv;
     my $r  = $self->request(
         '/release/_search',
         {
             query => {
                 bool => {
-                    must => \@filter,
+                    must => [
+                        { terms => { status => [qw< cpan latest >] } },
+                        (
+                            $pauseid ? { term => { author => $pauseid } } : ()
+                        ),
+                    ],
                 }
             },
             sort => [

--- a/lib/MetaCPAN/Web/Model/API/Module.pm
+++ b/lib/MetaCPAN/Web/Model/API/Module.pm
@@ -85,19 +85,16 @@ sub requires {
         '/release/_search',
         {
             query => {
-                filtered => {
-                    query  => { 'match_all' => {} },
-                    filter => {
-                        and => [
-                            { term => { 'status'     => 'latest' } },
-                            { term => { 'authorized' => 1 } },
-                            {
-                                term => {
-                                    'dependency.module' => $module
-                                }
+                bool => {
+                    must => [
+                        { term => { 'status'     => 'latest' } },
+                        { term => { 'authorized' => 1 } },
+                        {
+                            term => {
+                                'dependency.module' => $module
                             }
-                        ]
-                    }
+                        }
+                    ]
                 }
             },
             size => $page_size,

--- a/lib/MetaCPAN/Web/Model/API/Rating.pm
+++ b/lib/MetaCPAN/Web/Model/API/Rating.pm
@@ -42,15 +42,7 @@ sub get {
         {
             size  => 0,
             query => {
-                filtered => {
-                    query  => { match_all => {} },
-                    filter => {
-                        or => [
-                            map { { term => { 'distribution' => $_ } } }
-                                @distributions
-                        ]
-                    }
-                }
+                terms => { distribution => \@distributions }
             },
             aggregations => {
                 ratings => {

--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -52,13 +52,12 @@ sub _new_distributions_query {
     return {
         constant_score => {
             filter => {
-                and => [
-                    { term => { first => 1 } },
-                    {
-                        not =>
-                            { filter => { term => { status => 'backpan' } } }
-                    },
-                ]
+                bool => {
+                    must => [
+                        { term  => { first  => 1 } },
+                        { terms => { status => [qw< cpan latest >] } },
+                    ]
+                }
             }
         }
     };
@@ -116,7 +115,7 @@ sub recent {
         $query = {
             constant_score => {
                 filter => {
-                    not => { filter => { term => { status => 'backpan' } } }
+                    terms => { status => [qw< cpan latest >] }
                 }
             }
         };


### PR DESCRIPTION
We have leftover query elements that are deprecated since ES 2.0
I hope this change won't cause issues... at least it doesn't break any test.

Of course, later on all these queries will move to the API... this is an interim cleanup/simplification phase.