### PR TITLE
fix call to inc/favorite.html

### DIFF
--- a/root/search.html
+++ b/root/search.html
@@ -25,7 +25,7 @@
   <big><strong>
    <% link_to_file(item) | none %>
    <%- IF item.abstract; ' - '; item.abstract; END %>
-  </strong></big><% INCLUDE inc/favorite.html module = item %><br>
+  </strong></big><% INCLUDE inc/favorite.html release = item favorites = release.favorites %><br>
   <% IF item.description %><p class="description"><% item.description.chunk(250).0 _ '...' %></p>
   <% END %>
   <a class="author" href="/author/<% item.author %>"><% item.author %></a><a href="/release/<% IF item.status == 'latest'; item.distribution; ELSE; item.author; '/'; item.release; END %>">/<% item.release %></a>


### PR DESCRIPTION
this is a quick fix to make the search page work with the reworked inc/favorite.html data (release instead of module).

@haarg I didn't change the included template itself here (it's just a quick fix), but I wanted to save the need to send `favorites = release.favorites` when release is already sent to the template... thought that might break something you did.
anyway - that can be optimized to clean the code a little bit.