### PR TITLE
Change docker base image to metacpan-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.22
+FROM metacpan/metacpan-base:latest
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash \
     && apt-get update \


### PR DESCRIPTION
The perl:5.22 image is installing both 5.22 and 5.24 which is causing an
issue with module compilation. Using the metacpan-base image avoids this
problem, and is the direction we're heading anyway.