### PR TITLE
Use new /release/versions/DIST API endpoint

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Feed.pm
+++ b/lib/MetaCPAN/Web/Controller/Feed.pm
@@ -136,14 +136,12 @@ sub distribution : Local : Args(1) {
     $c->cdn_max_age('1y');
     $c->add_dist_key($distribution);
 
-    my $data = $c->model('API::Release')->versions($distribution)->recv;
+    my $versions = $c->model('API::Release')->versions($distribution);
+
     $c->stash->{feed} = $self->build_feed(
         host    => $c->config->{web_host},
         title   => "Recent CPAN uploads of $distribution - MetaCPAN",
-        entries => [
-            map { single_valued_arrayref_to_scalar($_) }
-            map { $_->{fields} } @{ $data->{hits}->{hits} }
-        ]
+        entries => $versions,
     );
 }
 

--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -217,6 +217,9 @@ sub view : Private {
 
     my $dist = $release->{distribution};
 
+    my $versions = $c->model('API::Release')->versions($dist);
+    $c->stash( { versions => $versions } );
+
     # Store at fastly for a year - as we will purge!
     $c->cdn_max_age('1y');
     $c->add_dist_key($dist);

--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -133,14 +133,14 @@ sub view : Private {
     my $changes
         = $c->model('API::Changes')->last_version( $reqs->{changes}, $out );
 
+    my $versions = $c->model('API::Release')->versions($distribution);
+
     # TODO: make took more automatic (to include all)
     $c->stash(
         template => 'release.html',
         release  => $out,
         total    => $modules->{hits}->{total},
-        took     => List::Util::max(
-            $modules->{took}, $files->{took}, $reqs->{versions}->{took}
-        ),
+        took     => List::Util::max( $modules->{took}, $files->{took} ),
         root     => \@root_files,
         examples => \@examples,
         files    => \@view_files,
@@ -149,6 +149,7 @@ sub view : Private {
         documentation_raw => $categories->{documentation_raw},
         provides          => $categories->{provides},
         modules           => $categories->{modules},
+        versions          => $versions,
 
         # TODO: Put this in a more general place.
         # Maybe make a hash for feature flags?

--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -341,16 +341,8 @@ sub interesting_files {
 
 sub versions {
     my ( $self, $dist ) = @_;
-    $self->request(
-        '/release/_search',
-        {
-            query => { term => { distribution => $dist } },
-            size  => 250,
-            sort  => [      { date            => 'desc' } ],
-            fields =>
-                [qw( name date author version status maturity authorized )],
-        }
-    );
+    my $data = $self->request("/release/versions/$dist")->recv;
+    return ( $data->{releases} || [] );
 }
 
 sub favorites {

--- a/lib/MetaCPAN/Web/Role/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Role/ReleaseInfo.pm
@@ -41,10 +41,9 @@ sub api_requests {
 
         rating => $c->model('API::Rating')->get( $data->{distribution} ),
 
-        versions =>
-            $c->model('API::Release')->versions( $data->{distribution} ),
         distribution =>
             $c->model('API::Release')->distribution( $data->{distribution} ),
+
         %$reqs,
     };
 }
@@ -57,13 +56,11 @@ sub stash_api_results {
         author       => $reqs->{author},
         distribution => $reqs->{distribution},
         rating       => $reqs->{rating}->{ratings}->{ $data->{distribution} },
-        versions =>
-            [ map { $_->{fields} } @{ $reqs->{versions}->{hits}->{hits} } ],
     );
 
     my %stash
         = map { $_ => single_valued_arrayref_to_scalar( $to_stash{$_} ) }
-        ( 'rating', 'distribution', 'versions' );
+        ( 'rating', 'distribution' );
 
     $stash{contributors} = $reqs->{contributors};
 

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -114,9 +114,9 @@ test_psgi app, sub {
 # A fragile and unsure way to get the version, but at least an 80% solution.
 # TODO: Set up a fake cpan; We'll know what version to expect; we can test that this matches
             ok(
-                my $version = (
+                my ($version) = (
                     $this =~ m!(?:/pod)?/release/[^/]+/\Q$release\E-([^/"]+)!
-                    )[0],
+                ),
                 'got version from "this" link'
             );
 

--- a/t/model/release.t
+++ b/t/model/release.t
@@ -8,14 +8,6 @@ use MetaCPAN::Web;
 use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
     qw/ single_valued_arrayref_to_scalar /;
 
-sub search_release {
-    my ( $method, @args ) = @_;
-
-    return
-        map { @{ $_->{hits}{hits} } }
-        MetaCPAN::Web->model('API::Release')->$method(@args)->recv;
-}
-
 my ( $true, $false ) = @{ decode_json('[true, false]') };
 
 # Explicitly test that we get a boolean.
@@ -29,9 +21,11 @@ sub is_bool {
 }
 
 subtest modules => sub {
+    my @args = ( 'OALDERS', 'HTTP-CookieMonster-0.09' );
     my @files
         = map { $_->{fields} }
-        search_release( modules => 'OALDERS', 'HTTP-CookieMonster-0.09' );
+        @{ MetaCPAN::Web->model('API::Release')->modules(@args)
+            ->recv->{hits}{hits} };
 
     ok( scalar @files, 'found files with modules' );
 
@@ -60,9 +54,8 @@ subtest modules => sub {
 subtest versions => sub {
 
     # Something with not too many versions.
-    my @versions
-        = map { $_->{fields} }
-        search_release( versions => 'Mojolicious-Plugin-HamlRenderer' );
+    my @versions = @{ MetaCPAN::Web->model('API::Release')
+            ->versions('Mojolicious-Plugin-HamlRenderer') };
 
     ok( scalar @versions, 'found release versions' );
 


### PR DESCRIPTION
Replace the Elasticsearch query sending with a call to the new
API endpoit.

This change also fixes the related tests and simplifies the
way 'verisons' query was called.