### PR TITLE
Add "How to Contribute" link and functionality

### DIFF
--- a/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
@@ -1,0 +1,60 @@
+package MetaCPAN::Web::Controller::ContributingDoc;
+
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'MetaCPAN::Web::Controller' }
+
+use List::Util ();
+
+sub index : Chained('/') : PathPart('contributing-to') : CaptureArgs(0) {
+}
+
+sub release : Chained('index') : PathPart('') : Args(2) {
+    my ( $self, $c, $author, $release ) = @_;
+
+    # force consistent casing in URLs
+    if ( $author ne uc($author) ) {
+        $c->res->redirect(
+            $c->uri_for( $c->action, [ uc($author), $release ] ), 301 );
+        $c->detach();
+    }
+
+    $c->forward( 'get', [ $author, $release ] );
+}
+
+sub get : Private {
+    my ( $self, $c, @args ) = @_;
+
+    my $contributing_re = qr/(CONTRIBUTING|HACKING)/i;
+    my $files
+        = $c->model('API::Release')->interesting_files(@args)->get->{files};
+
+    my $file = List::Util::first { $_->{name} =~ /$contributing_re/ } @$files;
+
+    if ( !exists $file->{path} ) {
+        my $release = join q{/}, @args;
+        $c->stash( {
+            message => 'Ask the author on how to contribute to this release.',
+            suggest => {
+                description => 'Try the release info page',
+                url         => $c->uri_for("/release/$release"),
+                link_text   => $release,
+            }
+        } );
+        $c->detach('/not_found');
+    }
+    else {
+        my $path = join '/' => @$file{qw(author release path)};
+        if ( $path =~ /\.(pod|pm)$/ ) {
+            $c->res->redirect( "/pod/release/$path", 301 );
+        }
+        else {
+            $c->res->redirect( "/source/$path", 301 );
+        }
+    }
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/root/inc/release-info.html
+++ b/root/inc/release-info.html
@@ -6,6 +6,9 @@
     <a class="nopopup" href="<% release.resources.homepage %>"><i class="fa fa-fw fa-external-link black"></i>Homepage</a>
 </li>
 <% END %>
+<li>
+    <a class="nopopup" href="/contributing-to/<% [release.author, release.name].join('/') %>"><i class="fa fa-fw fa-plus-circle black"></i>How to Contribute</a>
+</li>
 <% IF release.resources.repository %>
 <li>
     <% IF is_url(release.resources.repository.web) %>


### PR DESCRIPTION
This implements a link to a release's `CONTRIBUTING` or similar files in its MetaCPAN page:

![image](https://user-images.githubusercontent.com/110625/39082691-b663f79e-4589-11e8-9b05-e6955a21cce4.png)

Currently this will link to a new route `/contributing-to/$author/$release` which calls ~a new API implemented in https://github.com/metacpan/metacpan-api/pull/802~ `API::Release->interesting_files` and filters for Contributing/Hacking files, as implemented in https://github.com/metacpan/metacpan-api/pull/803.  If a Contributing file is found, it will use the appropriate renderer for it (e.g. HTML if it is in pod, source if otherwise.) If no file is found, it will show a 404 with a suggestion to contact the author.

Fixes #1779.