### PR TITLE
fixes metacpan-docker/issues/67

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
-    && apt-get install -y -f --no-install-recommends nodejs=10.17.0-1nodesource1 yarn=1.19.2-1 \
+    && apt-get install -y -f --no-install-recommends nodejs yarn=1.19.2-1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
relying on nodejs=10.17.0-1nodesource1 breaks building Dockerfile because it's not found.

https://github.com/metacpan/metacpan-docker/issues/67