### PR TITLE
consistently show help wanted once on sidebar

### DIFF
--- a/root/inc/release-info.html
+++ b/root/inc/release-info.html
@@ -48,6 +48,16 @@
   <i class="fa fa-fw fa-greater-than-equal black"></i>Perl: <% release.metadata.prereqs.runtime.requires.perl | version %>
 </li>
 <% END %>
+<% IF release.metadata.x_help_wanted %>
+<li class="nav-header">Help Wanted</li>
+<li>
+  <ul>
+    <%- FOREACH position IN release.metadata.x_help_wanted %>
+    <li><% position %></li>
+    <%- END %>
+  </ul>
+</li>
+<%- END %>
 <% IF irc.web %>
 <li class="irc-chat">
     <div><a rel="noopener nofollow" target="_blank" href="<% irc.web %>">Questions? Chat with us!</a></div>

--- a/root/inc/release-tools.html
+++ b/root/inc/release-tools.html
@@ -58,14 +58,7 @@
     </select>
 </li>
 <%- END %>
-<% IF release.metadata.x_help_wanted %>
-<li class="nav-header">Help Wanted</li>
-<ul>
-    <%- FOREACH position IN release.metadata.x_help_wanted %>
-    <li><% position %></li>
-    <%- END %>
-</ul>
-<%- END;
+<%-
 has_latest = 0;
 FOREACH version IN versions;
     IF version.status == 'latest';

--- a/root/release.html
+++ b/root/release.html
@@ -15,13 +15,6 @@
     <% PROCESS inc/release-info.html %>
     <li class="nav-header">Activity</li>
     <li><% INCLUDE inc/activity.html query = 'distribution=' _ release.distribution %></li>
-    <% IF release.metadata.x_help_wanted %>
-    <li>Help Wanted<ul>
-    <% FOREACH position IN release.metadata.x_help_wanted %>
-      <li><% position %></li>
-    <% END %>
-    </ul></li>
-    <% END %>
     <%- INCLUDE inc/release-tools.html %>
 </ul>
 


### PR DESCRIPTION
If x_help_wanted was specifed, it would appear once on the sidebar on
pod pages, but twice on release pages.

Move the help wanted message to be consistently shown above the IRC
banner or activity graph, and not shown twice.