### PR TITLE
Remove redundant code

### DIFF
--- a/root/author.html
+++ b/root/author.html
@@ -139,7 +139,7 @@
     </div>
     <div class="visible-xs inline-author-pic"><% INCLUDE inc/author-pic.html author = author %></div>
 <% IF releases.0 %>
-    <% INCLUDE inc/release-table.html releases = aggregated, header = 1, tablesorter = 1, table_id = "author_releases" %>
+    <% INCLUDE inc/release-table.html releases = releases, header = 1, tablesorter = 1, table_id = "author_releases" %>
 <% ELSE %>
     <div class="message">
         <strong>Releases</strong>


### PR DESCRIPTION
Some old logic that was moved out of the templates before, but
doesn't seem to add any value.

The 'latest' value isn't used and the 'aggregated' doesn't
seem right - using existing 'releases' value do the job
just fine.