### PR TITLE
Remove needless imports

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Author.pm
+++ b/lib/MetaCPAN/Web/Controller/Author.pm
@@ -7,9 +7,6 @@ use DateTime::Format::ISO8601 ();
 use namespace::autoclean;
 use Locale::Country ();
 
-use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
-    qw/ single_valued_arrayref_to_scalar /;
-
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 # Capture the PAUSE id in the root of the chain so we handle the upper-case redirect once.

--- a/lib/MetaCPAN/Web/Controller/Source.pm
+++ b/lib/MetaCPAN/Web/Controller/Source.pm
@@ -3,9 +3,6 @@ package MetaCPAN::Web::Controller::Source;
 use Moose;
 use namespace::autoclean;
 
-use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
-    qw/ single_valued_arrayref_to_scalar /;
-
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 sub index : Path : Args {

--- a/lib/MetaCPAN/Web/Model/API/Favorite.pm
+++ b/lib/MetaCPAN/Web/Model/API/Favorite.pm
@@ -7,9 +7,6 @@ extends 'MetaCPAN::Web::Model::API';
 use List::Util qw(uniq);
 use Future;
 
-use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
-    qw/ single_valued_arrayref_to_scalar /;
-
 sub get {
     my ( $self, $user, @distributions ) = @_;
     @distributions = uniq @distributions;

--- a/lib/MetaCPAN/Web/Model/API/Module.pm
+++ b/lib/MetaCPAN/Web/Model/API/Module.pm
@@ -4,9 +4,6 @@ use namespace::autoclean;
 
 extends 'MetaCPAN::Web::Model::API::File';
 
-use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
-    qw/ single_valued_arrayref_to_scalar /;
-
 =head1 NAME
 
 MetaCPAN::Web::Model::Module - Catalyst Model

--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -11,8 +11,6 @@ use MetaCPAN::Web::Types qw( HashRef Object );
 use URI;
 use URI::Escape qw(uri_escape uri_unescape);
 use URI::QueryParam;    # Add methods to URI.
-use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
-    qw/ single_valued_arrayref_to_scalar /;
 
 sub ACCEPT_CONTEXT {
     my ( $class, $c, $args ) = @_;


### PR DESCRIPTION
While moving queries to API calls some of these ES output
formatters are not needed anymore (and will soon be removed
altogether)