### PR TITLE
Preload

### DIFF
--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -80,6 +80,9 @@
         <%- IF need_less %>
         <script src="/static/js/less.min.js" type="text/javascript"></script>
         <%- END %>
+        <link rel="preload" href="/static/fonts/fa-regular-400.woff2" as="font" type="font/woff2" crossorigin />
+        <link rel="preload" href="/static/fonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin />
+        <link rel="preload" href="/static/fonts/fa-solid-900.woff2" as="font" type="font/woff2" crossorigin />
         <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Partly address #2309 to preload / preconnect.

The `woff2` is hardcoded because browsers that support `preload` appear a subset of the ones supporting `woff2`, so it will never be a waste to preload the `woff2`. There may be a slightly better way, but I cannot see it!