### PR TITLE
include more transitive deps in cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -19,7 +19,6 @@ requires 'Config::General';
 requires 'Config::ZOMG', '1.000000';
 requires 'Cpanel::JSON::XS';
 requires 'CPAN::DistnameInfo', '0.12';
-requires 'CPAN::Meta', '2.141520'; # Avoid issues with List::Util dep under carton install.
 requires 'Data::Pageset';
 requires 'DateTime', '1.24';
 requires 'DateTime::Format::HTTP';
@@ -38,7 +37,6 @@ requires 'HTML::Escape';
 requires 'HTML::Restrict', '2.2.2';
 requires 'HTML::Tree';
 requires 'HTTP::Message::PSGI';
-requires 'HTTP::Lite', '2.44'; # Optional dep of XML::TreePP, which is a dep of XML::FeedPP
 requires 'HTTP::Request';
 requires 'HTTP::Request::Common';
 requires 'IO::Async::Loop';
@@ -90,7 +88,17 @@ requires 'URI::Escape';
 requires 'With::Roles', '0.001002';
 requires 'WWW::Form::UrlEncoded::XS';
 requires 'XML::FeedPP';
-requires 'YAML', '1.15'; # fix dep chain issue
+
+# transitive deps
+# Not used directly, but they need to be explicitly listed to ensure they are
+# in our cpanfile.snapshot at appropriate versions. Either for older perl
+# versions, or unpredictable dynamic deps.
+requires 'CPAN::Meta', '2.141520';
+requires 'Devel::PPPort', '3.62';   # for older perls
+requires 'HTTP::Lite', '2.44';      # Unpredictably depended on by XML::TreePP, which is a dep of XML::FeedPP
+requires 'Pod::Parser', '1.63';     # for newer perls
+requires 'version', '0.9929';       # for older perls
+requires 'YAML', '1.15';
 
 # Test dependencies
 requires 'aliased', '0.34';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1590,6 +1590,13 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
+  Devel-PPPort-3.62
+    pathname: A/AT/ATOOMIC/Devel-PPPort-3.62.tar.gz
+    provides:
+      Devel::PPPort 3.62
+    requirements:
+      ExtUtils::MakeMaker 0
+      FindBin 0
   Devel-StackTrace-2.04
     pathname: D/DR/DROLSKY/Devel-StackTrace-2.04.tar.gz
     provides:
@@ -4952,6 +4959,28 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
+  Pod-Parser-1.63
+    pathname: M/MA/MAREKR/Pod-Parser-1.63.tar.gz
+    provides:
+      Pod::Cache 1.63
+      Pod::Cache::Item 1.63
+      Pod::Find 1.63
+      Pod::Hyperlink 1.63
+      Pod::InputObjects 1.63
+      Pod::InputSource 1.63
+      Pod::InteriorSequence 1.63
+      Pod::List 1.63
+      Pod::Paragraph 1.63
+      Pod::ParseTree 1.63
+      Pod::ParseUtils 1.63
+      Pod::Parser 1.63
+      Pod::PlainText 2.07
+      Pod::Select 1.63
+    requirements:
+      Cwd 0
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      Test::More 0.6
   Pod-Spell-1.20
     pathname: D/DO/DOLMEN/Pod-Spell-1.20.tar.gz
     provides:
@@ -6440,3 +6469,13 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Package::Stash 0.23
       perl 5.008001
+  version-0.9929
+    pathname: L/LE/LEONT/version-0.9929.tar.gz
+    provides:
+      version 0.9929
+      version::regex 0.9929
+      version::vpp 0.9929
+      version::vxs 0.9929
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006002


### PR DESCRIPTION
Add some additional transitive deps to the cpanfile and snapshot to
cover a wider range of perl versions. The system that is automatically
updating the snapshot is running a different perl version than the
current live servers, so it won't have the same modules available. We
need to ensure all of the potentially required modules are listed in the
snapshot or the production machines won't install them.

Also document this a bit better in the cpanfile by splitting out these
deps to its own section.