### PR TITLE
Fix pre-commit hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,14 +80,6 @@ notifications:
   irc: "irc.perl.org#metacpan-infra
 
 # Use newer travis infrastructure.
-sudo: false
 cache:
   directories:
     - local
-
-addons:
-  artifacts:
-    debug: false
-    s3_region: "us-east-1"
-    paths:
-    - $TRAVIS_BUILD_DIR/cpanfile.snapshot

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -2,8 +2,12 @@
 
 use strict;
 use warnings;
+
 # Hack to use carton's local::lib.
 use lib 'local/lib/perl5';
 
 use Code::TidyAll::Git::Precommit;
-Code::TidyAll::Git::Precommit->check();
+Code::TidyAll::Git::Precommit->check(
+    no_stash        => 1,
+    tidyall_options => { verbose => $ENV{TIDYALL_VERBOSE} // 0 },
+);


### PR DESCRIPTION
Enabling TidyAll stashing leads to files being deleted when the hook runs.