### PR TITLE
s/https/http/ on dashboard blogs.perl.org link

### DIFF
--- a/root/lab/dashboard.html
+++ b/root/lab/dashboard.html
@@ -53,7 +53,7 @@
     <ul>
       <li>Repo R - missing link to public VCS in META files <a href="https://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributions">ways to fix it</a>.</li>
       <li>License L - missing license information in META files <a href="https://perlmaven.com/how-to-add-the-license-field-to-meta-files-on-cpan">ways to fix it</a>.</li>
-      <li>Abstract A - the <b>=head1 NAME</b> field is missing. <a href="https://blogs.perl.org/users/neilb/2014/07/give-your-modules-a-good-abstract.html">How to write good abstract</a>.</li>
+      <li>Abstract A - the <b>=head1 NAME</b> field is missing. <a href="http://blogs.perl.org/users/neilb/2014/07/give-your-modules-a-good-abstract.html">How to write good abstract</a>.</li>
       <li>Unauthorized U - One or more of the modules in this distribution are 'owned' by another CPAN author and you don't have co-maintainer rights.</li>
       <li>Bugs - number of open bugs/tickets/issues.</li>
     </ul>


### PR DESCRIPTION
On the [dashboard](https://metacpan.org/lab/dashboard), there's a link to neil bowers writeup on how to write a good abstract. The link is dead because blogs.perl.org doesn't seem to like https.
Should be replaced by
http://blogs.perl.org/users/neilb/2014/07/give-your-modules-a-good-abstract.html