### PR TITLE
fix empty space on sidebar on desktop

### DIFF
--- a/root/static/less/nav-list.less
+++ b/root/static/less/nav-list.less
@@ -4,7 +4,6 @@
     margin-bottom: 0;
     line-height: 1.54em;
     float: left;
-    margin-top: 32px;
 
     a,
     .btn-link,

--- a/root/static/less/responsive.less
+++ b/root/static/less/responsive.less
@@ -149,6 +149,7 @@
 @import "bootstrap-slidepanel.less";
 
     .slidepanel {
+        margin-top: 32px;
         background-color: #fff;
         padding: 10px;
         border-right: 1px solid #e5e5e5;


### PR DESCRIPTION
This fixes the empty space at the top of the left sidebar on desktop by
only applying it on smaller viewport sizes. Also, move it to the correct
class, which fixes the margin not appearing on the about page.