### PR TITLE
force install all transitive modules when building snapshot

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -8,14 +8,33 @@ jobs:
         runs-on: "ubuntu-20.04"
         steps:
             - uses: actions/checkout@v2.3.4
+            - name: Get cpm
+              run: >
+                  curl -sL -o cpm https://git.io/cpm;
+                  chmod +x cpm
             - name: Install deps
               run: >
-                  curl -sL https://git.io/cpm | perl -
+                  ./cpm
                   install
                   --cpanfile cpanfile
                   --resolver metacpan
                   --show-build-log-on-failure
                   --local-lib-contained=local
+            - name: Install forced deps
+              run: >
+                  curl -sL https://cpanmin.us/ | perl -
+                  --cpanfile cpanfile.forced
+                  --showdeps --installdeps
+                  -L local
+                  -q
+                  .
+                  | ./cpm
+                  install
+                  --resolver metacpan
+                  --show-build-log-on-failure
+                  --local-lib-contained=local
+                  --reinstall
+                  -
             - name: Maybe update cpanfile.snapshot
               run: perl -Ilocal/lib/perl5 local/bin/carton
             - name: Create Pull Request

--- a/cpanfile
+++ b/cpanfile
@@ -89,17 +89,6 @@ requires 'With::Roles', '0.001002';
 requires 'WWW::Form::UrlEncoded::XS';
 requires 'XML::FeedPP';
 
-# transitive deps
-# Not used directly, but they need to be explicitly listed to ensure they are
-# in our cpanfile.snapshot at appropriate versions. Either for older perl
-# versions, or unpredictable dynamic deps.
-requires 'CPAN::Meta', '2.141520';
-requires 'Devel::PPPort', '3.62';   # for older perls
-requires 'HTTP::Lite', '2.44';      # Unpredictably depended on by XML::TreePP, which is a dep of XML::FeedPP
-requires 'Pod::Parser', '1.63';     # for newer perls
-requires 'version', '0.9929';       # for older perls
-requires 'YAML', '1.15';
-
 # Test dependencies
 requires 'aliased', '0.34';
 requires 'App::Prove';

--- a/cpanfile.forced
+++ b/cpanfile.forced
@@ -1,0 +1,13 @@
+# transitive deps
+# Not used directly, but they need to be explicitly listed to ensure they are
+# in our cpanfile.snapshot at appropriate versions. Either for older perl
+# versions, or unpredictable dynamic deps. These will be installed using a
+# different process to ensure they are present in the snapshot, even if they
+# would be satisfied by core.
+requires 'CPAN::Meta', '2.141520';
+requires 'Devel::PPPort', '3.62';   # for older perls
+requires 'HTTP::Lite', '2.44';      # Unpredictably depended on by XML::TreePP, which is a dep of XML::FeedPP
+requires 'HTTP::Tiny', '0.076';     # for older perls
+requires 'Pod::Parser', '1.63';     # for newer perls
+requires 'version', '0.9929';       # for older perls
+requires 'YAML', '1.15';


### PR DESCRIPTION
The cpanfile.snapshot file is generated using a version of perl that may
not match what we are deploying on. Additionally, some dependencies may
not predictably be installed with a normal cpm/carton run. Both of these
cases can end up with modules missing from the snapshot which are
required when installing on various systems.

We could try to provide cpm with the deployment perl version, but that
means it may not be appropriate for other perl versions.

Instead, we provide a list of modules that should always be installed,
even if they are provided by core. We use cpanm to extract these prereqs
from a secondary cpanfile, then pass them to cpm to install. cpm can't
use the alternate cpanfile directly, because it only pays attention to
the --reinstall flag when provided a module list. cpanm is given both
--installdeps and --showdeps, because only "--installdeps ." will look
at a cpanfile. The --showdeps option overrides its actual behavior,
showing the prereqs rather than installing them. Yes, this is a horrible
hack. It also needs the -L option, even though it it isn't installing
anything, to silence warnings about unwritable paths.