### PR TITLE
use search/web/v2 api

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Search.pm
+++ b/lib/MetaCPAN/Web/Controller/Search.pm
@@ -75,10 +75,10 @@ sub index : Path : Args(0) {
         }
     }
     else {
-        my $results = $model->search_web( $query, $from, $page_size );
-
-        my $authors = $c->model('API::Author')->search( $query, $from );
-        ( $results, $authors ) = ( $results->get, $authors->get );
+        my ( $results, $authors ) = Future->needs_all(
+            $model->search_web( $query, $from, $page_size ),
+            $c->model('API::Author')->search( $query, $from ),
+        )->get;
 
         if ( !$results->{total} && !$authors->{total} ) {
             my $suggest = $query;

--- a/lib/MetaCPAN/Web/Model/API/Module.pm
+++ b/lib/MetaCPAN/Web/Model/API/Module.pm
@@ -42,10 +42,9 @@ sub autocomplete {
 
 sub search_web {
     my ( $self, $query, $from, $page_size ) = @_;
-    $self->request( "/search/web", undef,
+    $self->request( "/search/web/v2", undef,
         { q => $query, size => $page_size // 20, from => $from // 0 } )
-        ->then( $self->add_river(
-        sub { map @$_, @{ $_[0]{results} || [] } } ) );
+        ->then( $self->add_river( sub { @{ $_[0]{results} || [] } } ) );
 }
 
 sub first {

--- a/root/search.html
+++ b/root/search.html
@@ -18,13 +18,13 @@
   </div>
 <% END %>
 
-<% FOREACH group IN results; item = group.0 %>
+<% FOREACH group IN results; item = group.hits.0 %>
   <div class="module-result">
   <big><strong>
    <% link_to_file(item) | none %>
    <%- IF item.abstract; ' - '; item.abstract; END %>
   </strong></big>
-  <% INCLUDE inc/river-gauge.html, distribution = item.distribution, river = item.river %>
+  <% INCLUDE inc/river-gauge.html, distribution = item.distribution, river = group.river %>
   <% INCLUDE inc/favorite.html release = item favorites = release.favorites %>
   <br>
   <% IF item.description %><p class="description"><% item.description.chunk(250).0 _ '...' %></p>
@@ -38,12 +38,12 @@
   <%- END %>
   <!-- <% item.score %> -->
 <br>
-<% IF group.size > 1 %>
+<% IF group.hits.size > 1 %>
 <ul>
-  <% FOREACH item IN group; IF loop.first; NEXT; END; IF loop.index > 3; LAST; END %><li>
+  <% FOREACH item IN group.hits; IF loop.first; NEXT; END; IF loop.index > 3; LAST; END %><li>
   <% link_to_file(item) | none %>
   <% IF item.abstract; ' - '; item.abstract; END %></li><!-- <% item.score %> --><% END %>
-  <% IF group.size > 4 %><li><a href="/search?q=distribution:<% item.distribution %>+<% query %>"><% group.size - 4 %> more result<% IF group.size - 4 > 1; 's'; END %> from <% item.distribution %> »</a></li><% END %>
+  <% IF group.total > 4 %><li><a href="/search?q=distribution:<% item.distribution %>+<% query %>"><% group.total - 4 %> more result<% IF group.total - 4 > 1; 's'; END %> from <% item.distribution %> »</a></li><% END %>
 </ul>
 <% END %>
   </div>


### PR DESCRIPTION
The search/web/v2 API has a different form.  Rather than each result
being an arrayref, the result is an object with hits containing the top
sub-results.  The total number of sub-results is then available on the
result object.  This gives a more accurate number of sub-results,
without having to return every hit and then throwing away most of them.