### PR TITLE
Moved color-related 'release' css-rules from breadcrumbs.less to global.less…

### DIFF
--- a/root/pod.html
+++ b/root/pod.html
@@ -11,7 +11,6 @@
 
 <div itemscope itemtype="http://schema.org/SoftwareApplication">
   <% INCLUDE inc/breadcrumbs.html schema_org = 1 %>
-
   <ul class="nav-list slidepanel">
     <li class="visible-xs">
       <% INCLUDE mobile/toolbar-search-form.html %>
@@ -29,7 +28,9 @@
     <% END %>
     <% IF release.maturity == 'developer' %>
     <li>
-      <b style="color: #ff4500">Development release</b>
+      <span class="dist-release maturity-developer">
+        <b class="release-name">Development release</b>
+      </span>
     </li>
     <% END %>
     <% IF permalinks || release.status != 'latest';

--- a/root/static/less/breadcrumbs.less
+++ b/root/static/less/breadcrumbs.less
@@ -35,22 +35,7 @@
             margin-right: 2px;
         }
 
-        &.status-cpan .release-name {
-            color: #999;
-        }
-        &.status-backpan .release-name {
-            color: #a00;
-        }
-        &.maturity-developer .release-name {
-            color: #ff4500;
-        }
-        &.unauthorized .release-name {
-            color: #f00;
-        }
-        &.unauthorized .warning {
-            color: #f00;
-            font-weight: bold;
-        }
+        &:extend(.dist-release all);
     }
 }
 

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -536,3 +536,22 @@ form#logout {
     text-align: center;
     margin: 1px 15% 20px;
 }
+
+.dist-release {
+    &.status-cpan .release-name {
+        color: #999;
+    }
+    &.status-backpan .release-name {
+        color: #a00;
+    }
+    &.maturity-developer .release-name {
+        color: #ff4500;
+    }
+    &.unauthorized .release-name {
+        color: #f00;
+    }
+    &.unauthorized .warning {
+        color: #f00;
+        font-weight: bold;
+    }
+}


### PR DESCRIPTION
… to make it easier to use in other places without unnecessary duplication.

Used this for the new "Development release" text in the side bar in pod.html so that it is always in sync with the breadcrumb color (for dev releases) and thus easier to maintain.