### PR TITLE
Improve release table layout

### DIFF
--- a/root/browse.html
+++ b/root/browse.html
@@ -33,12 +33,12 @@
 <tbody>
 <% i = 0; FOREACH file IN files %>
 <tr>
-  <td class="name" sort="<% file.directory == 1 ? "!" _ file.name : file.name %>"><strong><a href="/source/<% [author, release, file.path | uri ].join("/") %>" class="<%
+  <td class="name" sort="<% file.directory == 1 ? "!" _ file.name : file.name %>"><a href="/source/<% [author, release, file.path | uri ].join("/") %>" class="<%
     file.directory == 1 ? 'silk-folder'
   : file.mime.match("perl") ? 'silk-page-white-code'
   : file.mime.match("x-c") ? 'silk-page-white-c'
   : 'silk-page-white'
-  -%>" title="<% file.path %>"><% file.name %></a></strong></td>
+  -%>" title="<% file.path %>"><% file.name %></a></td>
   <td class="documentation"><strong><a href="/pod/release/<% [author, release, file.path].join("/") %>" title="<% file.path %>" class="ellipsis"><% file.slop ? file.documentation ? file.documentation : file.name : "" %></a></strong></td>
   <td class="size" sort="<% file.directory == 0 ? file.${"stat.size"} : 0 %>"><% file.directory == 0 ? file.${"stat.size"} | format_bytes : "" %></td>
   <td class="mtime relatize" nowrap="nowrap" sort="<% date = datetime(file.${"stat.mtime"}).to_http; date %>"><% date %></td>

--- a/root/favorite/leaderboard.html
+++ b/root/favorite/leaderboard.html
@@ -14,7 +14,7 @@
   <% FOREACH leader IN leaders %>
     <tr>
       <td class="number<% IF loop.index() < 5; " strong"; END %>"><% loop.index() + 1 %></td>
-      <td class="name"><strong><a href="/release/<% leader.key %>"><% leader.key %></a></strong></td>
+      <td class="name"><a href="/release/<% leader.key %>"><% leader.key %></a></td>
       <td class="number"><% leader.doc_count %> ++</td>
     </tr>
   <% END %>

--- a/root/inc/release-table.html
+++ b/root/inc/release-table.html
@@ -13,7 +13,7 @@
   <%- FOREACH release IN releases %>
     <tr>
       <td class="river-gauge" sort="<% release.river.total || 0 %>"><% INCLUDE inc/river-gauge.html, distribution = release.distribution, river = release.river %></td>
-      <td class="name"><strong><a href="/release/<% IF release.status == 'latest'; release.distribution; ELSE; release.author; '/'; release.name; END %>" class="ellipsis" title="<% release.author; '/'; release.name %>"><% release.name %></a></strong></td>
+      <td class="name"><a href="/release/<% IF release.status == 'latest'; release.distribution; ELSE; release.author; '/'; release.name; END %>" class="ellipsis" title="<% release.author; '/'; release.name %>"><% release.name %></a></td>
       <td class="abstract"><% IF release.abstract; release.abstract; END %></td>
       <td class="date relatize" sort="<% date = datetime(release.date).to_http; date %>"><% date %></td>
     </tr>

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -269,11 +269,22 @@ $(document).ready(function() {
     for (var i = 0; i < items.length; i++) {
         var element = items[i];
         var text = element.textContent;
+
+        // try to find a reasonable place to cut to allow mid-abbreviation.
+        // we want to cut "near" the middle, but prefer on a boundary.
         var cut = Math.floor(text.length / 5 * 3);
+        var start_text = text.substr(0, cut);
+        var end_text = text.substr(cut);
+        var res = start_text.match(/^(.*[- :])(.*?)$/);
+        if (res && res[1].length > text.length / 4) {
+            start_text = res[1];
+            end_text = res[2] + end_text;
+        }
+
         var start = document.createElement('span');
-        start.appendChild(document.createTextNode(text.substr(0, cut)));
+        start.appendChild(document.createTextNode(start_text));
         var end = document.createElement('span');
-        end.appendChild(document.createTextNode(text.substr(cut)));
+        end.appendChild(document.createTextNode(end_text));
         $(element).empty();
         element.appendChild(end);
         start.style.maxWidth = 'calc(100% - ' + end.clientWidth + 'px)';

--- a/root/static/less/table.less
+++ b/root/static/less/table.less
@@ -33,6 +33,7 @@
 
   td.name, th.name {
     width: 266px;
+    font-weight: bold;
   }
 
   th.position {

--- a/root/static/less/table.less
+++ b/root/static/less/table.less
@@ -27,7 +27,7 @@
   }
 
   th.date, th.number {
-    width: 90px;
+    width: 8em;
     direction: rtl; // overflow left, not right
   }
 

--- a/root/static/less/table.less
+++ b/root/static/less/table.less
@@ -32,7 +32,7 @@
   }
 
   td.name, th.name {
-    width: 266px;
+    width: 21em;
     font-weight: bold;
   }
 

--- a/root/static/less/table.less
+++ b/root/static/less/table.less
@@ -42,6 +42,5 @@
 
   th.river-gauge, td.river-gauge {
     width: 36px;
-    padding-bottom: 0px;
   }
 }


### PR DESCRIPTION
This attempts to improve the layout of the release table by fixing the width of the date column, giving more space to release names on wide screens, and trying to cut release names in half for abbreviation on word boundaries where possible.