### PR TITLE
If not latest release, link to that version of cpan-deps-graph

### DIFF
--- a/root/inc/dependencies.html
+++ b/root/inc/dependencies.html
@@ -30,7 +30,7 @@ FOREACH dep IN deps.sort %>
         <i class="fa fa-share fa-fw black"></i>Reverse dependencies</a>
     </li>
     <li>
-        <a href="https://cpandeps.grinnz.com/?dist=<% release.distribution | uri %>">
+        <a href="https://cpandeps.grinnz.com/?dist=<% release.distribution | uri %><% IF permalinks || release.status != 'latest' %>&dist_version=<% release.version | uri %><% END %>">
         <i class="fa fa-asterisk fa-fw black"></i>Dependency graph</a>
     </li>
 </ul>


### PR DESCRIPTION
Now that @Grinnz's excellent cpan-deps-graph can support showing deps for non-latest versions, this changes the link to that service to add the `dist_version` if viewing the non-latest version.