### PR TITLE
List 2020 coming Perl Events

### DIFF
--- a/root/home.html
+++ b/root/home.html
@@ -13,6 +13,27 @@
         <button type="submit" class="btn search-btn" name="lucky" value="1" title="Hint: Press shift and enter if you are feeling lucky">I'm Feeling Lucky</button>
     </div>
   </form>
+  <div>
+    <div class="row">
+       <div class="alert alert-info">
+         <p>
+            <strong>DC-Baltimore Perlyglot Workshop 2020</strong> <a href="https://dcbpw.org/dcbpw2020/" title="Join the Perl Workshop">April 18-19</a>
+          </p>
+         <p>
+            <strong>Perl Toolchain 2020</strong> <a href="#" title="Perl Toolchain">May 14-17</a>
+          </p>
+          <p id="mpe"><a href="#" onclick="$('#mpe').hide(); $('#perlevents').show(); false;">view more Perl Events...</a></p>
+          <div id="perlevents" style="display: none; padding-top: 8px;">
+           <p>
+              <strong>The Perl and Raku Conference in Houston</strong> <a href="https://perlconference.us/tpc-2020-hou/" title="Join the Conference">June 23-27 in Houston, TX</a>
+            </p>
+           <p>
+              <strong>The Perl and Raku Conference in Amsterdam</strong> <a href="https://perlrakucon.eu/" title="Join the Conference">August 10-14 in Amsterdam, NL</a>
+            </p>
+          </div>
+       </div>
+    </div>
+  </div>
   <div class="news-highlight row">
     <div class="col-xs-12 col-sm-8 col-sm-push-2 col-md-6 col-md-push-3">
       <p>


### PR DESCRIPTION
Display two by default, then show all of them
on demand.

By default only show two events
![Screen Shot 2020-01-15 at 1 33 47 PM](https://user-images.githubusercontent.com/405282/72469240-4200dc80-379c-11ea-921e-6fc5dcf906e3.png)

then on click list all remaining events
note: now using `The Perl and Raku` for both events, the screenshot is not up to date
![Screen Shot 2020-01-15 at 1 33 53 PM](https://user-images.githubusercontent.com/405282/72469271-504ef880-379c-11ea-85ef-2f3c584a1ffa.png)
