### PR TITLE
Latest changelog in feed

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Feed.pm
+++ b/lib/MetaCPAN/Web/Controller/Feed.pm
@@ -26,9 +26,19 @@ sub recent : Chained('feed_index') PathPart Args(0) {
     # Set surrogate key and ttl from here as well
     $c->forward('/recent/index');
 
-    ## TODO: fix this N+1 Query.
-    for my $entry (@{$c->stash->{recent}}) {
-        $entry->{changes} = $c->model('API::Changes')->release_changes([ $entry->{author}, $entry->{name} ])->get;
+    my $changes
+        = $c->model('API::Changes')
+        ->by_releases( [
+        map { [ $_->{author}, $_->{name} ] } @{ $c->stash->{recent} }
+        ] )->get;
+
+    my %changes_index
+        = map { ( $_->{author} . '/' . $_->{name} ) => $_ } @$changes;
+    for ( @{ $c->stash->{recent} } ) {
+
+        # Provided in Model/API/Changes.pm Line 67
+        my $k = $_->{author} . '/' . $_->{name};
+        $_->{changes} = $changes_index{$k};
     }
 
     $c->stash->{feed} = $self->build_feed(
@@ -181,17 +191,22 @@ sub build_entry {
     $e->issued( DateTime::Format::ISO8601->parse_datetime( $entry->{date} ) );
     $e->title( $entry->{name} );
 
-    my $summary = $entry->{abstract};
-    if (@{$entry->{changes}}) {
-        $summary .= "\n";
-        for my $changelog (@{$entry->{changes}}) {
-            $summary .= "Changes for $changelog->{version} - $changelog->{date}\n";
-            for my $entry (@{$changelog->{entries}}) {
-                $summary .= "- " . $entry->{text} . "\n";
-            }
+    if ( my $changelog = $entry->{changes} ) {
+        my $content = '<p>' . escape_html( $entry->{abstract} ) . '</p>';
+        $content .= '<p>Changes for ' . escape_html( $changelog->{version} );
+        if ( $changelog->{date} ) {
+            $content .= ' - ' . escape_html( $changelog->{date} );
         }
+        $content .= '</p><ul>';
+        for my $entry ( @{ $changelog->{entries} } ) {
+            $content .= '<li>' . escape_html( $entry->{text} ) . "</li>\n";
+        }
+        $content .= '</ul>';
+        $e->summary($content);
     }
-    $e->summary( escape_html( $summary ) );
+    else {
+        $e->summary( escape_html( $entry->{abstract} ) );
+    }
 
     # this is a hack to work around RT#124346
     delete $e->{entry}{content}

--- a/lib/MetaCPAN/Web/Controller/Feed.pm
+++ b/lib/MetaCPAN/Web/Controller/Feed.pm
@@ -29,7 +29,7 @@ sub recent : Chained('feed_index') PathPart Args(0) {
     my %changes_index;
 
     my @copy = @{ $c->stash->{recent} };
-    while ( my @batch = splice( @copy, 0, 10 ) ) {
+    while ( my @batch = splice( @copy, 0, 100 ) ) {
         my $changes
             = $c->model('API::Changes')
             ->by_releases( [ map { [ $_->{author}, $_->{name} ] } @batch ] )

--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -58,8 +58,8 @@ sub by_releases {
 
             my @changelogs;
             for my $change (@changes) {
-                my $version = _parse_version(
-                    $change->{release} =~ m/-([^-]+(:?-TRIAL)?)$/ );
+                next unless $change->{release} =~ m/-([0-9_\.]+(-TRIAL)?)\z/;
+                my $version = _parse_version($1);
                 my @releases = _releases( $change->{changes_text} );
 
                 while ( my $r = shift @releases ) {

--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -59,7 +59,7 @@ sub by_releases {
             my @changelogs;
             for my $change (@changes) {
                 next unless $change->{release} =~ m/-([0-9_\.]+(-TRIAL)?)\z/;
-                my $version = _parse_version($1);
+                my $version  = _parse_version($1);
                 my @releases = _releases( $change->{changes_text} );
 
                 while ( my $r = shift @releases ) {


### PR DESCRIPTION
Context: https://github.com/metacpan/metacpan-web/issues/2142

With this PR, the output of `/feed/recent` action now contains the latest change log entries for each releases. Here's how it looks like when rendered with [Vienna RSS reader](https://www.vienna-rss.com/)

![](https://gugod.org/x/9ae4a0cb2338d0a934b105181ca116d0f37acbec.png)

In order to make it looks nice, the "summary" field of each entry is changed to be HTML. This might break some feed consumers. Should it be preferred, I can make this effective only when a parameter is given.

With the current implemention, when there are N recent releases to render (N is usually 100), metacpan-api is queried N/10 times instead of 1 times. I tried with 1 very long query but metacpan-api wouldn't return N results. 10 seems to be the upper bound. I'm guessig this is due to the default resultset size of Elasticsearch, and some parts from metacpan-api needs to be modified in order to retrieve 100 results in one go.

I'm not sure if this newly introduced latency is "fine" for the current server setup. If not, I can certainly patch metacpan-api to yield larger resultset.

Please take a look, and thanks for your time.
