### PR TITLE
Release: use 'get' endpoint in API

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -27,7 +27,7 @@ it under the same terms as Perl itself.
 
 sub get {
     my ( $self, $author, $release ) = @_;
-    $self->request("/release/by_author_and_name/$author/$release");
+    $self->request("/release/$author/$release");
 }
 
 sub distribution {


### PR DESCRIPTION
requires https://github.com/metacpan/metacpan-api/pull/731 (so expects tests to fail now)

after this one is merged - remove api.release.by_author_and_name endpoint