### PR TITLE
Reverse dependencies: pass 'sort' in the request body

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -75,7 +75,7 @@ sub reverse_dependencies {
     $sort ||= { date => 'desc' };
 
     return $self->request( "/reverse_dependencies/dist/$distribution",
-        undef, { sort => $sort } );
+        { sort => $sort } );
 }
 
 sub interesting_files {


### PR DESCRIPTION
The 'sort' param is a complex structure (hash) which gets
stringified if passed as a URL param which leads to an error
on the API side, and data not to be displayed on the page.

This change makes the request to be sent as POST.