### PR TITLE
Remove Conference in the Cloud banner

### DIFF
--- a/root/home.html
+++ b/root/home.html
@@ -14,15 +14,6 @@
         <button type="submit" class="btn search-btn" name="lucky" value="1" title="Hint: Press shift and enter if you are feeling lucky">I'm Feeling Lucky</button>
     </div>
   </form>
-  <div>
-    <div class="row">
-       <div class="alert alert-info">
-         <p>
-            <strong>Conference in the Cloud</strong> &#45; A Perl &amp; Raku Conference <a href="https://perlconference.us/" title="Join the Conference">June 24-26 2020</a>
-          </p>
-       </div>
-    </div>
-  </div>
   <div class="news-highlight row">
     <div class="col-xs-12 col-sm-8 col-sm-push-2 col-md-6 col-md-push-3">
       <p>


### PR DESCRIPTION
I'm not sure we have any other event to advertise for now, let's remove the Conference in the Cloud banner.