### PR TITLE
home.html - render alerts as rows

### DIFF
--- a/root/home.html
+++ b/root/home.html
@@ -14,13 +14,17 @@
         <button type="submit" class="btn search-btn" name="lucky" value="1" title="Hint: Press shift and enter if you are feeling lucky">I'm Feeling Lucky</button>
     </div>
   </form>
-  <!-- rt.cpan sunset notice -->
-  <div class="alert alert-danger">
-    <strong>N.B. <a href="https://log.perl.org/2020/12/rtcpanorg-sunset.html" title="rt.cpan.org will sunset on March 1st, 2021">rt.cpan.org will sunset on March 1st, 2021</a>.</strong>
+  <div class="row">
+    <!-- rt.cpan sunset notice -->
+    <div class="alert alert-danger">
+      <strong>N.B. <a href="https://log.perl.org/2020/12/rtcpanorg-sunset.html" title="rt.cpan.org will sunset on March 1st, 2021">rt.cpan.org will sunset on March 1st, 2021</a>.</strong>
+    </div>
   </div>
-  <!-- TPF survey remains until Jan 31, 2021 -->
-  <div class="alert alert-info">
-    <strong>Are you new to Perl? Please take The Perl Foundation's survey: <a href="https://news.perlfoundation.org/post/newperluserssurvey" title="TPF survey: what support do you need?">what support do you need?</a></strong>
+  <div class="row">
+    <!-- TPF survey remains until Jan 31, 2021 -->
+    <div class="alert alert-info">
+      <strong>Are you new to Perl? Please take The Perl Foundation's survey: <a href="https://news.perlfoundation.org/post/newperluserssurvey" title="TPF survey: what support do you need?">what support do you need?</a></strong>
+    </div>
   </div>
   <div class="news-highlight row">
     <div class="col-xs-12 col-sm-8 col-sm-push-2 col-md-6 col-md-push-3">


### PR DESCRIPTION
[As requested](https://github.com/metacpan/metacpan-web/pull/2422), a fix for the commit yesterday. Each alert is now an individual row, and renders as requested on mobile and large screens. Screenshots attached.

![Screenshot_2021-01-21_20-35-51_phone](https://user-images.githubusercontent.com/1374568/105409904-0ad3cf80-5c29-11eb-8b9b-35f4b91ae948.png)
![Screenshot_2021-01-21_20-36-32_desktop](https://user-images.githubusercontent.com/1374568/105409910-0b6c6600-5c29-11eb-8000-459969aeb05a.png)
