### PR TITLE
Use grep metacpan for distro search

### DIFF
--- a/root/inc/release-tools.html
+++ b/root/inc/release-tools.html
@@ -41,6 +41,14 @@
         <input type="submit" style="display: none">
     </form>
 </li>
+<li>
+    <form action="https://grep.metacpan.org/search">
+        <input type="hidden" name="qd" value="<% release.distribution %>">
+        <input type="hidden" name="source" value="metacpan">
+         <input type="search" name="q" placeholder="grep distribution" style="width: 153px" class="form-control tool-bar-form">
+         <input type="submit" style="display: none">
+     </form>
+</li>
 <%- IF versions.size > 1 %>
 <li>
     <select onchange="document.location.href='/<% IF module; "module"; ELSE; "release"; END %>/'+this.value" class="form-control tool-bar-form">


### PR DESCRIPTION
note that grep.metacpan is only going to perform
the search for the last available version of
the distribution.

![Left bar search inside a distro](https://s3.amazonaws.com/uploads.hipchat.com/163339/1299963/F63q7uF9G63IG8j/Screen%20Shot%202017-11-17%20at%2012.07.16%20PM.png)

![Results in grep.metacpan](https://s3.amazonaws.com/uploads.hipchat.com/163339/1299963/4LciKCB6PEmAqzE/Screen%20Shot%202017-11-17%20at%2012.07.27%20PM.png)

