### PR TITLE
fix file listing data in model

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/File.pm
+++ b/lib/MetaCPAN/Web/Model/API/File.pm
@@ -17,7 +17,17 @@ sub dir {
     my $path = join '/', @path;
     my $data = $self->request("/file/dir/$path")->transform(
         done => sub {
-            $_[0]->{dir};
+            my $dir = $_[0]->{dir};
+            for my $entry (@$dir) {
+                my $stat = $entry->{stat} ||= {};
+                for my $stat_entry ( map /^stat\.(.*)/ ? $1 : (),
+                    keys %$entry )
+                {
+                    $stat->{$stat_entry}
+                        = delete $entry->{"stat.$stat_entry"};
+                }
+            }
+            return $dir;
         }
     );
 }

--- a/root/browse.html
+++ b/root/browse.html
@@ -40,8 +40,8 @@
   : 'silk-page-white'
   -%>" title="<% file.path %>"><% file.name %></a></td>
   <td class="documentation"><strong><a href="/pod/release/<% [author, release, file.path].join("/") %>" title="<% file.path %>" class="ellipsis"><% file.slop ? file.documentation ? file.documentation : file.name : "" %></a></strong></td>
-  <td class="size" sort="<% file.directory == 0 ? file.${"stat.size"} : 0 %>"><% file.directory == 0 ? file.${"stat.size"} | format_bytes : "" %></td>
-  <td class="mtime relatize" nowrap="nowrap" sort="<% date = datetime(file.${"stat.mtime"}).to_http; date %>"><% date %></td>
+  <td class="size" sort="<% file.directory == 0 ? file.stat.size : 0 %>"><% file.directory == 0 ? file.stat.size | format_bytes : "" %></td>
+  <td class="mtime relatize" nowrap="nowrap" sort="<% date = datetime(file.stat.mtime).to_http; date %>"><% date %></td>
 </tr>
 <% END %>
 </tbody>


### PR DESCRIPTION
Having keys with periods in them is hard to work with, and 'stat' should
be a hash anyway, to be consistent with everywhere else. Fix the format
of the file listing in the model rather than forcing the template to
deal with it.

This should probably be different in the API, but for now adapt it here.