### PR TITLE
Default to installing test deps in Docker images

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -2,3 +2,5 @@
 ignored:
     # PDL3007 asks you to pin the FROM version explicitly to a release tag.
     - DL3007
+    # PDL3007 asks you to pin apt packages to a release tag.
+    - DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM metacpan/metacpan-base:latest
 
-ARG CPM_ARGS=--without-test
+ARG CPM_ARGS=--with-test
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
This makes it easier to test things in a Docker container as we won't always need to build one first. It also makes for less differences between the deployed environment and the test environment. If we ever need to slim down the containers, we can worry about that later.