### PR TITLE
be explicit about perl critic policies

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,35 +1,56 @@
 # please alpha sort config items as you add them
-
-severity = 5
+only = 1
 verbose = 11
-theme = core
+program-extensions = .t
 
-[-ControlStructures::ProhibitPostfixControls]
-[-Documentation::RequirePodLinksIncludeText]
-[-Documentation::RequirePodSections]
-[-Modules::RequireVersionVar]
-[-RegularExpressions::RequireDotMatchAnything]
-[-RegularExpressions::RequireExtendedFormatting]
-[-RegularExpressions::RequireLineBoundaryMatching]
-[-Subroutines::ProhibitExplicitReturnUndef]
-[-Variables::ProhibitPunctuationVars]
+[BuiltinFunctions::ProhibitSleepViaSelect]
+
+[BuiltinFunctions::ProhibitStringyEval]
+
+[BuiltinFunctions::RequireGlobFunction]
+
+[ClassHierarchies::ProhibitOneArgBless]
 
 [CodeLayout::RequireTrailingCommas]
-severity = 4
+
+[ControlStructures::ProhibitMutatingListFunctions]
+
+[InputOutput::ProhibitBarewordFileHandles]
+
+[InputOutput::ProhibitInteractiveTest]
+
+[InputOutput::ProhibitTwoArgOpen]
+
+[InputOutput::RequireEncodingWithUTF8Layer]
+
+[Modules::ProhibitEvilModules]
+
+[Modules::RequireBarewordIncludes]
+
+[Modules::RequireFilenameMatchesPackage]
+
+[Subroutines::ProhibitNestedSubs]
+
+[Subroutines::ProhibitReturnSort]
+
+[Subroutines::ProhibitSubroutinePrototypes]
+
+[TestingAndDebugging::RequireUseStrict]
+equivalent_modules = MetaCPAN::Moose
+
+[TestingAndDebugging::RequireUseWarnings]
+equivalent_modules = MetaCPAN::Moose
 
 [ValuesAndExpressions::ProhibitEmptyQuotes]
-severity = 4
 
 [ValuesAndExpressions::ProhibitInterpolationOfLiterals]
 allow_if_string_contains_single_quote = 1
 allow = qq{} qq[]
-severity = 4
+
+[ValuesAndExpressions::ProhibitLeadingZeros]
 
 [ValuesAndExpressions::ProhibitNoisyQuotes]
-severity = 4
 
-[TestingAndDebugging::RequireUseStrict]
-equivalent_modules = MetaCPAN::Moose Moose
+[Variables::ProhibitConditionalDeclarations]
 
-[TestingAndDebugging::RequireUseWarnings]
-equivalent_modules = MetaCPAN::Moose Moose
+[Variables::RequireLexicalLoopIterators]

--- a/tidyall.ini
+++ b/tidyall.ini
@@ -1,7 +1,6 @@
 [PerlTidy]
 select = {bin,lib,t}/**/*.{pl,pm,t,psgi}
 select = app.psgi
-ignore = t/encoding.t
 argv = --profile=$ROOT/.perltidyrc
 
 [SortLines]
@@ -15,14 +14,6 @@ ok_exit_codes = 0
 
 [Test::Vars]
 select = {lib,t}/**/*.pm
-ignore = lib/MetaCPAN/Web/View/HTML.pm
 
 [PerlCritic]
 select = {bin,lib,t}/**/*.{pl,pm,t,psgi}
-ignore = lib/MetaCPAN/Web/Controller/Author.pm
-ignore = lib/MetaCPAN/Web/Controller/Pod.pm
-ignore = lib/MetaCPAN/Web/Controller/Release.pm
-ignore = lib/MetaCPAN/Web/Model/API.pm
-ignore = lib/MetaCPAN/Web/Test.pm
-ignore = t/encoding.t
-ignore = t/metacpan/sitemap.t


### PR DESCRIPTION
Rather than relying on the theme and severity which are unpredictable,
explicitly list the perl critic policies we want to use.

Also remove all the excluded files from the critic/tidy checks, since
they are all passing now.