### PR TITLE
Expand non-Docker hacking instructions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,6 +7,8 @@ Andrew Fresh <andrew@afresh1.com> <andrew+github@afresh1.com>
 Barry Walsh <draegtun@googlemail.com> <draegtun@googlemail.com>
 Brad Lhotsky <brad@divisionbyzero.net> <blhotsky@craigslist.org>
 Chris Nehren <apeiron@cpan.org> <cnehren@gmail.com>
+Christopher White <cxw@cpan.org> <cwhite@d3engineering.com>
+Christopher White <cxw@cpan.org> <chrisw@leehayes.com>
 Clinton Gormley <clint@traveljury.com> <clinton@iannounce.co.uk>
 Gabor Szabo <gabor@szabgab.com> <szabgab@gmail.com>
 Grant McLean <grant@mclean.net.nz>

--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ this will give you a virtual machine already configured and ready to start devel
 ## Installing manually
 
 If you prefer not to use the Docker, the following commands will get you started:
-commands can be converted to:
 
     $ carton install
+    $ npm install
+    $ export PATH="$(realpath ./node_modules/.bin):$PATH"
     $ ./bin/prove t
     $ carton exec plackup -p 5001 -r
+
+To run the tests in parallel, add `-j8` (or however many CPUs you have) to the
+`prove` command.
 
 ## Local configuration changes
 
@@ -28,7 +32,6 @@ new file called `metacpan_web_local.conf` that contains
     api_external_secure http://127.0.0.1:5000
 
 which will be loaded on top of the existing config file.
-
 
 ## COMPATIBILITY NOTES
 

--- a/cpanfile
+++ b/cpanfile
@@ -108,4 +108,5 @@ requires 'Test::Needs';
 requires 'Test::Perl::Critic';
 requires 'Test::Warnings';
 requires 'Test::XPath', '0.15';
+requires 'WWW::Form::UrlEncoded::XS';
 


### PR DESCRIPTION
I am not using Docker, and the instructions didn't cover setting up the JS side.  This PR adds installation of JS packages to the README.

I'm using my work computer at the moment (with permission), so I'm adding myself to the `.mailmap` also.