### PR TITLE
Add Perl syntax highlighting to alienfile

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Source.pm
+++ b/lib/MetaCPAN/Web/Controller/Source.pm
@@ -93,7 +93,7 @@ sub detect_filetype {
         # No separate pod brush as of 2011-08-04.
         return 'perl' if /\. ( p[ml] | psgi | pod ) $/ix;
 
-        return 'perl' if /^ cpanfile $/ix;
+        return 'perl' if /^ (cpan|alien)file $/ix;
 
         return 'yaml' if /\. ya?ml $/ix;
 


### PR DESCRIPTION
alienfile is a recipe used by Aliens during the build process. alienfile, like cpanfile is essentially Perl source.  It is already in use by a few Alien developers aside from myself.  It would be helpful, and I think not harmful to get the same syntax highlighting as cpanfile.