### PR TITLE
Make tolerant of diverse Perl version-spec

### DIFF
--- a/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
@@ -46,11 +46,13 @@ sub get : Private {
         my $pod_file = $c->stash->{module}
             = $c->model('API::Module')->find(@args)->get;
 
-        my $release_info
-            = $c->model('ReleaseInfo')
-            ->get( $pod_file->{author}, $pod_file->{release} )
-            ->else( sub { Future->done( {} ) } );
-        $c->stash( $release_info->get );
+        my @ri_request_info = @$pod_file{qw(author release)};
+        if ( !grep !defined, @ri_request_info ) {
+            my $release_info
+                = $c->model('ReleaseInfo')->get(@ri_request_info)
+                ->else( sub { Future->done( {} ) } );
+            $c->stash( $release_info->get );
+        }
 
         $c->stash( {
             template => 'contributing_not_found.html'

--- a/lib/MetaCPAN/Web/View/HTML.pm
+++ b/lib/MetaCPAN/Web/View/HTML.pm
@@ -72,8 +72,13 @@ sub common_date_format {
     return sprintf( '%04d-%02d-%02d', $year, $month, $day );
 }
 
-Template::Alloy->define_vmethod( 'text',
-    version => sub { version->parse(shift)->normal } );
+Template::Alloy->define_vmethod(
+    'text',
+    version => sub {
+        my $v = shift;
+        eval { version->parse($v)->normal } || $v;
+    }
+);
 
 Template::Alloy->define_vmethod( 'text', dt => \&parse_datetime );
 


### PR DESCRIPTION
 https://metacpan.org/pod/YATT::Lite::XHF blows up as it has a runtime Perl requirement of: `>= v5.10.1, != 5.17, != v5.19.3`. This fixes that.