### PR TITLE
Zap JSONP from GitHub API use

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -137,7 +137,9 @@ builder {
         # temporary 'unsafe-eval' because root/static/js/jquery.tablesorter.js
                         "script-src 'self' 'unsafe-eval' 'unsafe-inline' *.metacpan.org *.google-analytics.com *.google.com *.flattr.com",
                         ),
-                        'X-Frame-Options' => "SAMEORIGIN",
+                        'X-Frame-Options'        => "SAMEORIGIN",
+                        'X-XSS-Protection'       => "1; mode=block",
+                        'X-Content-Type-Options' => "nosniff",
                         ;
                 },
             );

--- a/app.psgi
+++ b/app.psgi
@@ -135,7 +135,7 @@ builder {
                         "frame-ancestors 'self' *.metacpan.org",
 
         # temporary 'unsafe-eval' because root/static/js/jquery.tablesorter.js
-                        "script-src 'self' 'unsafe-eval' 'unsafe-inline' *.metacpan.org *.google-analytics.com *.google.com *.flattr.com api.github.com",
+                        "script-src 'self' 'unsafe-eval' 'unsafe-inline' *.metacpan.org *.google-analytics.com *.google.com *.flattr.com",
                         ),
                         'X-Frame-Options' => "SAMEORIGIN",
                         ;

--- a/root/about/contributors.html
+++ b/root/about/contributors.html
@@ -47,31 +47,29 @@
         },
 
         fetch: function(url) {
-          url = url.replace(/callback=jsonp[^&]+/, 'callback=?');
-          $.getJSON(url, function(res) {
-            cv.requestFinished(res);
+          $.getJSON(url, function(res, statusMessage, jqXHR) {
+            cv.requestFinished(res, jqXHR);
           });
         },
 
-        paginate: function(meta) {
-          var self = this;
-          if (typeof meta.Link == 'undefined') {
+        paginate: function(jqXHR) {
+          var link = jqXHR.getResponseHeader('Link');
+          if (!link) {
             return;
           }
-          $.each(meta.Link, function(idx, row) {
-            var url = row[0];
-            var type = row[1];
-            if (type.rel !== 'next') {
-              return;
-            }
+          var self = this;
+          var links = link.split(/\s*,\s*/).map(
+            l => l.match(/<(.*?)>;\s*rel="(.*?)"/)
+          ).filter(lt => lt[2] === "next").map(lt => lt[1]);
+          $.each(links, function(idx, url) {
             requests++;
             self.fetch(url);
           });
         },
 
-        requestFinished: function(res) {
-          this.paginate(res.meta);
-          $.each(res.data, function(idx, row) {
+        requestFinished: function(data, jqXHR) {
+          this.paginate(jqXHR);
+          $.each(data, function(idx, row) {
             if (typeof result[row.login] == 'undefined') {
               result[row.login] = row;
             }
@@ -87,7 +85,7 @@
     }();
 
     $.each(repos, function(idx, repo) {
-      var url = [baseUrl, repo, path].join('/') +'?per_page=100&callback=?';
+      var url = [baseUrl, repo, path].join('/') +'?per_page=100';
       cv.fetch(url);
     });
 


### PR DESCRIPTION
This uses AJAX instead of JSONP for interacting with GitHub API. Lessons learned:
- jQuery uses JSONP if there is a `callback=?` CGI arg on its URL
- with JSONP, it calls `success` with an object with keys `meta` and `data`
- with proper AJAX, the `success` receives the `data` directly, but its third arg is a `jqXHR` which you can call `getResponseHeader` to achieve the same thing as the `meta` information

The CSP is amended back to not needing GitHub as a source of scripts.