### PR TITLE
Sync RSS link titles with respective feeds

### DIFF
--- a/root/author.html
+++ b/root/author.html
@@ -1,4 +1,4 @@
-<% title = author.name _ " (" _ author.pauseid _ ")"; rss = 'author/' _ author.pauseid %>
+<% title = author.name _ " (" _ author.pauseid _ ")"; rss = 'author/' _ author.pauseid; rss_title = 'Recent CPAN Activity of ' _ author.pauseid _ ' - MetaCPAN' %>
 <% twitter_card_inc = 'inc/twitter/author.html' %>
 <ul class="nav-list slidepanel">
     <li class="hidden-phone"><% INCLUDE inc/author-pic.html author = author %></li>

--- a/root/favorite/recent.html
+++ b/root/favorite/recent.html
@@ -1,5 +1,6 @@
 <%
   rss = 'recent';
+  rss_title = 'Recent CPAN Uploads - MetaCPAN';
   title = "Recent Favorites";
   INCLUDE inc/recent-bar.html;
 %>

--- a/root/home.html
+++ b/root/home.html
@@ -1,4 +1,4 @@
-<%- rss = "recent" %>
+<%- rss = "recent"; rss_title = 'Recent CPAN Uploads - MetaCPAN' %>
 
 <div align="center" class="home">
   <a href="/" class="big-logo" alt="meta::cpan"></a>

--- a/root/news.html
+++ b/root/news.html
@@ -1,5 +1,5 @@
 <%- title = "News" %>
-<%- rss = "news" %>
+<%- rss = "news"; rss_title = 'Recent MetaCPAN News' %>
 <a class="news_feed" href="/feed/news"><i class="fa fa-rss fa-2x"></i></a>
 <div class="content anchors">
 <% USE MultiMarkdown(heading_ids => 1) -%>

--- a/root/pod.html
+++ b/root/pod.html
@@ -5,7 +5,8 @@
   title =
     (module.documentation or module.module.0.name ) _
     (module.abstract ? ' - ' _ module.abstract : '');
-  rss = 'distribution/' _ module.distribution
+  rss = 'distribution/' _ module.distribution;
+  rss_title = 'Recent CPAN Uploads of ' _ module.distribution _ ' - MetaCPAN';
 %>
 
 <div itemscope itemtype="http://schema.org/SoftwareApplication">

--- a/root/recent.html
+++ b/root/recent.html
@@ -1,5 +1,6 @@
 <%
   rss = 'recent?f=' _ c.req.params.f || 'l';
+  rss_title = 'Recent CPAN Uploads - MetaCPAN';
   title = "Recent";
   INCLUDE inc/recent-bar.html;
 %>

--- a/root/release.html
+++ b/root/release.html
@@ -1,4 +1,4 @@
-<% title = release.name _ ' - ' _ release.abstract; rss = 'distribution/' _ release.distribution %>
+<% title = release.name _ ' - ' _ release.abstract; rss = 'distribution/' _ release.distribution; rss_title = 'Recent CPAN Uploads of ' _ release.distribution _ ' - MetaCPAN' %>
 <% canonical = '/release/' _ release.distribution %>
 <% meta_description = release.abstract %>
 <% twitter_card_inc = 'inc/twitter/release.html' %>

--- a/root/source.html
+++ b/root/source.html
@@ -1,4 +1,4 @@
-<%- rss = 'distribution/' _ file.distribution %>
+<%- rss = 'distribution/' _ file.distribution; rss_title = 'Recent CPAN Uploads of ' _ file.distribution _ ' - MetaCPAN' %>
 <%- title = file.path %>
 <div class="breadcrumbs">
     <a data-keyboard-shortcut="g s" href="/source/<% base = [file.author, file.release].join("/"); base %>"><% [file.author, file.release].join(" / ") %></a>

--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -56,7 +56,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
         <title><% IF title; title; ELSE; 'Search the CPAN'; END %> - metacpan.org</title>
         <%- IF rss %>
-        <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed/<% rss %>" />
+        <link rel="alternate" type="application/rss+xml" title="<% IF rss_title; rss_title; ELSE; 'RSS'; END %>" href="/feed/<% rss %>" />
         <%- END %>
         <%- FOREACH css IN req.env.item('psgix.assets').grep(/\.css$/) %>
         <link href="<% css %>" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Various readers and browser add-ons show the link title in feed
discovery phase, and the title may also end up as the title of a
subscription in a feed reader. A plain "RSS" doesn't look good in
either, and is ambiguous in subscription lists.