### PR TITLE
Display who can actually release a distribution

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Permission.pm
+++ b/lib/MetaCPAN/Web/Controller/Permission.pm
@@ -16,6 +16,18 @@ sub distribution : Local Args(1) {
     my ( $self, $c, $distribution ) = @_;
 
     $c->forward( 'get', $c, [ 'distribution', $distribution ] );
+
+    my $modules       = $c->stash->{permission};
+    my $total_modules = scalar @$modules;
+    my %num_modules_of;
+    for my $module (@$modules) {
+        ++$num_modules_of{ $module->{owner} };
+        ++$num_modules_of{$_} for @{ $module->{co_maintainers} };
+    }
+    my @releaser = sort grep { $num_modules_of{$_} == $total_modules }
+        keys %num_modules_of;
+
+    $c->stash( releaser => \@releaser );
 }
 
 sub module : Local Args(1) {

--- a/lib/MetaCPAN/Web/Controller/Permission.pm
+++ b/lib/MetaCPAN/Web/Controller/Permission.pm
@@ -1,6 +1,7 @@
 package MetaCPAN::Web::Controller::Permission;
 
 use Moose;
+use List::Util qw(uniq);
 use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
@@ -38,6 +39,12 @@ sub get : Private {
     }
 
     $c->stash( { search_term => $name, permission => $perms } );
+
+    return if $type eq 'module';
+    $c->stash( {
+        num_owners   => scalar( uniq map $_->{owner},               @$perms ),
+        num_comaints => scalar( uniq map @{ $_->{co_maintainers} }, @$perms ),
+    } );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/root/inc/permission.html
+++ b/root/inc/permission.html
@@ -1,8 +1,8 @@
 <table class="table table-striped">
   <tr>
-    <th>Name</th>
-    <th>Owner</th>
-    <th>Co-Maintainers</th>
+    <th>Module (<% permission.size %>)</th>
+    <th>Owner (<% num_owners %>)</th>
+    <th>Co-Maintainers (<% num_comaints %>)</th>
   </tr>
   <% FOREACH module IN permission %>
     <tr>

--- a/root/permission/distribution.html
+++ b/root/permission/distribution.html
@@ -2,4 +2,24 @@
 
 <h1>Module Permissions for <% search_term %></h1>
 
+<table class="table table-striped" style="width: auto; min-width: 33%">
+  <tr>
+    <th>Authorized Releasers (<% releaser.size %>)</th>
+  </tr>
+  <% FOREACH author IN releaser %>
+    <tr>
+      <td>
+        <a href="/author/<% author %>"><% author %></a>
+      </td>
+    </tr>
+  <% END %>
+  <% IF releaser.size == 0 %>
+    <tr>
+      <td>
+        <i>No owner<% IF num_comaints %> or co-maintainer<% END %> has permissions for all modules in this distribution.</i>
+      </td>
+    </tr>
+  <% END %>
+</table>
+
 <% INCLUDE 'inc/permission.html' %>


### PR DESCRIPTION
Currently to figure out who can upload a new release of a distribution that will actually get indexed properly, you have to intersect the sets of the owner and co-maintainers of each module in your head. This is a job for a computer.

This PR makes the computer do it.