### PR TITLE
Clean up some donation options on author pages

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -135,7 +135,7 @@ builder {
                         "frame-ancestors 'self' *.metacpan.org",
 
         # temporary 'unsafe-eval' because root/static/js/jquery.tablesorter.js
-                        "script-src 'self' 'unsafe-eval' 'unsafe-inline' *.metacpan.org *.google-analytics.com *.google.com www.gstatic.com *.flattr.com",
+                        "script-src 'self' 'unsafe-eval' 'unsafe-inline' *.metacpan.org *.google-analytics.com *.google.com www.gstatic.com",
 
                         ),
                         'X-Frame-Options'        => "SAMEORIGIN",

--- a/root/author.html
+++ b/root/author.html
@@ -72,27 +72,6 @@
     <li class="author-donate">
         <a rel="me noopener nofollow" href="<% donate.id %>" target="_blank">Wishlist</a>
     </li>
-    <% ELSIF donate.name == 'flattr' && donate.id %>
-    <li class="author-donate">
-        <script type="text/javascript">
-            (function() {
-              var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
-
-              s.type = 'text/javascript';
-              s.async = true;
-              s.src = 'https://api.flattr.com/js/0.6/load.js?mode=auto';
-
-              t.parentNode.insertBefore(s, t);
-            })();
-        </script>
-        <a class="FlattrButton" style="display:none;"
-            title="<% author.name %> (<% author.pauseid %>) on MetaCPAN"
-            rev="flattr;uid:<% donate.id %>;button:compact;category:software;tags:perl,cpan,metacpan;"
-            href="/author/<% author.pauseid %>"
-            language="en_GB" >
-        <% author.name %> is <% author.pauseid %> on CPAN, the Comprehensive Perl Archive Network.
-        </a>
-    </li>
     <% END; END; END %>
     <li class="nav-header">Activity</li>
     <li><% INCLUDE inc/activity.html query = 'author=' _ author.pauseid %></li>

--- a/root/author.html
+++ b/root/author.html
@@ -64,7 +64,6 @@
             <input type="hidden" name="currency_code" value="USD">
             <input type="hidden" name="bn" value="PP-DonationsBF:btn_donate_SM.gif:NonHostedGuest">
             <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!" style="width: auto">
-            <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
         </form>
     </center>
     </li>


### PR DESCRIPTION
Remove the PayPal tracking pixel.

Remove the Flattr button. The script for it no longer exists, and they seem to be using a different model now.