### PR TITLE
Tentative and untested fix for missing count.

### DIFF
--- a/root/author.html
+++ b/root/author.html
@@ -134,7 +134,7 @@
 
 <div class="content">
     <div id="feed_subscription" class="page-header">
-        <p><% IF relases.0 %><% releases.size %><% ELSE %>No<% END %> distributions uploaded by <span class="author-name"><% author.name %></span> (<% author.pauseid %>)</p>
+        <p><% IF releases.0 %><% releases.size %><% ELSE %>No<% END %> distributions uploaded by <span class="author-name"><% author.name %></span> (<% author.pauseid %>)</p>
         <a href="/feed/author/<% author.pauseid %>"><i class="fa fa-rss fa-2x black"></i></a>
     </div>
     <div class="visible-xs inline-author-pic"><% INCLUDE inc/author-pic.html author = author %></div>

--- a/root/author.html
+++ b/root/author.html
@@ -134,7 +134,7 @@
 
 <div class="content">
     <div id="feed_subscription" class="page-header">
-        <p>Distributions uploaded by <span class="author-name"><% author.name %></span> (<% author.pauseid %>)</p>
+        <p><% IF relases.0 %><% releases.size %><% ELSE %>No<% END %> distributions uploaded by <span class="author-name"><% author.name %></span> (<% author.pauseid %>)</p>
         <a href="/feed/author/<% author.pauseid %>"><i class="fa fa-rss fa-2x black"></i></a>
     </div>
     <div class="visible-xs inline-author-pic"><% INCLUDE inc/author-pic.html author = author %></div>


### PR DESCRIPTION
See https://github.com/metacpan/metacpan-web/issues/1975 :

<<<<
Seems like the result count is now completely missing on authors pages
such as https://metacpan.org/author/BOOK which renders this issue report
outdated - #1507 . I personally really liked the distributions count and
think it should be restored and may likely work on that. What is the
consensus for that? Also note the demise of perlresume -
vti/perlresume.org#15 .
>>>>