### PR TITLE
use non-version specific source links on latest pages

### DIFF
--- a/root/pod.html
+++ b/root/pod.html
@@ -26,19 +26,25 @@
       Module version: <span itemprop="softwareVersion"><% documented_module.version | html %></span>
     </li>
     <% END %>
+    <% IF permalinks || release.status != 'latest';
+        source_base = '/source/' _ module.author _ '/' _ module.release;
+      ELSE
+        source_base = '/release/' _ module.distribution _ '/source';
+      END
+    -%>
     <li>
-      <a data-keyboard-shortcut="g s" href="/source/<% module.author %>/<% module.release %>/<% module.path %>"><i class="fa fa-fw fa-file-code-o black"></i>Source</a>
-      (<a href="<% source_host %>/source/<% module.author %>/<% module.release %>/<% module.path %>">raw</a>)
+      <a data-keyboard-shortcut="g s" href="<% source_base %>/<% module.path %>"><i class="fa fa-fw fa-file-code-o black"></i>Source</a>
+      (<a href="<% source_base %>/<% module.path %>?raw=1">raw</a>)
     </li>
     <% IF module.pod_path %>
     <li>
-      <a data-keyboard-shortcut="g p" href="/source/<% module.author %>/<% module.release %>/<% module.pod_path %>"><i class="fa fa-fw fa-file-code-o black"></i>Pod Source</a>
-      (<a href="<% source_host %>/source/<% module.author %>/<% module.release %>/<% module.pod_path %>">raw</a>)
+      <a data-keyboard-shortcut="g p" href="<% source_base %>/<% module.pod_path %>"><i class="fa fa-fw fa-file-code-o black"></i>Pod Source</a>
+      (<a href="<% source_base %>/<% module.pod_path %>?raw=1">raw</a>)
     </li>
     <% END %>
     <li>
-      <a data-keyboard-shortcut="g b" href="/source/<% module.author %>/<% module.release %>/<% module.path.split("/").splice(0,-1).join("/") %>"><i class="fa fa-fw fa-folder-open black"></i>Browse</a>
-      (<a href="<% source_host %>/source/<% module.author %>/<% module.release %>/">raw</a>)
+      <a data-keyboard-shortcut="g b" href="<% source_base %>/<% module.path.split("/").splice(0,-1).join("/") %>"><i class="fa fa-fw fa-folder-open black"></i>Browse</a>
+      (<a href="<% source_base %>/<% module.path.split("/").splice(0,-1).join("/") %>?raw=1">raw</a>)
     </li>
     <% PROCESS inc/release-info.html schema_org = 1 %>
     <li class="nav-header">Activity</li>

--- a/t/controller/raw.t
+++ b/t/controller/raw.t
@@ -19,7 +19,10 @@ test_psgi app, sub {
         'Content-type text/html; charset=utf-8'
     );
 
-    ok( $res = $cb->( GET "$source?download=1" ), "GET $source?download=1" );
+    $tx = tx($res);
+    ok( my $dl = $tx->find_value('//a[text()="Download"]/@href'),
+        'contains link to Download' );
+    ok( $res = $cb->( GET $dl ), "GET $dl" );
     is(
         $res->header('Content-Disposition'),
         'attachment; filename=Moose.pm',
@@ -28,7 +31,7 @@ test_psgi app, sub {
     is(
         $res->header('Content-Type'),
         'text/plain; charset=UTF-8',
-        'cotent-type text/plain'
+        'content-type text/plain'
     );
 
 };


### PR DESCRIPTION
When on a latest page using a non-version specific URL, make the source
links use non-versioned forms.

Fixes #1109