### PR TITLE
Mention and link to CPAN on main page

### DIFF
--- a/root/home.html
+++ b/root/home.html
@@ -2,6 +2,7 @@
 
 <div align="center" class="home">
   <a href="/" class="big-logo" alt="meta::cpan"></a>
+  <h4>A search engine for <a href="https://www.cpan.org">CPAN</a></h4>
   <form action="/search">
     <input type="hidden" name="size" id="search-size" value="20">
     <div class="form-group">


### PR DESCRIPTION
As an attempt to limit confusion on the relationship between CPAN and MetaCPAN, the main page could succinctly describe MetaCPAN's function and link to the CPAN home page.