### PR TITLE
refactor and improve file sorting on release page

### DIFF
--- a/root/preprocess.html
+++ b/root/preprocess.html
@@ -85,13 +85,12 @@ profiles = {
   END;
 
   MACRO link_to_source(file, linktext) BLOCK;
-    # NOTE: The 'package' attribute is fabricated in the release template.
+    # NOTE: The 'name' attribute is fabricated in the release template.
     path = ['source', file.author, file.release, file.path].join('/');
-    # Append "#P${package}" if we have a package name.
-    IF file.package;
-      path = path _  '#P' _ file.package;
+    IF file.name;
+      path = path _  '#P' _ file.name;
     END
-    %><a href="/<% path %>"><% linktext || file.package || file.path %></a><%
+    %><a href="/<% path %>"><% linktext || file.name || file.path %></a><%
   END;
 
   # protocols = {

--- a/root/release.html
+++ b/root/release.html
@@ -94,7 +94,7 @@
 <div class="file-group release-provides">
   <h2 id="provides">Provides</h2>
   <ul>
-  <%- FOREACH module IN provides.sort('package') %>
+  <%- FOREACH module IN provides %>
   <li>
     <% link_to_source(module) | none %> in <% module.path %>
     <% IF module.indexed AND NOT module.authorized %><em class="unauthorized">UNAUTHORIZED</em><% END %>
@@ -108,7 +108,7 @@
 <div class="file-group release-examples">
   <h2 id="examples">Examples</h2>
   <ul>
-  <%- FOREACH file IN examples.sort('path') %>
+  <%- FOREACH file IN examples %>
   <li>
     <%- IF file.path.match('\.pod$') %>
       <% link_to_file(file, file.path) | none %>
@@ -124,11 +124,11 @@
 </div>
 <%- END %>
 
-<%- IF root.size %>
+<%- IF other.size %>
 <div class="file-group release-other-files">
   <h2 id="other">Other files</h2>
   <ul>
-    <%- FOREACH file IN root %>
+    <%- FOREACH file IN other %>
     <li><% link_to_file(file, file.name) | none %></li>
     <%- END %>
   </ul>


### PR DESCRIPTION
Move all file sorting into one routine.  Only link one one of a matching
pod/pm pair.  Allow for other interesting files that aren't in the root
directory.