### PR TITLE
Embed river gauge

### DIFF
--- a/lib/MetaCPAN/Web/Test.pm
+++ b/lib/MetaCPAN/Web/Test.pm
@@ -14,6 +14,7 @@ use Test::XPath;
 use Try::Tiny;
 use Encode;
 use Future;
+use MetaCPAN::Web::Test::HTML5::TreeBuilder;
 use base 'Exporter';
 our @EXPORT = qw(
     GET
@@ -75,7 +76,8 @@ sub tx {
 
 # Text::XPath has `is_html` but the LibXML HTML parser doesn't like some html 5 (like nav).
     if ( delete $opts->{html} ) {
-        $xml = HTML::TreeBuilder->new_from_content( $res->content )->as_XML;
+        $xml = MetaCPAN::Web::Test::HTML5::TreeBuilder->new_from_content($xml)
+            ->as_XML;
     }
 
     # A nice alternative to XPath when the full power isn't needed.

--- a/lib/MetaCPAN/Web/Test/HTML5/Element/SVG.pm
+++ b/lib/MetaCPAN/Web/Test/HTML5/Element/SVG.pm
@@ -1,0 +1,17 @@
+package MetaCPAN::Web::Test::HTML5::Element::SVG;
+use strict;
+use warnings;
+
+use parent 'HTML::Element';
+
+sub starttag_XML {
+    my $self   = shift;
+    my $is_svg = $self->{_tag} eq 'svg';
+    local $self->{xmlns} = "http://www.w3.org/2000/svg" if $is_svg;
+    local $self->{'xmlns:xlink'} = "http://www.w3.org/1999/xlink"
+        if $is_svg;
+
+    return $self->SUPER::starttag_XML(@_);
+}
+
+1;

--- a/lib/MetaCPAN/Web/Test/HTML5/TreeBuilder.pm
+++ b/lib/MetaCPAN/Web/Test/HTML5/TreeBuilder.pm
@@ -1,0 +1,85 @@
+package MetaCPAN::Web::Test::HTML5::TreeBuilder;
+use strict;
+use warnings;
+
+use parent 'HTML::TreeBuilder';
+
+use MetaCPAN::Web::Test::HTML5::Element::SVG;
+use constant SVG_CLASS => 'MetaCPAN::Web::Test::HTML5::Element::SVG';
+
+my @svg_elements = qw(
+    a altGlyph altGlyphDef altGlyphItem animate animateColor animateMotion
+    animateTransform audio canvas circle clipPath color-profile cursor defs desc
+    discard ellipse feBlend feColorMatrix feComponentTransfer feComposite
+    feConvolveMatrix feDiffuseLighting feDisplacementMap feDistantLight
+    feDropShadow feFlood feFuncA feFuncB feFuncG feFuncR feGaussianBlur feImage
+    feMerge feMergeNode feMorphology feOffset fePointLight feSpecularLighting
+    feSpotLight feTile feTurbulence filter font-face-format font-face-name
+    font-face-src font-face-uri font-face font foreignObject g glyph glyphRef
+    hatch hatchpath hkern iframe image line linearGradient marker mask mesh
+    meshgradient meshpatch meshrow metadata missing-glyph mpath path pattern
+    polygon polyline radialGradient rect script set solidcolor stop style svg
+    switch symbol text textPath title tref tspan unknown use video view vkern
+);
+
+sub start {
+    my $self = shift;
+    my $e;
+    my $pos = $self->{'_pos'} || $self;
+    if ( !$pos->isa(SVG_CLASS) ) {
+        local $HTML::TreeBuilder::isBodyElement{article}    = 1;
+        local $HTML::TreeBuilder::isBodyElement{audio}      = 1;
+        local $HTML::TreeBuilder::isBodyElement{aside}      = 1;
+        local $HTML::TreeBuilder::isBodyElement{bdi}        = 1;
+        local $HTML::TreeBuilder::isBodyElement{datalist}   = 1;
+        local $HTML::TreeBuilder::isBodyElement{canvas}     = 1;
+        local $HTML::TreeBuilder::isBodyElement{details}    = 1;
+        local $HTML::TreeBuilder::isBodyElement{dialog}     = 1;
+        local $HTML::TreeBuilder::isBodyElement{embed}      = 1;
+        local $HTML::TreeBuilder::isBodyElement{figcaption} = 1;
+        local $HTML::TreeBuilder::isBodyElement{figure}     = 1;
+        local $HTML::TreeBuilder::isBodyElement{footer}     = 1;
+        local $HTML::TreeBuilder::isBodyElement{header}     = 1;
+        local $HTML::TreeBuilder::isBodyElement{main}       = 1;
+        local $HTML::TreeBuilder::isBodyElement{mark}       = 1;
+        local $HTML::TreeBuilder::isBodyElement{menuitem}   = 1;
+        local $HTML::TreeBuilder::isBodyElement{meter}      = 1;
+        local $HTML::TreeBuilder::isBodyElement{nav}        = 1;
+        local $HTML::TreeBuilder::isBodyElement{output}     = 1;
+        local $HTML::TreeBuilder::isBodyElement{progress}   = 1;
+        local $HTML::TreeBuilder::isBodyElement{rp}         = 1;
+        local $HTML::TreeBuilder::isBodyElement{rt}         = 1;
+        local $HTML::TreeBuilder::isBodyElement{ruby}       = 1;
+        local $HTML::TreeBuilder::isBodyElement{section}    = 1;
+        local $HTML::TreeBuilder::isBodyElement{source}     = 1;
+        local $HTML::TreeBuilder::isBodyElement{summary}    = 1;
+        local $HTML::TreeBuilder::isBodyElement{svg}        = 1;
+        local $HTML::TreeBuilder::isBodyElement{time}       = 1;
+        local $HTML::TreeBuilder::isBodyElement{track}      = 1;
+        local $HTML::TreeBuilder::isBodyElement{video}      = 1;
+        local $HTML::TreeBuilder::isBodyElement{wbr}        = 1;
+        $e = $self->SUPER::start(@_);
+
+        if ( $e->tag eq 'svg' ) {
+            bless $e, SVG_CLASS;
+        }
+    }
+    else {
+        local %HTML::TreeBuilder::isHeadElement       = ();
+        local %HTML::TreeBuilder::isHeadOrBodyElement = ();
+        local %HTML::TreeBuilder::isBodyElement       = map +( $_ => 1 ),
+            @svg_elements;
+        $e = $self->SUPER::start(@_);
+        bless $e, SVG_CLASS;
+    }
+    return $e;
+}
+
+sub _valid_name {
+    my ( $self, $attr ) = @_;
+    $attr =~ s/^xlink://;
+    return 1 if $attr =~ /\A[krxyz]\z/;
+    $self->SUPER::_valid_name($attr);
+}
+
+1;

--- a/root/inc/breadcrumbs.html
+++ b/root/inc/breadcrumbs.html
@@ -48,7 +48,7 @@ END %>
       IF have_released; %>
     <a class="latest" href="<% IF module %>/pod/<% module.documentation %><% ELSE %>/release/<% release.distribution; END %>" title="<%- IF release.maturity == 'developer'; 'dev release, '; END %>go to latest"><span class="fa fa-step-forward"></span></a>
   <%- END; END; %>
-  <% INCLUDE inc/river-gauge.html, distribution = release.distribution %>
+  <% INCLUDE inc/river-gauge.html, river = distribution.river, distribution = release.distribution %>
   <%- INCLUDE inc/favorite.html %>
   <%- IF module %>
   &nbsp;/&nbsp;<span <% IF schema_org %>itemprop="name"<% END %> ><% module.documentation or module.module.0.name %></span>

--- a/root/inc/river-gauge.html
+++ b/root/inc/river-gauge.html
@@ -2,9 +2,15 @@
   Unlike an <img>, an <object> grafts the SVG document into the DOM, which
   means browsers will display the <title> elements of the SVG.  Yay!
 -->
+<% IF river -%>
+<span class="river-gauge-gauge">
+  <%- INCLUDE river/gauge.svg, embed = 1, river = river -%>
+</span>
+<% ELSE -%>
 <object data="/river/gauge/<% distribution | uri | html %>"
   type="image/svg+xml"
   width="24px"
   height="15px"
   alt="river gauge for <% distribution %>"
   class="river-gauge-gauge"></object>
+<% END -%>

--- a/root/river/gauge.svg
+++ b/root/river/gauge.svg
@@ -5,9 +5,10 @@
     empty  = "#e4e2e2"
     filled = "#7ea3f2"
 ~%>
+<% IF !embed -%>
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-
+<% END -%>
 <% IF defined(bucket) %>
 
   <svg width="24px"


### PR DESCRIPTION
The river gauge data will often be available on the page including it, so it makes more sense to embed it rather than having a separate request.  This can be extended to other areas later.

This requires adding a hacked-up HTML5 parser to properly handle the SVG elements in the tests.