### PR TITLE
Search: fix author search results reading

### DIFF
--- a/root/search.html
+++ b/root/search.html
@@ -6,7 +6,7 @@
 <% IF authors.total %>
   <div class="author-results">
     <ul class="authors clearfix">
-      <%- FOREACH author IN authors.results %>
+      <%- FOREACH author IN authors.authors %>
         <li>
           <a href="/author/<% author.id %>" title="Author page for <% author.name | html %>">
             <%- IF author.gravatar_url %>


### PR DESCRIPTION
After moving to a new API endpoint the structure name has
changed from 'results' to 'authors'.

This will fix the authors matches not showing on the search results page.