### PR TITLE
Gratipay (née Gittip) was shut down at the end of 2017

### DIFF
--- a/root/preprocess.html
+++ b/root/preprocess.html
@@ -17,7 +17,6 @@ profiles = {
   flickr = { name = 'Flickr', url = 'https://www.flickr.com/people/%s/' },
   github = { name = 'GitHub', url = 'https://github.com/%s' },
   'github-meets-cpan' = { name = 'GitHub Meets CPAN', url = 'https://gh.metacpan.org/user/%s' },
-  gittip = { name = 'Gratipay', url = 'https://gratipay.com/%s' },
   googleplus = { name = 'Google+', url = 'https://plus.google.com/%s' },
   hackernews = { name = 'Hacker News', url = 'https://news.ycombinator.com/user?id=%s' },
   identica = { name = 'Identi.ca', url = 'https://identi.ca/%s' },


### PR DESCRIPTION
https://gratipay.news/the-end-cbfba8f50981