### PR TITLE
skip codeql on dependabot push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
   schedule:
     - cron: '0 22 * * 3'


### PR DESCRIPTION
The checks will fail due to only having read-only access, but they will
still get checked by the pull request event.