### PR TITLE
avoid renavigating when getting a #P{package} link target

### DIFF
--- a/root/static/js/syntaxhighlighter.js
+++ b/root/static/js/syntaxhighlighter.js
@@ -122,11 +122,11 @@ $(function () {
             var lineCount = leadingSource[0].split("\n").length;
             if (leadingSource.length > 1 && lineCount > 1) {
                 source.attr('data-line', lineCount);
-                document.location.hash = "#L" + lineCount;
             }
-            else {
+            else if (window.history && window.history.replaceState) {
                 // reset the anchor portion of the URL (it just looks neater).
-                document.location.hash = '';
+                var loc = document.location.toString().replace(/#.*/, '');
+                window.history.replaceState(null, '', loc);
             }
         }
     }


### PR DESCRIPTION
Rather than changing the location hash to #L{line}, just leave it with
the package target.

If the package is the first line, erase the location hash using
replaceState, avoiding an extra browser history entry, as well as
removing the extraneous empty hash.

Fixes #1980.