### PR TITLE
Added distribution name to POD page

### DIFF
--- a/root/pod.html
+++ b/root/pod.html
@@ -18,6 +18,9 @@
     <li class="nav-header">
       <time class="relatize" itemprop="dateModified" datetime="<% module.date.dt_date_common %>"><% module.date.dt_http %></time>
     </li>
+    <li>
+      Distribution: <% module.distribution | html %></span>
+    </li>
     <% IF documented_module.version %>
     <li>
       Module version: <span itemprop="softwareVersion"><% documented_module.version | html %></span>


### PR DESCRIPTION
Oddly enough, we don't currently have an easy-to-select distribution
name in the POD page (which I need quite often).