### PR TITLE
use correct path for non-latest pod pages

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -142,17 +142,16 @@ sub view : Private {
             && $documented_module->{authorized}
             && $documented_module->{indexed}
         ) ? "/pod/$documentation"
-        : $release ?
-            join(q{/}, q{}, qw( pod distribution ), $release->{distribution},
-                # Strip $author/$release from front of path.
-                @path[ 2 .. $#path ]
-            ) : undef;
+        : join(q{/}, q{}, qw( pod distribution ), $release->{distribution},
+            # Strip $author/$release from front of path.
+            @path[ 2 .. $#path ]
+        );
     #>>>
 
     # Store at fastly for a year - as we will purge!
     $c->cdn_max_age('1y');
-    $c->add_dist_key( $release ? $release->{distribution} : $path[1] );
-    $c->add_author_key( $path[0] );
+    $c->add_dist_key( $release->{distribution} );
+    $c->add_author_key( $release->{author} );
 
     $c->stash( {
         canonical         => $canonical,

--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -137,16 +137,12 @@ sub view : Private {
 
     my $release = $c->stash->{release};
 
-    #<<<
-    my $canonical = ( $documented_module
+    my $canonical
+        = (    $documented_module
             && $documented_module->{authorized}
             && $documented_module->{indexed}
         ) ? "/pod/$documentation"
-        : join(q{/}, q{}, qw( pod distribution ), $release->{distribution},
-            # Strip $author/$release from front of path.
-            @path[ 2 .. $#path ]
-        );
-    #>>>
+        : "/pod/distribution/$release->{distribution}/$data->{path}";
 
     # Store at fastly for a year - as we will purge!
     $c->cdn_max_age('1y');


### PR DESCRIPTION
The value in `@path` may not be a file path, so we should use the path
from the file we're querying instead.