### PR TITLE
change release row background to even rows rather than odd

### DIFF
--- a/root/static/less/release.less
+++ b/root/static/less/release.less
@@ -3,7 +3,7 @@
     .release-modules,
     .release-provides {
         display: table;
-        div.release-row:nth-child(2n) {
+        div.release-row:nth-of-type(even) {
             background-color: #f5f5f5;
         }
         div.release-row {


### PR DESCRIPTION
nth-child was applying to even elements, but there is a h2 element
before the rows. This would apply the background to the odd rows.

When there is only one row, applying to odd elements means there is a
bare element with a background, which is a bit visually weird.