### PR TITLE
Display notification when owner is a special PAUSE author.

### DIFF
--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -283,12 +283,22 @@ sub normalize_issue_url {
 sub normalize_notification_type {
     my ( $self, $data ) = @_;
     if ( is_hashref($data) ) {
-        if (   is_hashref( $data->{permission} )
-            && is_arrayref( $data->{permission}{co_maintainers} ) )
-        {
-            for ( reverse @{ $data->{permission}{co_maintainers} } ) {
-                if ( $_ =~ m/^(NEEDHELP|ADOPTME|HANDOFF)$/ ) {
-                    return $_;
+        if ( is_hashref( $data->{permission} ) ) {
+            my %special = (
+                NEEDHELP => 1,
+                ADOPTME  => 1,
+                HANDOFF  => 1
+            );
+            if (   $data->{permission}->{owner}
+                && $special{ $data->{permission}->{owner} } )
+            {
+                return $data->{permission}->{owner};
+            }
+            elsif ( is_arrayref( $data->{permission}{co_maintainers} ) ) {
+                for ( reverse @{ $data->{permission}{co_maintainers} } ) {
+                    if ( $special{$_} ) {
+                        return $_;
+                    }
                 }
             }
         }

--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -289,14 +289,14 @@ sub normalize_notification_type {
                 ADOPTME  => 1,
                 HANDOFF  => 1
             );
-            if (   $data->{permission}->{owner}
-                && $special{ $data->{permission}->{owner} } )
+            if ( defined $data->{permission}{owner}
+                && exists $special{ $data->{permission}{owner} } )
             {
-                return $data->{permission}->{owner};
+                return $data->{permission}{owner};
             }
             elsif ( is_arrayref( $data->{permission}{co_maintainers} ) ) {
                 for ( reverse @{ $data->{permission}{co_maintainers} } ) {
-                    if ( $special{$_} ) {
+                    if ( exists $special{$_} ) {
                         return $_;
                     }
                 }

--- a/t/model/release-info.t
+++ b/t/model/release-info.t
@@ -185,12 +185,67 @@ subtest 'normalize_notification_type' => sub {
         {
             params => {
                 permission => {
+                    owner          => 'LNATION',
                     co_maintainers => [ 'ONE', 'TWO', 'THREE', 'HANDOFF' ]
                 }
             },
             expected => 'HANDOFF',
             message  => 'HANDOFF passed in co_maintainers'
-        }
+        },
+        {
+            params => {
+                permission => {
+                    owner => ''
+                }
+            },
+            expected => 0,
+            message  => 'Null string as owner'
+        },
+        {
+            params => {
+                permission => {
+                    owner => undef
+                }
+            },
+            expected => 0,
+            message  => 'Undef as owner'
+        },
+        {
+            params => {
+                permission => {
+                    owner => 'LNATION'
+                }
+            },
+            expected => 0,
+            message  => 'LNATION as owner'
+        },
+        {
+            params => {
+                permission => {
+                    owner => 'ADOPTME'
+                }
+            },
+            expected => 'ADOPTME',
+            message  => 'ADOPTME passed as owner'
+        },
+        {
+            params => {
+                permission => {
+                    owner => 'HANDOFF'
+                }
+            },
+            expected => 'HANDOFF',
+            message  => 'HANDOFF passed as owner'
+        },
+        {
+            params => {
+                permission => {
+                    owner => 'NEEDHELP'
+                }
+            },
+            expected => 'NEEDHELP',
+            message  => 'NEEDHELP passed as owner'
+        },
     );
 
     for my $test (@tests) {


### PR DESCRIPTION
The logic was only looking up in the co_maintainers for an author that was NEEDHELP|ADOPTME|HANDOFF. Now it will first check the owner and then the co_maintainers.

Closes #2234