### PR TITLE
Re-enable "deprecated" notifications

### DIFF
--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -287,7 +287,7 @@ sub _get_notifications {
 
         # Unless we already have Notifications from Permissions, see if there
         # are others needing to be added.
-        unless ( 1 || $data->{notification} ) {
+        unless ( $data->{notification} ) {
             if ( $release->{deprecated} ) {
                 $data->{notification} = { type => 'DEPRECATED' };
             }


### PR DESCRIPTION
This reverts commit 19df9e5be15a14ef4f8fa44d15eca7c9d8046ae2.

Re-enables "Deprecated" notifications.

As per discussion in metacpan/metacpan-web#2438, the data in ElasticSearch has been updated and now returns proper boolean values (instead of potential string `"true"` or `"false"`).

With the data corrected, we should now be able to re-enable these notifications for deprecated Modules/Distributions.