### PR TITLE
Render Markdown source files as HTML

### DIFF
--- a/News.md
+++ b/News.md
@@ -1,3 +1,9 @@
+Title: Rendering .md files
+------------------------------
+Date: 2019-10-18T01:54:00
+
+We're now rendering .md files as HTML instead of as raw code.
+
 Title: The traffic is comming
 ------------------------------
 Date: 2018-12-02T19:30:00

--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -4,9 +4,8 @@ use Moose;
 
 use Encode qw( encode decode DIE_ON_ERR LEAVE_SRC );
 use Future;
-use HTML::Escape qw(escape_html);
-use HTML::Restrict   ();
 use HTML::TokeParser ();
+use MetaCPAN::Web::RenderUtil 'filter_html';
 use Try::Tiny qw( try );
 use URI ();
 
@@ -136,7 +135,7 @@ sub view : Private {
         }
     )->get;
 
-    my $pod_html = $self->filter_html( $pod->{raw}, $data );
+    my $pod_html = filter_html( $pod->{raw}, $data );
 
     my $release = $c->stash->{release};
 
@@ -197,7 +196,7 @@ sub pod2html : Path('/pod2html') {
         'POST'
     )->get->{raw};
 
-    $html = $self->filter_html($html);
+    $html = filter_html($html);
 
     if ( $c->req->parameters->{raw} ) {
         $c->res->content_type('text/html');
@@ -228,125 +227,6 @@ sub pod2html : Path('/pod2html') {
             ( $abstract ? ( abstract => $abstract ) : () ),
         } );
     }
