### PR TITLE
Side bar changes for better clarity and presentation

### DIFF
--- a/root/inc/release-tools.html
+++ b/root/inc/release-tools.html
@@ -56,6 +56,12 @@
         <%- PROCESS version_options %>
     </select>
 </li>
+<%- ELSE -%>
+<li>
+    <select class="form-control tool-bar-form" style="font-style: italic" disabled="disabled">
+        <option>No other versions</option>
+    </select>
+</li>
 <%- END %>
 <% IF release.metadata.x_help_wanted %>
 <li class="nav-header">Help Wanted</li>
@@ -64,13 +70,20 @@
     <li><% position %></li>
     <%- END %>
 </ul>
-<%- END %>
+<%- END;
+stable = [];
+FOREACH version IN versions;
+    IF version.maturity == 'released';
+        stable.push(version);
+        NEXT;
+    END;
+END %>
 <li class="nav-header">Permalinks</li>
 <li>
     <a href="/<% module ? "pod/release" : "release" %>/<% release.author %>/<% release.name %><% IF module; "/"; module.path; END %>">This version</a>
 </li>
 <%- IF canonical %>
-<li>
+<% IF stable.size >= 1 %><li>
     <a <% IF schema_org %>itemprop="url"<% END %> href="<% canonical %>">Latest version</a>
-</li>
+</li><%- END %>
 <%- END %>

--- a/root/inc/release-tools.html
+++ b/root/inc/release-tools.html
@@ -71,11 +71,11 @@
     <%- END %>
 </ul>
 <%- END;
-stable = [];
+has_latest = 0;
 FOREACH version IN versions;
-    IF version.maturity == 'released';
-        stable.push(version);
-        NEXT;
+    IF version.status == 'latest';
+        has_latest = 1;
+        LAST;
     END;
 END %>
 <li class="nav-header">Permalinks</li>
@@ -83,7 +83,7 @@ END %>
     <a href="/<% module ? "pod/release" : "release" %>/<% release.author %>/<% release.name %><% IF module; "/"; module.path; END %>">This version</a>
 </li>
 <%- IF canonical %>
-<% IF stable.size >= 1 %><li>
+<% IF has_latest %><li>
     <a <% IF schema_org %>itemprop="url"<% END %> href="<% canonical %>">Latest version</a>
 </li><%- END %>
 <%- END %>

--- a/root/pod.html
+++ b/root/pod.html
@@ -27,6 +27,11 @@
       Module version: <span itemprop="softwareVersion"><% documented_module.version | html %></span>
     </li>
     <% END %>
+    <% IF release.maturity == 'developer' %>
+    <li>
+      <b style="color: #ff4500">Development release</b>
+    </li>
+    <% END %>
     <% IF permalinks || release.status != 'latest';
         source_base = '/source/' _ module.author _ '/' _ module.release;
       ELSE


### PR DESCRIPTION
Display "Development release" to side bar (under "Module version")
with matching text color to the release text in bread brumbs area
for dev ("maturity": "developer") releases. This is to make it
more clear that a release (especially when the version only has
an underscore, and no "TRIAL" or other such clues) is in fact a
development release.

When there is only one version for a distribution, display a
disabled drop down with "No other versions" text in place of,
and matching the style of, the "Jump to version" drop down, in
the side bar.

Hide "Latest version" link in side bar when there are no stable
("maturity": "released") releases, which would result in a 404
if followed.