### PR TITLE
Show notifications for Deprecated modules/distributions

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -55,11 +55,13 @@ sub release : Local : Args {
         $c->detach();
     }
 
+    my $pod_file
+        = $c->model('API::Module')->get( $author, $release, @path )->get;
     my $release_data
-        = $c->model('ReleaseInfo')->get( $author, $release )->else_done( {} );
-    my $pod_file = $c->model('API::Module')->get( $author, $release, @path );
+        = $c->model('ReleaseInfo')->get( $author, $release, $pod_file )
+        ->else_done( {} );
     $c->stash( {
-        pod_file => $pod_file->get,
+        pod_file => $pod_file,
         %{ $release_data->get },
         permalinks => 1,
     } );

--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -30,8 +30,8 @@ sub find : Path : Args(1) {
 
     my $release_info
         = $c->model('ReleaseInfo')
-        ->get( $pod_file->{author}, $pod_file->{release},
-        $pod_file->{module}[0]{name} )->else( sub { Future->done( {} ) } );
+        ->get( $pod_file->{author}, $pod_file->{release}, $pod_file )
+        ->else( sub { Future->done( {} ) } );
     $c->stash( $release_info->get );
 
     # TODO: Disambiguate if there's more than one match. #176

--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -281,7 +281,21 @@ sub normalize_issue_url {
 sub _get_notifications {
     my ( $self, $release ) = @_;
     return $self->_permission->get_notification_info(
-        $release->{main_module} );
+        $release->{main_module} )->then( sub {
+        my $data = shift;
+
+        # Unless we already have Notifications from Permissions, see if there
+        # are others needing to be added.
+        unless ( $data->{notification} ) {
+            if ( $release->{deprecated} ) {
+                $data->{notification} = { type => 'DEPRECATED' };
+            }
+        }
+
+        # Return the Notifications (either Permission based, or for Deprecated
+        # status).
+        return Future->wrap($data);
+        } );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -58,7 +58,7 @@ sub find {
 }
 
 sub get {
-    my ( $self, $author, $release_name ) = @_;
+    my ( $self, $author, $release_name, $module_info ) = @_;
     my $release      = $self->_release->get( $author, $release_name );
     my %release_data = $self->_release_data( $author, $release_name );
     $release->then( sub {
@@ -70,7 +70,8 @@ sub get {
         $self->_wrap(
             release => $data,
             %release_data,
-            notification => $self->_get_notifications( $data->{release} ),
+            notification =>
+                $self->_get_notifications( $data->{release}, $module_info ),
             $self->_dist_data( $data->{release}{distribution} ),
         );
     } )->then( $self->normalize );
@@ -279,7 +280,7 @@ sub normalize_issue_url {
 }
 
 sub _get_notifications {
-    my ( $self, $release ) = @_;
+    my ( $self, $release, $module ) = @_;
     return $self->_permission->get_notification_info(
         $release->{main_module} )->then( sub {
         my $data = shift;
@@ -289,6 +290,9 @@ sub _get_notifications {
         unless ( $data->{notification} ) {
             if ( $release->{deprecated} ) {
                 $data->{notification} = { type => 'DEPRECATED' };
+            }
+            elsif ( $module && $module->{deprecated} ) {
+                $data->{notification} = { type => 'MODULE_DEPRECATED' };
             }
         }
 

--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -48,9 +48,7 @@ sub find {
         $self->_wrap(
             release => $data,
             %dist_data,
-            notification => $self->_permission->get_notification_info(
-                $data->{release}{main_module}
-            ),
+            notification => $self->_get_notifications( $data->{release} ),
             $self->_release_data(
                 $data->{release}{author},
                 $data->{release}{name}
@@ -72,9 +70,7 @@ sub get {
         $self->_wrap(
             release => $data,
             %release_data,
-            notification => $self->_permission->get_notification_info(
-                $data->{release}{main_module}
-            ),
+            notification => $self->_get_notifications( $data->{release} ),
             $self->_dist_data( $data->{release}{distribution} ),
         );
     } )->then( $self->normalize );
@@ -280,6 +276,12 @@ sub normalize_issue_url {
     }{https://rt.cpan.org/Dist/Display.html?Name=}x;
 
     return $url;
+}
+
+sub _get_notifications {
+    my ( $self, $release ) = @_;
+    return $self->_permission->get_notification_info(
+        $release->{main_module} );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/root/inc/notification.html
+++ b/root/inc/notification.html
@@ -24,6 +24,10 @@
             text   = "The maintainer of this distribution is looking for someone to take over!",
             body   = "Hello,\r\n\r\nI'm interested in taking over the %s module. If you can grant me the privilege I will release the next version.\r\n\r\n"
         },
+        DEPRECATED = {
+            title  = "Deprecated.",
+            text   = "The maintainer of this distribution has indicated that it is deprecated and no longer suitable for use.",
+        },
     }.$notification_type;
     NOTIFICATION.mailto = MAILTO.sprintf(
         notification.emails.join(','),

--- a/root/inc/notification.html
+++ b/root/inc/notification.html
@@ -40,10 +40,12 @@
         <h2><% NOTIFICATION.title %></h2>
         <span>
             <% NOTIFICATION.text %>
-            If you're interested then please contact
-            <% NOTIFICATION.contactwhom %> via
-            <a href="<% NOTIFICATION.mailto %>">email</a>.
-            <a href="/about/faq#howtoadoptadistribution"><i class="fa fa-info-circle"></i></a>
+            <%- IF NOTIFICATION.contactwhom %>
+                If you're interested then please contact
+                <% NOTIFICATION.contactwhom %> via
+                <a href="<% NOTIFICATION.mailto %>">email</a>.
+                <a href="/about/faq#howtoadoptadistribution"><i class="fa fa-info-circle"></i></a>
+            <%- END %>
         </span>
     </div>
 </div>

--- a/root/inc/notification.html
+++ b/root/inc/notification.html
@@ -34,7 +34,7 @@
 <input id="<% notification_type %>" type="checkbox" class="notification-toggle-checkbox" />
 <div id="notification" class="well collapsed notify-<% notification_type %>">
     <label class="remove-notification" for="<% notification_type %>" >
-        <i class="fa fa-fw fa-close black""></i>
+        <i class="fa fa-fw fa-close black"></i>
     </label>
     <div id="notification-container">
         <h2><% NOTIFICATION.title %></h2>

--- a/root/inc/notification.html
+++ b/root/inc/notification.html
@@ -28,6 +28,10 @@
             title  = "Deprecated.",
             text   = "The maintainer of this distribution has indicated that it is deprecated and no longer suitable for use.",
         },
+        MODULE_DEPRECATED = {
+            title  = "Deprecated.",
+            text   = "The maintainer of this module has indicated that the module is deprecated and no longer suitable for use.",
+        },
     }.$notification_type;
     NOTIFICATION.mailto = MAILTO.sprintf(
         notification.emails.join(','),

--- a/root/static/less/notification.less
+++ b/root/static/less/notification.less
@@ -44,6 +44,6 @@ label.remove-notification {
     background: #d7e1f5;
 }
 
-.notify-DEPRECATED {
+.notify-DEPRECATED, .notify-MODULE_DEPRECATED {
     background: #f8d7da;
 }

--- a/root/static/less/notification.less
+++ b/root/static/less/notification.less
@@ -43,3 +43,7 @@ label.remove-notification {
 .notify-HANDOFF {
     background: #d7e1f5;
 }
+
+.notify-DEPRECATED {
+    background: #f8d7da;
+}


### PR DESCRIPTION
Using similar visual indicators to what we have in place already for ADOPTME, NEEDHELP, and HANDOFF, provide an indication that a Module has been Deprecated, or possibly the entire Release/Distribution.

Relates to metacpan/metacpan-web#1435