-}
-
-sub filter_html {
-    my ( $self, $html, $data ) = @_;
-
-    my $hr = HTML::Restrict->new(
-        uri_schemes =>
-            [ undef, 'http', 'https', 'data', 'mailto', 'irc', 'ircs' ],
-        rules => {
-            a       => [qw( href id target )],
-            b       => [],
-            br      => [],
-            caption => [],
-            center  => [],
-            code    => [ { class => qr/^language-\S+$/ } ],
-            dd      => [],
-            div     => [ { class => qr/^pod-errors(?:-detail)?$/ } ],
-            dl      => [],
-            dt      => ['id'],
-            em      => [],
-            h1      => ['id'],
-            h2      => ['id'],
-            h3      => ['id'],
-            h4      => ['id'],
-            h5      => ['id'],
-            h6      => ['id'],
-            i       => [],
-            li      => ['id'],
-            ol      => [],
-            p       => [],
-            pre     => [ {
-                class        => qr/^line-numbers$/,
-                'data-line'  => qr/^\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*$/,
-                'data-start' => qr/^\d+$/,
-            } ],
-            span   => [ { style => qr/^white-space: nowrap;$/ } ],
-            strong => [],
-            sub    => [],
-            sup    => [],
-            table  => [ qw( border cellspacing cellpadding align ), ],
-            tbody  => [],
-            th     => [],
-            td     => [],
-            tr     => [],
-            u      => [],
-            ul     => [ { id => qr/^index$/ } ],
-
-            #
-            # SVG tags.
-            #
-            circle   => [qw(id cx cy r style transform)],
-            clippath => [qw(id clippathunits style transform)],
-            defs     => [qw(id style transform)],
-            ellipse  => [qw(id cx cy rx ry style transform)],
-            g        => [qw(id style transform)],
-            line     => [qw(id style transform x1 y1 x2 y2)],
-            marker   => [
-                qw(id markerheight markerunits markerwidth orient refx refy)],
-            mask =>
-                [qw(id height maskunits maskcontentunits style x y width)],
-            lineargradient => [
-                qw(id gradientunits gradienttransform spreadmethod
-                    x1 x2 y1 y2 xlink:href)
-            ],
-            path           => [qw(id d pathlength style transform)],
-            polygon        => [qw(id points style transform)],
-            polyline       => [qw(id points style transform)],
-            radialgradient => [
-                qw(id gradientunits gradienttransform spreadmethod
-                    cx cy fx fy r xlink:href)
-            ],
-            rect => [qw(id height style transform x y width)],
-            stop => [qw(id offset style)],
-            svg  => [ qw(id height preserveaspectratio version viewbox
-                    width xmlns xmlns:xlink) ],
-            title => [qw(id style)],
-            use   => [qw(id height transform width x xlink xlink:href y)],
-        },
-        replace_img => sub {
-
-            # last arg is $text, which we don't need
-            my ( $tagname, $attrs, undef ) = @_;
-            my $tag = '<img';
-            for my $attr (qw( alt border height width src title)) {
-                next
-                    unless exists $attrs->{$attr};
-                my $val = $attrs->{$attr};
-                if ( $attr eq 'src' ) {
-                    if ( $val =~ m{^(?:(?:https?|ftp):)?//|^data:} ) {
-
-                        # use directly
-                    }
-                    elsif ( $val =~ /^[0-9a-zA-Z.+-]+:/ ) {
-
-                        # bad protocol
-                        return '';
-                    }
-                    elsif ($data) {
-                        my $base = "https://st.aticpan.org/source/";
-                        if ( $val =~ s{^/}{} ) {
-                            $base .= "$data->{author}/$data->{release}/";
-                        }
-                        else {
-                            $base .= $data->{associated_pod}
-                                || "$data->{author}/$data->{release}/$data->{path}";
-                        }
-                        $val = URI->new_abs( $val, $base )->as_string;
-                    }
-                    else {
-                        $val = '/static/images/gray.png';
-                    }
-                }
-                $tag .= qq{ $attr="} . escape_html($val) . qq{"};
-            }
-            $tag .= ' />';
-            return $tag;
-        },
-    );
-    $hr->process($html);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -33,7 +33,7 @@ sub find : Path : Args(1) {
         ->else( sub { Future->done( {} ) } );
     $c->stash( $release_info->get );
 
-    # TODO: Disambiguate if there's more than once match. #176
+    # TODO: Disambiguate if there's more than one match. #176
 
     $c->forward( 'view', [@path] );
 }

--- a/lib/MetaCPAN/Web/Controller/Source.pm
+++ b/lib/MetaCPAN/Web/Controller/Source.pm
@@ -116,6 +116,8 @@ sub detect_filetype {
 
         return 'c' if /\. ( c | h | xs ) $/ix;
 
+        return 'markdown' if /\. md $/ix;
+
         # Are other changelog files likely to be in CPAN::Changes format?
         return 'cpanchanges' if /^ Changes $/ix;
     }

--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -49,7 +49,7 @@ sub by_releases {
     my ( $self, $releases ) = @_;
 
     my %release_lookup = map { ( $_->[0] . '/' . $_->[1] ) => $_ } @$releases;
-    my $path = 'by_releases?'
+    my $path           = 'by_releases?'
         . join( '&', map { 'release=' . $_ } keys %release_lookup );
     $self->get($path)->transform(
         done => sub {

--- a/lib/MetaCPAN/Web/RenderUtil.pm
+++ b/lib/MetaCPAN/Web/RenderUtil.pm
@@ -1,0 +1,130 @@
+package MetaCPAN::Web::RenderUtil;
+
+use strict;
+use warnings;
+use Sub::Exporter -setup => { exports => [qw(filter_html)], };
+
+use HTML::Escape qw(escape_html);
+use HTML::Restrict ();
+use URI            ();
+
+sub filter_html {
+    my ( $html, $data ) = @_;
+
+    my $hr = HTML::Restrict->new(
+        uri_schemes =>
+            [ undef, 'http', 'https', 'data', 'mailto', 'irc', 'ircs' ],
+        rules => {
+            a       => [qw( href id target )],
+            b       => [],
+            br      => [],
+            caption => [],
+            center  => [],
+            code    => [ { class => qr/^language-\S+$/ } ],
+            dd      => [],
+            div     => [ { class => qr/^pod-errors(?:-detail)?$/ } ],
+            dl      => [],
+            dt      => ['id'],
+            em      => [],
+            h1      => ['id'],
+            h2      => ['id'],
+            h3      => ['id'],
+            h4      => ['id'],
+            h5      => ['id'],
+            h6      => ['id'],
+            i       => [],
+            li      => ['id'],
+            ol      => [],
+            p       => [],
+            pre     => [ {
+                class        => qr/^line-numbers$/,
+                'data-line'  => qr/^\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*$/,
+                'data-start' => qr/^\d+$/,
+            } ],
+            span   => [ { style => qr/^white-space: nowrap;$/ } ],
+            strong => [],
+            sub    => [],
+            sup    => [],
+            table  => [ qw( border cellspacing cellpadding align ), ],
+            tbody  => [],
+            th     => [],
+            td     => [],
+            tr     => [],
+            u      => [],
+            ul     => [ { id => qr/^index$/ } ],
+
+            #
+            # SVG tags.
+            #
+            circle   => [qw(id cx cy r style transform)],
+            clippath => [qw(id clippathunits style transform)],
+            defs     => [qw(id style transform)],
+            ellipse  => [qw(id cx cy rx ry style transform)],
+            g        => [qw(id style transform)],
+            line     => [qw(id style transform x1 y1 x2 y2)],
+            marker   => [
+                qw(id markerheight markerunits markerwidth orient refx refy)],
+            mask =>
+                [qw(id height maskunits maskcontentunits style x y width)],
+            lineargradient => [
+                qw(id gradientunits gradienttransform spreadmethod
+                    x1 x2 y1 y2 xlink:href)
+            ],
+            path           => [qw(id d pathlength style transform)],
+            polygon        => [qw(id points style transform)],
+            polyline       => [qw(id points style transform)],
+            radialgradient => [
+                qw(id gradientunits gradienttransform spreadmethod
+                    cx cy fx fy r xlink:href)
+            ],
+            rect => [qw(id height style transform x y width)],
+            stop => [qw(id offset style)],
+            svg  => [ qw(id height preserveaspectratio version viewbox
+                    width xmlns xmlns:xlink) ],
+            title => [qw(id style)],
+            use   => [qw(id height transform width x xlink xlink:href y)],
+        },
+        replace_img => sub {
+
+            # last arg is $text, which we don't need
+            my ( $tagname, $attrs, undef ) = @_;
+            my $tag = '<img';
+            for my $attr (qw( alt border height width src title)) {
+                next
+                    unless exists $attrs->{$attr};
+                my $val = $attrs->{$attr};
+                if ( $attr eq 'src' ) {
+                    if ( $val =~ m{^(?:(?:https?|ftp):)?//|^data:} ) {
+
+                        # use directly
+                    }
+                    elsif ( $val =~ /^[0-9a-zA-Z.+-]+:/ ) {
+
+                        # bad protocol
+                        return '';
+                    }
+                    elsif ($data) {
+                        my $base = "https://st.aticpan.org/source/";
+                        if ( $val =~ s{^/}{} ) {
+                            $base .= "$data->{author}/$data->{release}/";
+                        }
+                        else {
+                            $base .= $data->{associated_pod}
+                                || "$data->{author}/$data->{release}/$data->{path}";
+                        }
+                        $val = URI->new_abs( $val, $base )->as_string;
+                    }
+                    else {
+                        $val = '/static/images/gray.png';
+                    }
+                }
+                $tag .= qq{ $attr="} . escape_html($val) . qq{"};
+            }
+            $tag .= ' />';
+            return $tag;
+        },
+    );
+    $hr->process($html);
+}
+
+1;

--- a/lib/MetaCPAN/Web/View/HTML.pm
+++ b/lib/MetaCPAN/Web/View/HTML.pm
@@ -7,6 +7,7 @@ use Digest::SHA;
 use List::Util       ();
 use Cpanel::JSON::XS ();
 use Gravatar::URL;
+use MetaCPAN::Web::RenderUtil 'filter_html';
 use Regexp::Common qw(time);
 use Template::Plugin::DateTime;
 use Template::Plugin::Markdown;
@@ -161,6 +162,8 @@ Template::Alloy->define_vmethod(
         return quotemeta( $_[0] );
     },
 );
+
+Template::Alloy->define_vmethod( 'text', filter_html => \&filter_html );
 
 __PACKAGE__->meta->make_immutable( inline_constructor => 0 );
 

--- a/root/source.html
+++ b/root/source.html
@@ -45,9 +45,14 @@
 
 <div class="content">
 <% IF !file.binary %>
+  <% IF filetype == 'markdown' %>
+    <% USE MultiMarkdown(heading_ids => 1) -%>
+    <% FILTER multimarkdown %><% source.filter_html %><% END %>
+  <% ELSE %>
 <pre id="source" class="line-numbers pod-toggle<% IF file.sloc > 10; " pod-hidden"; END %>" data-pod-lines="<%
   file.pod_lines.map(->(lines){ lines.0+1 _ "-" _ (lines.0+lines.1) }).join(', ')
 %>"><code class="language-<% filetype %>"><% source %></code></pre>
+  <% END %>
 <% ELSE %>
 This file cannot be displayed inline.  Try the <a href="<% raw_url %>">raw file</a>.
 <% END %>


### PR DESCRIPTION
Relating to #2191, this PR seeks to render .md files as HTML instead of raw source. Comments, questions and suggestions welcome. I'm new to Catalyst, so one of the things I'd like to address is the code duplication between `source.html` and `md.html`.