### PR TITLE
fix changes display collapsing

### DIFF
--- a/root/release.tx
+++ b/root/release.tx
@@ -13,7 +13,7 @@
   %%  }
 </ul>
 %%  }
-<div id="last-changes" class="well collapsed">
+<div id="last-changes" class="well">
   <div id="last-changes-container">
     %%  for $changes -> $rel {
     <h2 id="whatsnew">Changes for version [% $rel.version %][% if $rel.date && datetime($rel.date) { %] - [% datetime($rel.date).to_ymd() } if $rel.trial { %] (TRIAL RELEASE)[% } %]</h2>

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -389,9 +389,14 @@ $(document).ready(function() {
     set_page_size('a[href*="/recent"]', 'recent_page_size');
     set_page_size('a[href*="/requires"]', 'requires_page_size');
 
-    var changes = $('#last-changes-container');
-    if (changes.prop('scrollHeight') > changes.height()) {
-        $("#last-changes-toggle").show();
+    var changes = $('#last-changes');
+    var changes_inner = $('#last-changes-container');
+    var changes_toggle = $("#last-changes-toggle");
+    changes.addClass(['collapsable', 'collapsed']);
+    var changes_content_height = Math.round(changes_inner.prop('scrollHeight'));
+    var changes_ui_height = Math.round(changes_inner.height() + changes_toggle.height());
+    if (changes_content_height <= changes_ui_height) {
+        changes.removeClass(['collapsable', 'collapsed']);
     }
 
     var pod2html_form = $('#metacpan-pod-renderer-form');

--- a/root/static/less/release.less
+++ b/root/static/less/release.less
@@ -52,13 +52,6 @@
         margin-bottom: 0px;
     }
 
-    .group-header {
-        margin-bottom: 1em;
-        &:last-child {
-            margin-bottom: 0em;
-        }
-    }
-
     ul, ul ul ul {
         list-style: disc;
     }
@@ -66,14 +59,21 @@
         list-style: circle;
     }
 
-    .show-more { display: none }
-    .hide-more { display: inline }
-    &.collapsed {
-        .show-more { display: inline }
-        .hide-more { display: none }
-        #last-changes-container {
-            overflow: hidden;
-            max-height: 20em;
+    &.collapsable {
+        #last-changes-toggle {
+            display: inline-block;
+        }
+
+        .show-more { display: none }
+        .hide-more { display: inline }
+        &.collapsed {
+            .show-more { display: inline }
+            .hide-more { display: none }
+
+            #last-changes-container {
+                overflow: hidden;
+                max-height: 20.02em;
+            }
         }
     }
 


### PR DESCRIPTION
Previously it was possible for the show/more less button on the changes
block to be displayed even if the hidden content was a single line,
which was rather pointless. And after changing the font size, the
calculated sizes could be off by a fraction of a pixel, resulting in
showing the button but it doing nothing.

Fix collapsing to not apply if javascript is disabled, and include the
size of the button when calculating if it should be collapsable.

Also tweak the collapse height to be an integer multiple of the line
height, and remove some unneeded padding between change groups.