### PR TITLE
convert most content uses of line-height to be relative

### DIFF
--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -316,7 +316,7 @@ ul {
 }
 
 h1, .h1, h2, .h2, h3, .h3 {
-    line-height: 35px;
+    line-height: 1.8em;
 }
 
 .black {
@@ -414,7 +414,7 @@ form#logout {
 .main-content {
     margin-bottom: 60px;
     margin-top: 20px;
-    line-height: 20px;
+    line-height: 1.54em;
 }
 
 .tool-bar-form {
@@ -516,7 +516,7 @@ form#logout {
     margin-left: 175px;
     border-left: 1px solid #e9e9e9;
     padding-left: 15px;
-    line-height: 20px;
+    line-height: 1.54em;
 }
 
 .site-alert-message {

--- a/root/static/less/nav-list.less
+++ b/root/static/less/nav-list.less
@@ -2,7 +2,7 @@
     padding-left: 0px;
     width: 174px;
     margin-bottom: 0;
-    line-height: 20px;
+    line-height: 1.54em;
     float: left;
 
     a,


### PR DESCRIPTION
If the font size is not what we expect for some reason, it's better to
have the line-height be relative to the font size rather than being hard
coded.
Fixes #2025.