### PR TITLE
use xpath for all tests

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -36,7 +36,6 @@ requires 'Gravatar::URL';
 requires 'Hash::AsObject';
 requires 'HTML::Escape';
 requires 'HTML::Restrict', '2.2.2';
-requires 'HTML::Selector::XPath';
 requires 'HTML::Tree';
 requires 'HTTP::Message::PSGI';
 requires 'HTTP::Lite', '2.44'; # Optional dep of XML::TreePP, which is a dep of XML::FeedPP

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1992,16 +1992,6 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       version 0
-  HTML-Selector-XPath-0.25
-    pathname: C/CO/CORION/HTML-Selector-XPath-0.25.tar.gz
-    provides:
-      HTML::Selector::XPath 0.25
-    requirements:
-      Carp 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      perl 5.008001
-      strict 0
   HTML-Tagset-3.20
     pathname: P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz
     provides:

--- a/t/controller/changes.t
+++ b/t/controller/changes.t
@@ -10,9 +10,9 @@ test_psgi app, sub {
         my $url = '/changes/release/RWSTAUNER/File-Spec-Native-1.003';
         my $res = $cb->( GET $url );
         is( $res->code, 200, "200 on $url" );
-        my $tx = tx( $res, { css => 1 } );
+        my $tx = tx($res);
         $tx->like(
-            'div.content pre#source',
+            '//div[contains-token(@class, "content")]//pre[@id="source"]',
             qr/^Revision history for File-Spec-Native/,
             'source view for plain text change log'
         );


### PR DESCRIPTION
We were only using CSS selectors for one test, which can trivially be
switched to xpath. This makes the tests more consistent, removes an odd
interface, and removes a prereq.