### PR TITLE
Add dealslands.co.uk to front page.

### DIFF
--- a/root/home.html
+++ b/root/home.html
@@ -26,13 +26,17 @@
         MetaCPAN would like to acknowledge the following sponsors:
       </p>
       <div class="row sponsor-grid">
-        <div class="col-sm-6">
+        <div class="col-sm-4">
           <!-- perl careers ad remains until Jan 1, 2018 -->
           <a href="http://perl.careers/" target="_blank"><img src="/static/images/sponsors/perl-careers.png" alt="Find Perl Jobs and Perl Developers with Perl Careers"></a>
         </div>
-        <div class="col-sm-6">
+        <div class="col-sm-4">
           <!-- promocodewatch ad remains until July 6, 2017 -->
           <a href="https://www.promocodewatch.com" target="_blank">PromoCodeWatch</a>
+        </div>
+        <div class="col-sm-4">
+          <!-- dealslands ad remains until July 1, 2018 -->
+          <a href="http://www.dealslands.co.uk/">Dealslands.co.uk</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This should eventually be moved to the footer on the front page, but we currently have no prior art for this, so I'll include it with the top level sponsor ads for the time being.