### PR TITLE
Tabular display on /release page

### DIFF
--- a/root/release.html
+++ b/root/release.html
@@ -80,14 +80,17 @@
 <%- IF modules.size %>
 <div class="file-group release-modules">
   <h2 id="modules">Modules</h2>
-  <ul>
   <%- FOREACH module IN modules %>
-  <li>
-    <% INCLUDE "inc/link-to-file.html" file = module %><% IF module.abstract %> - <% module.abstract; END %>
+  <div class="release-row">
+    <div class="left">
+    <% INCLUDE "inc/link-to-file.html" file = module %>
+    </div>
+    <div class="right">
+    <% IF module.abstract; module.abstract; END %>
     <% IF module.indexed AND NOT module.authorized %><em class="unauthorized">UNAUTHORIZED</em><% END %>
-  </li>
+    </div>
+  </div>
   <%- END %>
-  </ul>
 </div>
 <%- END %>
 

--- a/root/release.html
+++ b/root/release.html
@@ -67,13 +67,16 @@
 <%- IF documentation.size %>
 <div class="file-group release-documentation">
   <h2 id="docs">Documentation</h2>
-  <ul>
   <%- FOREACH module IN documentation %>
-  <li>
-    <% INCLUDE "inc/link-to-file.html" file = module %><% IF module.abstract %> - <% module.abstract; END %>
-  </li>
+  <div class="release-row">
+    <div class="left">
+    <% INCLUDE "inc/link-to-file.html" file = module %>
+    </div>
+    <div class="right">
+    <% IF module.abstract; module.abstract; END %>
+    </div>
+  </div>
   <%- END %>
-  </ul>
 </div>
 <%- END %>
 

--- a/root/release.html
+++ b/root/release.html
@@ -97,14 +97,17 @@
 <% IF provides.size %>
 <div class="file-group release-provides">
   <h2 id="provides">Provides</h2>
-  <ul>
   <%- FOREACH module IN provides %>
-  <li>
-    <% INCLUDE "inc/link-to-source.html" file = module %> in <% module.path %>
+  <div class="release-row">
+    <div class="left">
+    <% INCLUDE "inc/link-to-source.html" file = module %>
+    </div>
+    <div class="right">
+    in <% module.path %>
     <% IF module.indexed AND NOT module.authorized %><em class="unauthorized">UNAUTHORIZED</em><% END %>
-  </li>
+    </div>
+  </div>
   <%- END %>
-  </ul>
 </div>
 <%- END %>
 

--- a/root/static/less/release.less
+++ b/root/static/less/release.less
@@ -1,4 +1,5 @@
 .content {
+    .release-documentation,
     .release-modules,
     .release-provides {
         display: table;

--- a/root/static/less/release.less
+++ b/root/static/less/release.less
@@ -1,6 +1,20 @@
 .content {
     .release-modules,
     .release-provides {
+        display: table;
+        div.release-row:nth-child(2n) {
+            background-color: #f5f5f5;
+        }
+        div.release-row {
+            display: table-row;
+            div.left, div.right {
+                display: table-cell;
+            }
+            div.left {
+                font-weight: bold;
+                padding-right: 1em;
+            }
+        }
         .unauthorized {
             color: #f00;
             font-weight: bold;


### PR DESCRIPTION
This resurrects (with a little updating, it was over 3000 commits old) @plu's issue-224 branch. The same tabular change is also now applied to the documentation and provides sections.