### PR TITLE
Fix doc typo

### DIFF
--- a/root/about/missing_modules.html
+++ b/root/about/missing_modules.html
@@ -6,14 +6,14 @@
 
 ## Is it in the index?
 
-MetaCPAN uses the [PAUSE](https://pause.perl.org/) generated
+MetaCPAN uses the [PAUSE](https://pause.perl.org/)-generated
 [02packages.details.txt](https://cpan.metacpan.org/modules/02packages.details.txt)
 file. If it's not in there, then the module author will need to fix this.
 (Authors are usually emailed about this when they upload a distribution).
 
 ## Is the distribution POD only with no package?
 
-A distribution must contain a package, even if it is 100% POD, a good example
+A distribution must contain a package, even if it is 100% POD. A good example
 of this done correctly is [Catalyst::Manual](/pod/Catalyst::Manual).  Check
 the package declaration in the source of this file.  That's the key to getting
 your pure POD distribution indexed by PAUSE.


### PR DESCRIPTION
Fix typo in the [Missing Modules](https://metacpan.org/about/missing_modules) FAQ.