### PR TITLE
Add a Content-Security-Policy allowing JS only from GA and us

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -121,6 +121,27 @@ builder {
         };
     };
     enable sub {
+
+        # put all security-related headers here
+        my $app = shift;
+        sub {
+            my ($env) = @_;
+            Plack::Util::response_cb(
+                $app->($env),
+                sub {
+                    push @{ $_[0][1] },
+                        'Content-Security-Policy' => join( '; ',
+                        "default-src * 'unsafe-inline'",
+                        "frame-ancestors 'self' *.metacpan.org",
+                        "script-src 'self' 'unsafe-inline' *.metacpan.org *.google-analytics.com *.google.com *.flattr.com",
+                        ),
+                        'X-Frame-Options' => "SAMEORIGIN",
+                        ;
+                },
+            );
+        };
+    };
+    enable sub {
         my $app = shift;
         sub {
             my ($env) = @_;


### PR DESCRIPTION
Partly address #2311 by adding a CSP.

It doesn't restrict images, and only restricts JavaScript so as to mitigate the risk of XSS via MetaCPAN, since we use SSO.