### PR TITLE
clear and re-cache templates on server start in production

### DIFF
--- a/metacpan_web.conf
+++ b/metacpan_web.conf
@@ -27,6 +27,7 @@ mark_unauthorized_releases = 0
   STAT_TTL 1
   COMPILE_PERL 2
   COMPILE_DIR var/tmp/templates
+  GLOBAL_CACHE 1
 </view>
 
 <view Raw>


### PR DESCRIPTION
Several times, the cached templates on the server have become broken,
resulting in empty pages being output.  To make this easier to resolve,
clear the cached templates on server startup.  Also, since pre-cache all
of the templates at startup time.  This should prevent possible race
conditions of multiple forks trying to cache templates at the same time.

The STAT_TTL will be increased elsewhere, which should mean that the
templates are always cached in memory at server start, and never updated
after that.