### PR TITLE
Fix 'sort' param sending in URL for reverse_dependencies

### DIFF
--- a/lib/MetaCPAN/Web/ActionRole/Sortable.pm
+++ b/lib/MetaCPAN/Web/ActionRole/Sortable.pm
@@ -32,7 +32,10 @@ around execute => sub {
             if defined $p_order && defined $order->[$p_order];
     }
 
-    return $self->$orig( @_, { $sort->{column} => $sort->{order} } );
+    # convert sort to the non-structure form (so we can pass it in URL)
+    # API can handle it.
+    my $sort_param = sprintf "%s:%s", $sort->{column}, $sort->{order};
+    return $self->$orig( @_, $sort_param );
 };
 
 1;

--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -72,7 +72,7 @@ sub find {
 # stolen from Module/requires
 sub reverse_dependencies {
     my ( $self, $distribution, $page, $page_size, $sort ) = @_;
-    $sort ||= { date => 'desc' };
+    $sort ||= 'date:desc';
 
     return $self->request( "/reverse_dependencies/dist/$distribution",
         undef, { sort => $sort } );


### PR DESCRIPTION
goes together with https://github.com/metacpan/metacpan-api/pull/751
