### PR TITLE
Highlight modules/dists that have a special co-maintainer (ADOPTME, HANDOFF or NEEDHELP) - Closes #1643 - Attempt 2

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -28,8 +28,8 @@ sub find : Path : Args(1) {
 
     my $release_info
         = $c->model('ReleaseInfo')
-        ->get( $pod_file->{author}, $pod_file->{release} )
-        ->else( sub { Future->done( {} ) } );
+        ->get( $pod_file->{author}, $pod_file->{release},
+        $pod_file->{module}[0]{name} )->else( sub { Future->done( {} ) } );
     $c->stash( $release_info->get );
 
     # TODO: Disambiguate if there's more than one match. #176
@@ -105,7 +105,7 @@ sub view : Private {
 
     my ( $documentation, $assoc_pod, $documented_module )
         = map { $_->{name}, $_->{associated_pod}, $_ }
-        grep { @path > 1 || $path[0] eq $_->{name} }
+        grep  { @path > 1 || $path[0] eq $_->{name} }
         grep {
               !$data->{documentation}
             || $data->{documentation} eq $_->{name}

--- a/root/inc/notification.html
+++ b/root/inc/notification.html
@@ -37,10 +37,11 @@
         );
     END;
 %>
+<input id="<% notification %>" type="checkbox" class="notification-toggle-checkbox" />
 <div id="notification" class="well collapsed notify-<% notification %>">
-    <button class="remove-notification" onclick="this.parentNode.classList.add('notification-hide')">
+    <label class="remove-notification" for="<% notification %>" >
         <i class="fa fa-fw fa-close black""></i>
-    </button>
+    </label>
     <div id="notification-container">
         <h2><% NOTIFICATION.title %></h2>
         <span>

--- a/root/inc/notification.html
+++ b/root/inc/notification.html
@@ -1,0 +1,54 @@
+<%- IF notification %>
+<%-
+    USE format;
+    MAILTO = format('mailto:%s?subject=%s&body=%s');
+    NOTIFICATION = {
+        NEEDHELP = {
+            has_email = 1,
+            title = "Looking for help!",
+            text = "The maintainer of this distribution is looking for people to help them improve this module! If you're interested then please contact them via ",
+            body = format("Hey %s,\r\n\r\nI'm willing to provide some time to help you with new feature for the %s module. if you can let me know what you would like to be done.\r\n\r\nKind Regards,")
+        },
+        ADOPTME = {
+            has_email  = 1,
+            title  = "Why not adopt me?",
+            text   = "This distribution is up for adoption! If you're interested then please contact pause module admins via ",
+            body   = format("Hey %s,\r\n\r\nI'm interested in adopting the %s module. If you can grant me the privilidge I will release the next version. Kind Regards,"),
+            email  = author.email,
+            name   = author.name
+        },
+        HANDOFF = {
+            has_email  = 1,
+            title  = "Take me over?",
+            text   = "The maintainer of this distribution is looking for someone to take over! If you're intereset then please contact them via ",
+            body   = format("Hey %s,\r\n\r\nI'm interested in taking over the %s module. If you can grant me the privilidge I will release the next version.\r\n\r\n Kind Regards,")
+        },
+    }.$notification;
+    IF pod_file && pod_file.module[0];
+        NOTIFICATION.module = pod_file.module[0].name;
+    ELSE;
+        NOTIFICATION.module = release.main_module;
+    END;
+    IF NOTIFICATION.has_email;
+        NOTIFICATION.mailto = MAILTO(
+            (NOTIFICATION.email || author.email),
+            (NOTIFICATION.title _ ' <' _ NOTIFICATION.module _ '>') | url,
+            NOTIFICATION.body((NOTIFICATION.name || author.name), NOTIFICATION.module) | url
+        );
+    END;
+%>
+<div id="notification" class="well collapsed notify-<% notification %>">
+    <button class="remove-notification" onclick="this.parentNode.classList.add('notification-hide')">
+        <i class="fa fa-fw fa-close black""></i>
+    </button>
+    <div id="notification-container">
+        <h2><% NOTIFICATION.title %></h2>
+        <span>
+            <% NOTIFICATION.text %>
+            <%- IF NOTIFICATION.has_email %>
+            <a href="<% NOTIFICATION.mailto %>">email</a>
+            <%- END %>.
+        </span>
+    </div>
+</div>
+<%- END %>

--- a/root/pod.html
+++ b/root/pod.html
@@ -62,6 +62,7 @@
   </div>
   <a name="___pod"></a>
   <div class="pod content anchors">
+  <%- INCLUDE inc/notification.html %>
   <% IF pod %>
   <% pod | none %>
   <% ELSIF pod_error %>

--- a/root/release.html
+++ b/root/release.html
@@ -34,7 +34,7 @@
 </div>
 
 <div class="content">
-
+<%- INCLUDE inc/notification.html %>
 <% MACRO change_group(group) BLOCK; %>
 <ul>
     <%- FOREACH entry IN group; %>

--- a/root/static/less/notification.less
+++ b/root/static/less/notification.less
@@ -4,7 +4,11 @@
     position: relative;
 }
 
-#notification.notification-hide {
+.notification-toggle-checkbox {
+    display: none;
+}
+
+.notification-toggle-checkbox:checked ~ #notification {
     max-height: 0;
     border: none;
     min-height: 0;
@@ -13,12 +17,11 @@
     transition: min-height .5s cubic-bezier(0, 1, 0.5, 1);
 }
 
