### PR TITLE
Replace activity query with new API endpoint

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Activity.pm
+++ b/lib/MetaCPAN/Web/Controller/Activity.pm
@@ -6,75 +6,18 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 use DateTime;
 
-my %res = ( week => '1w', month => 'month' );
-
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
-    my $req = $c->req;
-    my $res = $res{ $req->parameters->{res} || 'week' } || '1w';
 
-    my $q = [];
-    if ( my $author = $req->parameters->{author} ) {
-        push( @$q, { term => { author => uc($author) } } );
-    }
-    if ( my $distribution = $req->parameters->{distribution} ) {
-        push( @$q, { term => { distribution => $distribution } } );
-    }
-    if ( my $module = $req->parameters->{module} ) {
-        push( @$q, { term => { 'dependency.module' => $module } } );
-    }
-    if ( $req->parameters->{f} && $req->parameters->{f} eq 'n' ) {
-        push( @$q,
-            { term  => { first  => 1 } },
-            { terms => { status => [qw< cpan latest >] } },
-        );
-    }
+    my %args = map { $_ => $c->req->parameters->{$_} }
+        keys %{ $c->req->parameters };
+    my $line = $c->model('API')->request( '/activity', undef, \%args )->recv;
+    return unless $line and exists $line->{activity};
 
-    my $start
-        = DateTime->now->truncate( to => 'month' )->subtract( months => 23 );
-    my $data = $c->model('API')->request(
-        '/release/_search',
-        {
-            query        => { match_all => {} },
-            aggregations => {
-                histo => {
-                    filter => {
-                        bool => {
-                            must => [
-                                {
-                                    range => {
-                                        date =>
-                                            { from => $start->epoch . '000' }
-                                    }
-                                },
-                                @$q
-                            ]
-                        }
-                    },
-                    aggregations => {
-                        entries => {
-                            date_histogram =>
-                                { field => 'date', interval => $res },
-                        }
-                    }
-                }
-            },
-            size => 0,
-        }
-    )->recv;
-    my $entries = $data->{aggregations}->{histo}->{entries}->{buckets};
-    $data = { map { $_->{key} => $_->{doc_count} } @$entries };
-    my $line = [
-        map {
-            $data->{ $start->clone->add( months => $_ )->epoch . '000' }
-                || 0
-        } ( 0 .. 23 )
-    ];
     $c->res->content_type('image/svg+xml');
     $c->res->headers->expires( time + 86400 );
-    $c->stash( { data => $line, template => 'activity.xml' } );
+    $c->stash( { data => $line->{activity}, template => 'activity.xml' } );
     $c->detach('View::Raw');
-
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
API now provides a new endpoint for activity info, we don't
need to send a query from WEB anymore.