### PR TITLE
Clean up river gauge

### DIFF
--- a/lib/MetaCPAN/Web/Controller/River.pm
+++ b/lib/MetaCPAN/Web/Controller/River.pm
@@ -21,6 +21,10 @@ sub gauge : Chained('root') PathPart('gauge') Args(1) {
             template     => 'river/gauge.svg',
         }
     );
+
+    $c->cdn_max_age('1y');
+    $c->add_dist_key( $dist->{name} );
+
     $c->detach( $c->view("Raw") );
 }
 

--- a/root/inc/breadcrumbs.html
+++ b/root/inc/breadcrumbs.html
@@ -48,8 +48,8 @@ END %>
       IF have_released; %>
     <a class="latest" href="<% IF module %>/pod/<% module.documentation %><% ELSE %>/release/<% release.distribution; END %>" title="<%- IF release.maturity == 'developer'; 'dev release, '; END %>go to latest"><span class="fa fa-step-forward"></span></a>
   <%- END; END; %>
-  <div class="inline"><% INCLUDE inc/river-gauge.html, distribution = release.distribution %></div>
-  <div class="inline"><%- INCLUDE inc/favorite.html %></div>
+  <% INCLUDE inc/river-gauge.html, distribution = release.distribution %>
+  <%- INCLUDE inc/favorite.html %>
   <%- IF module %>
   &nbsp;/&nbsp;<span <% IF schema_org %>itemprop="name"<% END %> ><% module.documentation or module.module.0.name %></span>
   <%- END %>

--- a/root/inc/release-table.html
+++ b/root/inc/release-table.html
@@ -1,5 +1,5 @@
 <table <% IF table_id %> id="<% table_id %>"<% END %>
-  <% IF tablesorter %>data-default-sort="<% default_sort || '0,0' %>"<% END %>
+  <% IF tablesorter %>data-default-sort="<% default_sort || '1,0' %>"<% END %>
   class="table table-condensed table-striped table-releases<% IF tablesorter %> tablesorter<% END %>">
     <thead>
     <tr>

--- a/root/inc/river-gauge.html
+++ b/root/inc/river-gauge.html
@@ -5,6 +5,6 @@
 <object data="/river/gauge/<% distribution | uri | html %>"
   type="image/svg+xml"
   width="24px"
-  height="16px"
+  height="15px"
   alt="river gauge for <% distribution %>"
-  class="river-gauge"></object>
+  class="river-gauge-gauge"></object>

--- a/root/river/gauge.svg
+++ b/root/river/gauge.svg
@@ -14,8 +14,7 @@
        height="15px"
        version="1.1"
        xmlns="http://www.w3.org/2000/svg"
-       xmlns:xlink="http://www.w3.org/1999/xlink"
-       xmlns:html="http://www.w3.org/1999/xhtml">
+       xmlns:xlink="http://www.w3.org/1999/xlink">
 
     <g>
       <!--
@@ -25,9 +24,9 @@
       -->
       <title>
         <%~~%>
-        River stage <% "{zero|one|two|three|four|five|flood}".pluralize(bucket) %> <html:br/>
+        River stage <% "{zero|one|two|three|four|five|flood}".pluralize(bucket) %> &#10;
         <%~ IF river.total ~%>
-          • <% river.immediate %> direct <% "dependent".pluralize(river.immediate) %> <html:br/><%~~%>
+          • <% river.immediate %> direct <% "dependent".pluralize(river.immediate) %> &#10;<%~~%>
           • <% river.total %> total <% "dependent".pluralize(river.total) %>
         <%~ ELSE ~%>
           No dependents

--- a/root/river/gauge.svg
+++ b/root/river/gauge.svg
@@ -11,7 +11,7 @@
 <% IF defined(bucket) %>
 
   <svg width="24px"
-       height="16px"
+       height="15px"
        version="1.1"
        xmlns="http://www.w3.org/2000/svg"
        xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -301,7 +301,7 @@ $(document).ready(function() {
         }, 1000);
     });
 
-    setFavTitle($('.inline').find('button'));
+    setFavTitle($('.breadcrumbs .favorite'));
 
     $('.dropdown-toggle').dropdown();
 

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -68,13 +68,13 @@ table.keyboard-shortcuts td.keys {
     font-weight: bold;
 }
 
-object.river-gauge {
-    vertical-align: text-top;
+.river-gauge-gauge {
+    position: relative;
+    bottom: -2px;
 }
 
 button.favorite, a.favorite {
     padding: 1px 3px;
-    margin-left: 5px;
     font-size: 0.9em;
     background-color: #fff;
     opacity: 0.5;

--- a/root/static/less/search.less
+++ b/root/static/less/search.less
@@ -10,11 +10,6 @@
         max-height: 3em;
         overflow: hidden;
     }
-
-    object.river-gauge {
-        position: relative;
-        top: -1px;
-    }
 }
 
 .no-results {

--- a/root/static/less/table.less
+++ b/root/static/less/table.less
@@ -41,5 +41,6 @@
 
   th.river-gauge, td.river-gauge {
     width: 36px;
+    padding-bottom: 0px;
   }
 }


### PR DESCRIPTION
Layout and some other cleanups for river gauge.  It also embeds the svg directly on pod and release pages.  We could also embed it on other pages if that was desired, but the data wasn't immediately available so I didn't both at this point.

The html br tags in the SVG don't work in Firefox, but an encoded newline seems to, so I replaced them.

### Search page
Chrome before:
![search-chrome before](https://user-images.githubusercontent.com/50029/33848795-6ab4bc6a-de74-11e7-94cf-5dc5783ed244.png)
After:
 ![search-chrome after](https://user-images.githubusercontent.com/50029/33848802-6d4972e0-de74-11e7-80ef-f1126c5e0dd5.png)
Firefox before:
![search-firefox before](https://user-images.githubusercontent.com/50029/33848808-6f2c61da-de74-11e7-87ec-77580dcc6058.png)
After:
![search-firefox after](https://user-images.githubusercontent.com/50029/33848810-71310d8c-de74-11e7-9626-e6c06a9f9ff0.png)
### Pod breadcrumbs
Chrome before:
![pod-chrome before](https://user-images.githubusercontent.com/50029/33848820-7b82d95a-de74-11e7-93d1-2f9e5398b783.png)
After:
![pod-chrome after](https://user-images.githubusercontent.com/50029/33848825-7f7b8ae8-de74-11e7-8e27-cfde49064c6e.png)
Firefox before:
![pod-firefox before](https://user-images.githubusercontent.com/50029/33848830-8252b552-de74-11e7-977b-deaa12e7962e.png)
After:
![pod-firefox after](https://user-images.githubusercontent.com/50029/33848834-87c71c80-de74-11e7-85b6-865b4b7ae1dd.png)
### Release list
Chrome before:
![author-chrome before](https://user-images.githubusercontent.com/50029/33848837-8b0b2882-de74-11e7-998f-8a612aa7be49.png)
After:
![author-chrome after](https://user-images.githubusercontent.com/50029/33848842-8e487c70-de74-11e7-9f17-ed913120c073.png)
Firefox before:
![author-firefox before](https://user-images.githubusercontent.com/50029/33848849-9576b624-de74-11e7-9cb2-c2fd263806ff.png)
After:
![author-firefox after](https://user-images.githubusercontent.com/50029/33848852-98089696-de74-11e7-860e-812fcfa75df3.png)
