### PR TITLE
do not link `source` files in sitemaps - we block in our robots.txt file

### DIFF
--- a/lib/MetaCPAN/Sitemap.pm
+++ b/lib/MetaCPAN/Sitemap.pm
@@ -12,6 +12,7 @@ use Future;
 
 use Moo;
 
+
 has api_secure  => ( is => 'ro',   required => 1 );
 has url_prefix  => ( is => 'ro',   required => 1 );
 has object_type => ( is => 'ro',   required => 1 );
@@ -96,6 +97,10 @@ END_XML_HEADER
             for my $hit (@$hits) {
                 my $link_field = $hit->{fields}{ $self->field_name };
                 $link_field = $link_field->[0] if ref $link_field;
+
+                # our robots.txt blocks /source/
+                next if $link_field =~ /source/;
+
                 my $url = $self->url_prefix . $link_field;
                 $fh->print( "    <url><loc>"
                         . encode_entities_numeric($url)


### PR DESCRIPTION
One of the warnins from Google is our sitemaps link to `/source/...` which we block with our robots.txt

This is a little hack to stop those being included