### PR TITLE
add new endpoint to check being logged in that doesn't error

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
+++ b/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
@@ -47,21 +47,12 @@ sub list_as_json : Local : Args(0) {
 
     $c->stash->{json}{faves} = $self->faves( $c, 1_000 )->get;
 
-    $c->add_surrogate_key( $self->_cache_key_for_user($c) );
     $c->cdn_max_age('30d');
 
     # Make sure the user re-requests from Fastly each time
     $c->browser_never_cache(1);
 
     $c->stash( { current_view => 'JSON' } );
-}
-
-sub _cache_key_for_user {
-    my ( $self, $c ) = @_;
-
-    my $user = $c->user;
-
-    return 'user/' . $user->id;
 }
 
 sub faves {

--- a/lib/MetaCPAN/Web/Controller/Search/AutoComplete.pm
+++ b/lib/MetaCPAN/Web/Controller/Search/AutoComplete.pm
@@ -1,7 +1,6 @@
 package MetaCPAN::Web::Controller::Search::AutoComplete;
 
 use Moose;
-use Cpanel::JSON::XS ();
 use List::Util qw(uniq);
 
 use namespace::autoclean;
@@ -28,9 +27,10 @@ sub index : Path : Args(0) {
         ),
     );
 
-    $c->res->content_type('application/json');
-    $c->res->body( Cpanel::JSON::XS::encode_json(
-        { suggestions => \@results } ) );
+    $c->stash( {
+        current_view => 'JSON',
+        json         => { suggestions => \@results },
+    } );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Controller/SysAdmin/DataCenters.pm
+++ b/lib/MetaCPAN/Web/Controller/SysAdmin/DataCenters.pm
@@ -27,7 +27,7 @@ sub list_datacenters : Path('list') : Args(0) GET {
     $c->cdn_max_age('1d');
     $c->browser_max_age('1d');
 
-    $c->stash( { success => $datacenters } );
+    $c->stash( { json => { success => $datacenters } } );
     $c->detach( $c->view('JSON') );
 }
 

--- a/lib/MetaCPAN/Web/View/JSON.pm
+++ b/lib/MetaCPAN/Web/View/JSON.pm
@@ -5,6 +5,10 @@ use Cpanel::JSON::XS ();
 
 extends 'Catalyst::View::JSON';
 
+__PACKAGE__->config( {
+    expose_stash => 'json',
+} );
+
 sub encode_json {
     my ( $self, undef, $data ) = @_;
     Cpanel::JSON::XS->new->utf8->encode($data);

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -580,9 +580,13 @@ function showUserData(fav_data) {
 function getFavDataFromServer() {
     $.ajax({
         type: 'GET',
-        url: '/account/favorite/list_as_json',
+        url: '/account/login_status',
         success: function(databack) {
-            showUserData(databack);
+            if (databack.logged_in) {
+                showUserData(databack);
+            } else {
+                $('.logged_out').css('display', 'inline');
+            }
         },
         error: function() {
             // Can't be logged in, should be getting 403

--- a/t/controller/search/autocomplete.t
+++ b/t/controller/search/autocomplete.t
@@ -22,8 +22,11 @@ test_psgi app, sub {
         ok( my $res = $cb->( GET "/search/autocomplete?q=$test" ),
             "GET /search/autocomplete?q=$test" );
         is( $res->code, 200, 'code 200' );
-        is( $res->header('content-type'),
-            'application/json', 'Content-type is application/json' );
+        is(
+            $res->header('content-type'),
+            'application/json; charset=utf-8',
+            'Content-type is application/json'
+        );
         ok( my $json = eval { decode_json( $res->content ) }, 'valid json' );
         is( ref $json, 'HASH', 'isa hashref' );
         my $module = $json->{suggestions}->[0];

--- a/t/lib/MetaCPAN/Web/Controller/Test.pm
+++ b/t/lib/MetaCPAN/Web/Controller/Test.pm
@@ -15,7 +15,7 @@ sub _json_body {
 sub json_echo : Local {
     my ( $self, $c ) = @_;
 
-    $c->stash->{echo} = $self->_json_body($c);
+    $c->stash->{json}{echo} = $self->_json_body($c);
 
     $c->detach( $c->view('JSON') );
 }


### PR DESCRIPTION
The account/favorite/list_as_json end point throws a forbidden error if
you aren't logged in.  While this works, it results in errors in the
browser console.  Add a new end point that returns a false value we can
check instead of an error.