### PR TITLE
view contributing files directly rather than redirecting

### DIFF
--- a/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
@@ -7,7 +7,16 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 use List::Util ();
 
-sub index : Chained('/') : PathPart('contributing-to') : CaptureArgs(0) {
+sub index : Chained('/') : PathPart('contributing-to') : CaptureArgs(0) { }
+
+sub dist : Chained('index') : PathPart('') : Args(1) {
+    my ( $self, $c, $dist ) = @_;
+
+    my $release = $c->model('API::Release')->find($dist)->get->{release};
+    if ( $release && $release->{author} && $release->{name} ) {
+        return $c->forward( 'get', [ $release->{author}, $release->{name} ] );
+    }
+    $c->detach('/not_found');
 }
 
 sub release : Chained('index') : PathPart('') : Args(2) {

--- a/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
@@ -35,7 +35,7 @@ sub release : Chained('index') : PathPart('') : Args(2) {
 sub get : Private {
     my ( $self, $c, @args ) = @_;
 
-    my $contributing_re = qr/(CONTRIBUTING|HACKING)/i;
+    my $contributing_re = qr/CONTRIBUTING|HACKING/i;
     my $files
         = $c->model('API::Release')->interesting_files(@args)->get->{files};
 
@@ -54,12 +54,14 @@ sub get : Private {
         $c->detach('/not_found');
     }
     else {
-        my $path = join '/' => @$file{qw(author release path)};
-        if ( $path =~ /\.(pod|pm)$/ ) {
-            $c->res->redirect( "/pod/release/$path", 301 );
+        my @path = split m{/}, $file->{path};
+        if ( $file->{pod_lines} && @{ $file->{pod_lines} } ) {
+            $c->forward( "/pod/release",
+                [ $file->{author}, $file->{release}, @path ] );
         }
         else {
-            $c->res->redirect( "/source/$path", 301 );
+            $c->forward( "/source/index",
+                [ $file->{author}, $file->{release}, @path ] );
         }
     }
 }

--- a/root/inc/release-info.html
+++ b/root/inc/release-info.html
@@ -7,7 +7,7 @@
 </li>
 <% END %>
 <li>
-    <a class="nopopup" href="/contributing-to/<% [release.author, release.name].join('/') %>"><i class="fa fa-fw fa-plus-circle black"></i>How to Contribute</a>
+    <a class="nopopup" href="/contributing-to/<% IF permalinks; [release.author, release.name].join('/'); ELSE; release.distribution; END %>"><i class="fa fa-fw fa-plus-circle black"></i>How to Contribute</a>
 </li>
 <% IF release.resources.repository %>
 <li>


### PR DESCRIPTION
Also adds and uses a dist-specific URL, in addition to the previously existing release-specific URL.