### PR TITLE
In HTML, allow <th> the same attributes as <td>

### DIFF
--- a/lib/MetaCPAN/Web/RenderUtil.pm
+++ b/lib/MetaCPAN/Web/RenderUtil.pm
@@ -47,7 +47,7 @@ sub filter_html {
             sup    => [],
             table  => [ qw( border cellspacing cellpadding align ), ],
             tbody  => [],
-            th     => [],
+            th     => [qw( colspan rowspan )],
             td     => [qw( colspan rowspan )],
             tr     => [],
             u      => [],


### PR DESCRIPTION
@davorg added the rowspan/colspan attributes for td here: da7060439dd145390cb92d1bc7ce62d8fd6e41a5. However, he omitted to add them for th. See this comment: https://github.com/metacpan/metacpan-web/commit/da7060439dd145390cb92d1bc7ce62d8fd6e41a5#commitcomment-45804935