### PR TITLE
use new endpoints by_user

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
+++ b/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
@@ -80,20 +80,10 @@ sub _cache_key_for_user {
 
 sub _add_fav_list_to_stash {
     my ( $self, $c, $size ) = @_;
-
     my $user = $c->user;
-
-    my $faves_cv   = $c->model('API::Favorite')->by_user( $user->id, $size );
-    my $faves_data = $faves_cv->recv;
-    my $faves      = [
-        sort { $b->{date} cmp $a->{date} }
-        map  { $_->{fields} } @{ $faves_data->{hits}{hits} }
-    ];
-
+    my $faves = $c->model('API::Favorite')->by_user( $user->id, $size );
     $c->stash( { faves => $faves } );
-
     return $user;
-
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Controller/Author.pm
+++ b/lib/MetaCPAN/Web/Controller/Author.pm
@@ -54,27 +54,7 @@ sub index : Chained('root') PathPart('') Args(0) {
     $c->detach('/not_found') unless ( $author->{pauseid} );
 
     my $took  = $data->{took};
-    my $faves = [];
-
-    if ( $author->{user} ) {
-        my $faves_data
-            = $c->model('API::Favorite')->by_user( $author->{user} )->recv;
-        $took += $faves_data->{took} || 0;
-
-        my @all_fav = map { $_->{fields}->{distribution} }
-            @{ $faves_data->{hits}->{hits} };
-        my $noLatest = $c->model('API::Release')->no_latest(@all_fav);
-        $took += $noLatest->{took} || 0;
-
-        $faves = [
-            map {
-                my $distro = $_->{fields}->{distribution};
-                $noLatest->{no_latest}->{$distro} ? () : $_->{fields};
-            } @{ $faves_data->{hits}->{hits} }
-        ];
-        single_valued_arrayref_to_scalar($faves);
-        $faves = [ sort { $b->{date} cmp $a->{date} } @{$faves} ];
-    }
+    my $faves = $c->model('API::Favorite')->by_user( $author->{user} );
 
     my $releases = [ map { $_->{fields} } @{ $data->{hits}->{hits} } ];
     single_valued_arrayref_to_scalar($releases);

--- a/lib/MetaCPAN/Web/Controller/Favorite.pm
+++ b/lib/MetaCPAN/Web/Controller/Favorite.pm
@@ -12,17 +12,12 @@ sub recent : Local : Args(0) {
     my @faves    = map { $_->{_source} } @{ $data->{hits}->{hits} };
     my @user_ids = map { $_->{user} } @faves;
 
-    my $authors
-        = $c->model('API::Author')->by_user( \@user_ids )->recv->{hits}
-        ->{hits};
-
-    my %author_for_user_id
-        = map { $_->{fields}->{user} => $_->{fields}->{pauseid} } @{$authors};
+    my $authors = $c->model('API::Author')->by_user( \@user_ids );
+    my %author_for_user_id = map { $_->{user} => $_->{pauseid} } @{$authors};
 
     foreach my $fave (@faves) {
-        if ( exists $author_for_user_id{ $fave->{user} } ) {
-            $fave->{clicked_by_author} = $author_for_user_id{ $fave->{user} };
-        }
+        next unless exists $author_for_user_id{ $fave->{user} };
+        $fave->{clicked_by_author} = $author_for_user_id{ $fave->{user} };
     }
 
     $c->stash(

--- a/lib/MetaCPAN/Web/Controller/Feed.pm
+++ b/lib/MetaCPAN/Web/Controller/Feed.pm
@@ -120,15 +120,7 @@ sub author : Local : Args(1) {
         $c->detach( '/not_found', [] );
     }
 
-    my $faves_cv = $author_info->{user}
-        && $c->model('API::Favorite')->by_user( $author_info->{user} );
-    my $faves_data
-        = $faves_cv
-        ? [
-        map { single_valued_arrayref_to_scalar($_) }
-        map { $_->{fields} } @{ $faves_cv->recv->{hits}{hits} }
-        ]
-        : [];
+    my $faves = $c->model('API::Favorite')->by_user( $author_info->{user} );
 
     $c->stash->{feed} = $self->build_feed(
         host    => $c->config->{web_host},
@@ -136,7 +128,7 @@ sub author : Local : Args(1) {
         entries => [
             sort { $b->{date} cmp $a->{date} }
                 @{ $self->_format_release_entries($release_data) },
-            @{ $self->_format_favorite_entries( $author, $faves_data ) }
+            @{ $self->_format_favorite_entries( $author, $faves ) }
         ],
     );
 }

--- a/lib/MetaCPAN/Web/Model/API/Favorite.pm
+++ b/lib/MetaCPAN/Web/Model/API/Favorite.pm
@@ -77,16 +77,11 @@ sub get {
 sub by_user {
     my ( $self, $user, $size ) = @_;
     $size ||= 250;
-    return $self->request(
-        '/favorite/_search',
-        {
-            query  => { match_all => {} },
-            filter => { term      => { user => $user }, },
-            sort   => ['distribution'],
-            fields => [qw(date author distribution)],
-            size   => $size,
-        }
-    );
+    my $ret = $self->request( "/favorite/by_user/$user", { size => $size } );
+    return unless $ret;
+    my $data = $ret->recv;
+    return [] unless exists $data->{favorites};
+    return $data->{favorites};
 }
 
 sub recent {


### PR DESCRIPTION
with this change WEB will make use of the new `/favorite/by_user` and `/author/by_user` API endpoints instead of sending the Elasticsearch query over.