-button.remove-notification {
+label.remove-notification {
     position: absolute;
-    right: 4px;
-    top: 4px;
-    border-color: transparent;
-    background: transparent;
+    right: 5px;
+    top: 5px;
+    cursor: pointer;
 }
 
 #notification h2 {

--- a/root/static/less/notification.less
+++ b/root/static/less/notification.less
@@ -1,0 +1,42 @@
+#notification {
+    margin-bottom: 15px;
+    overflow: auto;
+    position: relative;
+}
+
+#notification.notification-hide {
+    max-height: 0;
+    border: none;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    transition: min-height .5s cubic-bezier(0, 1, 0.5, 1);
+}
+
+button.remove-notification {
+    position: absolute;
+    right: 4px;
+    top: 4px;
+    border-color: transparent;
+    background: transparent;
+}
+
+#notification h2 {
+    display: block;
+    font-weight: bold;
+    font-size: 100%;
+    margin: 0;
+    line-height: inherit;
+}
+
+.notify-NEEDHELP {
+    background: #d7f5dd
+}
+
+.notify-ADOPTME {
+    background: #f5efd7;
+}
+
+.notify-HANDOFF {
+    background: #d7e1f5;
+}

--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -28,6 +28,7 @@
 @import "syntaxhighlighter.less";
 @import "login.less";
 @import "pod2html.less";
+@import "notification.less";
 
 @linkColor: #3366cc;
 @textColor: @black;

--- a/t/model/release-info.t
+++ b/t/model/release-info.t
@@ -82,7 +82,7 @@ subtest 'normalize_issues' => sub {
         http://rt.cpan.org/Public/Dist/Display.html?Queue=X
         http://rt.cpan.org/Public/Dist/Display.html?Status=Active&Name=X
         http://rt.cpan.org/Ticket/Create.html?Queue=X
-        ) )
+    ) )
     {
         normalize_issues_ok(
             bugtracker( web => $url ),
@@ -113,7 +113,7 @@ subtest 'normalize_issues' => sub {
         https://github.com/user/repo/issues
         http://www.github.com/user/repo/issues
         https://www.github.com/user/repo/tree
-        ) )
+    ) )
     {
         normalize_issues_ok(
             bugtracker( web => $url ),
@@ -123,6 +123,80 @@ subtest 'normalize_issues' => sub {
         );
     }
 
+};
+
+subtest 'normalize_notification_type' => sub {
+    my @tests = (
+        {
+            params   => undef,
+            expected => 0,
+            message  => 'undef passed as params'
+        },
+        {
+            params   => 'string',
+            expected => 0,
+            message  => 'string passed as params'
+        },
+        {
+            params   => [qw/one two three/],
+            expected => 0,
+            message  => 'array passed as params'
+        },
+        {
+            params   => {},
+            expected => 0,
+            message  => 'empty hash of data passed'
+        },
+        {
+            params => {
+                permission => {}
+            },
+            expected => 0,
+            message  => 'empty permissions hash past'
+        },
+        {
+            params => {
+                permission => {
+                    co_maintainers => [ 'ONE', 'TWO', 'THREE' ]
+                }
+            },
+            expected => 0,
+            message =>
+                'co_maintainers passed without "special" co_maintainer existing'
+        },
+        {
+            params => {
+                permission => {
+                    co_maintainers => [ 'ADOPTME', 'ONE', 'TWO', 'THREE' ]
+                }
+            },
+            expected => 'ADOPTME',
+            message  => 'ADOPTME passed in co_maintainers'
+        },
+        {
+            params => {
+                permission => {
+                    co_maintainers => [ 'ONE', 'NEEDHELP', 'TWO', 'THREE' ]
+                }
+            },
+            expected => 'NEEDHELP',
+            message  => 'NEEDHELP passed in co_maintainers'
+        },
+        {
+            params => {
+                permission => {
+                    co_maintainers => [ 'ONE', 'TWO', 'THREE', 'HANDOFF' ]
+                }
+            },
+            expected => 'HANDOFF',
+            message  => 'HANDOFF passed in co_maintainers'
+        }
+    );
+
+    for my $test (@tests) {
+        is( $model->normalize_notification_type( $test->{params} ),
+            $test->{expected}, $test->{message} );
+    }
 };
 
 done_testing;


### PR DESCRIPTION
Highlight modules or dists with ADOPTME or HANDOFF or NEEDHELP.

A notification will display at the top of the page in /release and /pod if ADOPTME, HANDOFF or NEEDHELP is found as an author within the modules permissions.