### PR TITLE
Link to dependency graphs

### DIFF
--- a/root/inc/dependencies.html
+++ b/root/inc/dependencies.html
@@ -29,6 +29,12 @@ FOREACH dep IN deps.sort %>
       <%- END -%>
         <i class="fa fa-share fa-fw black"></i>Reverse dependencies</a>
     </li>
+<%- IF deps.size %>
+    <li>
+        <a href="https://cpandeps.grinnz.com/?dist=<% release.distribution | uri %>">
+        <i class="fa fa-asterisk fa-fw black"></i>Dependency graph</a>
+    </li>
+<%- END %>
     <%- IF 0 && deps.size %>
         <!-- Disabled for now, since stratopan's TLS cert is expired -->
         <li>


### PR DESCRIPTION
Possible implementation of #2174. I am not sure on a couple things so please suggest fixes if needed.

* The distribution name needs to be URI-escaped as you can see on https://metacpan.org/release/Text-Tabs+Wrap. I assume the standard Template::Toolkit uri filter can be used. It probably also should be HTML escaped but I don't know a good test case for that.
* I don't really understand the `<i>` tag part, so I just copied it from the disabled stratopan link. I assume this is for the icon next to the link.
* I don't see a benefit to embedding the graph like the stratopan graphs, over just using a standard link that people can open in a new tab if they want to - the same as the other links that are there.