### PR TITLE
Add attributes to search input to disable autocorrect, autocapitalize, and spellcheck

### DIFF
--- a/root/home.html
+++ b/root/home.html
@@ -7,7 +7,7 @@
   <form action="/search">
     <input type="hidden" name="size" id="search-size" value="20">
     <div class="form-group">
-        <input type="text" name="q" size="41" autofocus="autofocus" id="search-input" class="form-control home-search-input">
+        <input type="text" name="q" size="41" autofocus="autofocus" autocorrect="off" autocapitalize="off" spellcheck="false" id="search-input" class="form-control home-search-input">
     </div>
     <div class="form-group">
         <button type="submit" class="btn search-btn">Search the CPAN</button>


### PR DESCRIPTION
Using metacpan on mobile, my phone likes to drive me nuts by auto-correcting my
search terms, uppercasing stuff and finally putting red squiggles under the
search term. I usually search for package names and unfortunately their names
often aren't in my phone's dictionary. Those three attributes should keep all
mobile browsers from meddling with search terms.