### PR TITLE
Fixed syntax-highlighting logic in JS code that was resulting in blank examples…

### DIFF
--- a/root/static/js/shCore.js
+++ b/root/static/js/shCore.js
@@ -2379,7 +2379,7 @@ function stripCData(original)
 
 	var copyLength = copy.length;
 
-	if (copy.indexOf(right) == copyLength - rightLength)
+	if ((copyLength >= rightLength) && (copy.indexOf(right) == copyLength - rightLength))
 	{
 		copy = copy.substring(0, copyLength - rightLength);
 		changed = true;


### PR DESCRIPTION
… in /pod/perlsecret (like `Bang bang`, `Eskimo greeting`, and `Inchworm`.)