### PR TITLE
Add TPC::NA advertising on the HomePage

### DIFF
--- a/root/home.html
+++ b/root/home.html
@@ -17,7 +17,7 @@
     Hint: <% hints.pick %>
   </div>
   <div class="alert alert-info">
-    <strong>New to CPAN?</strong> Maybe take a look at <a href="/pod/Task::Kensho">Task::Kensho!</a>
+    <strong>The Perl Conference 2019</strong> <a href="https://perlconference.us/tpc-2019-pit/" title="Join the Perl Conference">June 16-21 in Pittsburgh, PA</a>
   </div>
   <div class="news-highlight row">
     <div class="col-xs-12 col-sm-8 col-sm-push-2 col-md-6 col-md-push-3">


### PR DESCRIPTION
The goal is to promote the Perl Conference,
first in US to replace it for YAPC::EU
on June the 22nd. Before going back to normal
after August 15th.

I will set reminder to update this banner over time.