### PR TITLE
Add "Developer release" sidebar label to Release, Browse, and Source pages …

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Source.pm
+++ b/lib/MetaCPAN/Web/Controller/Source.pm
@@ -37,12 +37,14 @@ sub index : Path : Args {
             author    => shift @module,
             release   => shift @module,
             directory => \@module,
+            maturity  => $module->{maturity},
         } );
     }
     elsif ( exists $source->{raw} ) {
         $module->{content} = $source->{raw};
         $c->stash( {
-            file => $module,
+            file     => $module,
+            maturity => $module->{maturity},
         } );
         $c->forward('content');
     }

--- a/root/browse.html
+++ b/root/browse.html
@@ -10,6 +10,7 @@
   <li class="visible-xs">
     <% INCLUDE mobile/toolbar-search-form.html %>
   </li>
+  <% INCLUDE inc/release-status.html maturity = maturity, banner_class = 'release-banner-source' %>
   <li class="nav-header">Tools</li>
   <li><a data-keyboard-shortcut="g d" href="/release/<% author %>/<% release %>"><i class="fa fa-fw fa-info-circle black"></i>Release Info</a></li>
   <li><a data-keyboard-shortcut="g a" href="/author/<% author %>"><i class="fa fa-user fa-fw black"></i>Author</a></li>

--- a/root/inc/release-status.html
+++ b/root/inc/release-status.html
@@ -1,0 +1,7 @@
+<% IF maturity == 'developer' %>
+<li>
+  <span class="dist-release maturity-developer">
+    <b class="<% banner_class %>">Development release</b>
+  </span>
+</li>
+<% END %>

--- a/root/pod.html
+++ b/root/pod.html
@@ -18,19 +18,13 @@
     <li class="nav-header">
       <time class="relatize" itemprop="dateModified" datetime="<% module.date.dt_date_common %>"><% module.date.dt_http %></time>
     </li>
+    <% INCLUDE inc/release-status.html maturity = release.maturity, banner_class = 'release-banner' %>
     <li>
       Distribution: <% module.distribution | html %></span>
     </li>
     <% IF documented_module.version %>
     <li>
       Module version: <span itemprop="softwareVersion"><% documented_module.version | html %></span>
-    </li>
-    <% END %>
-    <% IF release.maturity == 'developer' %>
-    <li>
-      <span class="dist-release maturity-developer">
-        <b class="release-name">Development release</b>
-      </span>
     </li>
     <% END %>
     <% IF permalinks || release.status != 'latest';

--- a/root/release.html
+++ b/root/release.html
@@ -10,6 +10,7 @@
     <% INCLUDE mobile/toolbar-search-form.html %>
     </li>
     <li class="nav-header"><span class="relatize"><% release.date.dt_http %></span></li>
+    <% INCLUDE inc/release-status.html maturity = release.maturity, banner_class = 'release-banner' %>
     <li><a href="/source/<% release.author %>/<% release.name %>"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="<% source_host %>/source/<% release.author %>/<% release.name %>/">raw</a>)</li>
     <% PROCESS inc/release-info.html %>
     <li class="nav-header">Activity</li>

--- a/root/source.html
+++ b/root/source.html
@@ -14,6 +14,7 @@
   <li class="visible-xs">
     <% INCLUDE mobile/toolbar-search-form.html %>
   </li>
+  <% INCLUDE inc/release-status.html maturity = maturity, banner_class = 'release-banner-source' %>
   <li class="nav-header">Tools</li>
   <li>
     <a data-keyboard-shortcut="g d" href="/release/<% file.author %>/<% file.release %>"><i class="fa fa-info-circle fa-fw black"></i>Release Info</a>

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -554,4 +554,21 @@ form#logout {
         color: #f00;
         font-weight: bold;
     }
+    
+    &.maturity-developer .release-banner {
+        color: #fff;
+        background-color: #D9534F;
+        padding: 0px 4px;
+        border-radius: 4px;
+        display: inline-block;
+        margin-top: 5px;
+        margin-bottom: 10px;
+    }
+    
+    &.maturity-developer .release-banner-source {
+        &:extend(.dist-release.maturity-developer .release-banner all);
+        margin-top: 10px;
+        margin-bottom: 5px;
+    }
 }
+


### PR DESCRIPTION
… to match the Pod page.

Also moved the "Developer release" sidebar label in the `pod.html` a little higher, just below the breadcrumb line so it matches uniformly on all of those pages.

This is related to PR #2283.