### PR TITLE
Link to dependency graph unconditionally

### DIFF
--- a/root/inc/dependencies.html
+++ b/root/inc/dependencies.html
@@ -33,13 +33,4 @@ FOREACH dep IN deps.sort %>
         <a href="https://cpandeps.grinnz.com/?dist=<% release.distribution | uri %>">
         <i class="fa fa-asterisk fa-fw black"></i>Dependency graph</a>
     </li>
-    <%- IF 0 && deps.size %>
-        <!-- Disabled for now, since stratopan's TLS cert is expired -->
-        <li>
-            <button class="btn btn-link" data-toggle="modal" data-target="#dependencies-graph">
-            <i class="fa fa-asterisk fa-fw black"></i>Dependency graph</button>
-        </li>
-    <%- END %>
 </ul>
-
-<%- IF 0 && deps.size; INCLUDE inc/dependencies-graph.html; END %>

--- a/root/inc/dependencies.html
+++ b/root/inc/dependencies.html
@@ -29,12 +29,10 @@ FOREACH dep IN deps.sort %>
       <%- END -%>
         <i class="fa fa-share fa-fw black"></i>Reverse dependencies</a>
     </li>
-<%- IF deps.size %>
     <li>
         <a href="https://cpandeps.grinnz.com/?dist=<% release.distribution | uri %>">
         <i class="fa fa-asterisk fa-fw black"></i>Dependency graph</a>
     </li>
-<%- END %>
     <%- IF 0 && deps.size %>
         <!-- Disabled for now, since stratopan's TLS cert is expired -->
         <li>


### PR DESCRIPTION
The dependency graph may be configured to show dependencies from other phases or relationships, so it may be useful even if the runtime requirements are empty.