### PR TITLE
Disable "deprecated" notifications

### DIFF
--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -287,7 +287,7 @@ sub _get_notifications {
 
         # Unless we already have Notifications from Permissions, see if there
         # are others needing to be added.
-        unless ( $data->{notification} ) {
+        unless ( 1 || $data->{notification} ) {
             if ( $release->{deprecated} ) {
                 $data->{notification} = { type => 'DEPRECATED' };
             }


### PR DESCRIPTION
While this worked great in Dev on a partial index, something fishy is going on and the notification is showing incorrectly in Production.

Until we can diagnose the cause and correct, disable the display of Deprecated notifications.

Related to #2438 