### PR TITLE
Add permalink to source views

### DIFF
--- a/root/source.html
+++ b/root/source.html
@@ -4,6 +4,7 @@
     <a data-keyboard-shortcut="g s" href="/source/<% base = [file.author, file.release].join("/"); base %>"><% [file.author, file.release].join(" / ") %></a>
     <% doc_view_url = [base,file.path].join("/") %>
     <% raw_url = [api_external_secure,'source',base,file.path].join("/") %>
+    <% permalink_url = ['','source',base,file.path].join("/") %>
   <% FOREACH part IN file.path.split("/"); base = base _ "/" _ part -%>
     / <% UNLESS loop.last %><a href="/source/<% base %>"><% part %></a><% ELSE %><% part %><% END %>
     <% END %>
@@ -31,6 +32,7 @@
   </li>
   <li>&nbsp;</li>
   <li><a href="<% raw_url %>"><i class="fa fa-file-text-o fa-fw black"></i>Raw code</a></li>
+  <li><a href="<% permalink_url %>"><i class="fa fa-link fa-fw black"></i>Permalink</a></li>
   <li>
     <a href="/raw/<% file.author %>/<% file.release %>/<% file.path %>?download=1"><i class="fa fa-download fa-fw black"></i>Download</a>
   </li>

--- a/t/controller/source.t
+++ b/t/controller/source.t
@@ -45,6 +45,37 @@ test_psgi app, sub {
             }
         );
 
+        # Check the "Raw code" and "Permalink" URLs
+        my @versioned_link_tests = (
+            {
+                xpath    => '//a[text()="Raw code"]/@href',
+                expected => qr{\bfastapi.metacpan.org/},
+                desc     => 'raw code points to fastapi'
+            },
+            {
+                xpath => '//a[text()="Raw code"]/@href',
+                #<<<       Maintainer vvvvv       vvvvvvvvvvvvvvvv Dist version number #>>>
+                expected => qr{source/[^/]+/Moose-\d+(?:\.\d+){0,}/},
+                desc => 'raw code includes specific version'
+            },
+
+            {
+                xpath    => '//a[text()="Permalink"]/@href',
+                expected => qr{\bsource/[^/]+/Moose-\d+(?:\.\d+){0,}/},
+                desc     => 'Permalink includes specific version'
+            },
+        );
+
+        my $versioned_link_tx = tx($res);
+        foreach my $versioned_link_test (@versioned_link_tests) {
+            like(
+                $versioned_link_tx->find_value(
+                    $versioned_link_test->{xpath}
+                ),
+                $versioned_link_test->{expected},
+                $versioned_link_test->{desc},
+            );
+        }
     }
 
     {


### PR DESCRIPTION
This provides one-click access from a latest-release source view (e.g., `/release/Moose/source/lib/Moose.pm`) to a versioned source view (e.g., `/source/ETHER/Moose-2.2012/lib/Moose.pm`).

Fixes #2260.

Ping @dboehmer