### PR TITLE
mailto link: Email address is ARRAY(...)

### DIFF
--- a/root/inc/notification.html
+++ b/root/inc/notification.html
@@ -31,9 +31,9 @@
     END;
     IF NOTIFICATION.has_email;
         NOTIFICATION.mailto = MAILTO(
-            (NOTIFICATION.email || author.email),
+            (NOTIFICATION.email || author.email.0 || author.email),
             (NOTIFICATION.title _ ' <' _ NOTIFICATION.module _ '>') | url,
-            NOTIFICATION.body((NOTIFICATION.name || author.name), NOTIFICATION.module) | url
+            NOTIFICATION.body((NOTIFICATION.name || author.asciiname || author.name), NOTIFICATION.module) | url
         );
     END;
 %>


### PR DESCRIPTION
The API returns inconsistently either an array or a string for author.email take the following examples:

http://localhost:5000/v1/author/NEILB is indexed as "email" : "neil@bowers.com" (locally)
https://fastapi.metacpan.org/v1/author/NEILB is indexed as "email" : ["neil@bowers.com"]
https://fastapi.metacpan.org/v1/author/REHSACK is  "email" : "rehsack@cpan.org"

So update the template logic to check first if an array email.0

Also first check for asciiname before name, which should prevent breakage in the mailto 'URI' for cases like:
"asciiname" : "Audrey Tang"
"name" : "☻ 唐鳳 ☺"
I don't think any validation exits on the asciiname field to validate it is actually ascii, perhaps this needs to be added as a seperate ticket.

Closes #2237