### PR TITLE
update monospace fonts

### DIFF
--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -21,7 +21,7 @@
 @code-color:                  inherit;
 @code-bg:                     #f5f5f5;
 
-@font-family-monospace: Menlo, Monaco, 'DejaVu Sans Mono', Consolas, 'Bitstream Vera Sans Mono', Courier, 'Courier New', monospace;
+@font-family-monospace: Menlo, Monaco, Consolas, 'Liberation Mono', 'Bitstream Vera Sans Mono', Courier, 'Courier New', monospace;
 @font-size-base: 15px;
 
 @fa-font-path: "/static/fonts";


### PR DESCRIPTION
DejaVu Sans Mono is not the best looking font, and also has some issues:
https://gitlab.gnome.org/GNOME/pango/-/issues/392

Replace it with Liberation Mono, which is also included on many debian
systems. Also re-order the fonts to prefer Consolas on most Windows
systems.