### PR TITLE
Remove DC-Baltimore Perlyglot Workshop 2020

### DIFF
--- a/root/home.html
+++ b/root/home.html
@@ -17,20 +17,14 @@
     <div class="row">
        <div class="alert alert-info">
          <p>
-            <strong>DC-Baltimore Perlyglot Workshop 2020</strong> <a href="https://dcbpw.org/dcbpw2020/" title="Join the Perl Workshop">April 18-19</a>
-          </p>
-         <p>
             <strong>Perl Toolchain 2020</strong> <a href="#" title="Perl Toolchain">May 14-17</a>
+         </p>
+         <p>
+            <strong>The Perl and Raku Conference in Houston</strong> <a href="https://perlconference.us/tpc-2020-hou/" title="Join the Conference">June 23-27 in Houston, TX</a>
+         </p>
+         <p>
+            <strong>The Perl and Raku Conference in Amsterdam</strong> <a href="https://perlrakucon.eu/" title="Join the Conference">August 10-14 in Amsterdam, NL</a>
           </p>
-          <p id="mpe"><a href="#" onclick="$('#mpe').hide(); $('#perlevents').show(); false;">view more Perl Events...</a></p>
-          <div id="perlevents" style="display: none; padding-top: 8px;">
-           <p>
-              <strong>The Perl and Raku Conference in Houston</strong> <a href="https://perlconference.us/tpc-2020-hou/" title="Join the Conference">June 23-27 in Houston, TX</a>
-            </p>
-           <p>
-              <strong>The Perl and Raku Conference in Amsterdam</strong> <a href="https://perlrakucon.eu/" title="Join the Conference">August 10-14 in Amsterdam, NL</a>
-            </p>
-          </div>
        </div>
     </div>
   </div>


### PR DESCRIPTION
The workshop was cancel, promote other events.