### PR TITLE
Several minor cleanups

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,7 +1,17 @@
--pbp
--nst
-
+--maximum-line-length=78
+--indent-columns=4
+--continuation-indentation=4
+--standard-error-output
+--vertical-tightness=2
+--closing-token-indentation=0
+--paren-tightness=1
+--brace-tightness=1
+--square-bracket-tightness=1
+--block-brace-tightness=1
+--nospace-for-semicolon
+--nooutdent-long-quotes
+--want-break-before="% + - * / x != == >= <= =~ !~ < > | & = **= += *= &= <<= &&= -= /= |= >>= ||= //= .= %= ^= x="
 # Break a line after opening/before closing token.
--vt=0
--vtc=0
--wn
+--vertical-tightness=0
+--vertical-tightness-closing=0
+--weld-nested-containers

--- a/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
+++ b/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
@@ -5,6 +5,7 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 sub add : Local : Args(0) {
     my ( $self, $c ) = @_;
+    $c->stash( { current_view => 'JSON' } );
     $c->detach('/forbidden') unless ( $c->req->method eq 'POST' );
     my $user = $c->user;
     $c->detach('/forbidden') unless $user;
@@ -33,7 +34,6 @@ sub add : Local : Args(0) {
     else {
         $c->res->code(400) if ( $res->{error} );
         $c->stash->{json}{success} = $res->{error} ? \0 : \1;
-        $c->stash( { current_view => 'JSON' } );
     }
 }
 
@@ -44,6 +44,7 @@ sub list : Local : Args(0) {
 
 sub list_as_json : Local : Args(0) {
     my ( $self, $c ) = @_;
+    $c->stash( { current_view => 'JSON' } );
 
     $c->stash->{json}{faves} = $self->faves( $c, 1_000 )->get;
 
@@ -51,8 +52,6 @@ sub list_as_json : Local : Args(0) {
 
     # Make sure the user re-requests from Fastly each time
     $c->browser_never_cache(1);
-
-    $c->stash( { current_view => 'JSON' } );
 }
 
 sub faves {

--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -10,11 +10,6 @@ use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-sub begin : Private {
-    my ( $self, $c ) = @_;
-    $c->stash( { page_class => 'page-pod' } );
-}
-
 # /pod/$name
 sub find : Path : Args(1) {
     my ( $self, $c, @path ) = @_;

--- a/lib/MetaCPAN/Web/Controller/Root.pm
+++ b/lib/MetaCPAN/Web/Controller/Root.pm
@@ -67,6 +67,7 @@ sub internal_error : Private {
 
     $c->stash( {
         template => 'internal_error.tx',
+        json     => { error => 500, message => 'Internal Error' },
     } );
     $c->response->status(500);
 }
@@ -77,6 +78,7 @@ sub forbidden : Private {
 
     $c->stash( {
         template => 'forbidden.tx',
+        json     => { error => 403, message => 'Forbidden' },
     } );
     $c->response->status(403);
 }

--- a/lib/MetaCPAN/Web/Controller/Root.pm
+++ b/lib/MetaCPAN/Web/Controller/Root.pm
@@ -21,17 +21,6 @@ MetaCPAN::Web::Controller::Root - Root Controller for MetaCPAN::Web
 
 =head1 METHODS
 
-=head2 begin
-
-The begin block runs for all urls.
-
-=cut
-
-sub begin : Private {
-    my ( $self, $c ) = @_;
-    $c->stash( { page_class => 'page-metacpan' } );
-}
-
 =head2 index
 
 The root page (/)

--- a/lib/MetaCPAN/Web/Controller/Search/AutoComplete.pm
+++ b/lib/MetaCPAN/Web/Controller/Search/AutoComplete.pm
@@ -9,6 +9,7 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
+    $c->stash( { current_view => 'JSON' } );
     my $query       = join( q{ }, $c->req->param('q') );
     my $module_data = $c->model('API::Module')->autocomplete($query);
     my $author_data = $c->model('API::Author')->search($query);
@@ -28,8 +29,7 @@ sub index : Path : Args(0) {
     );
 
     $c->stash( {
-        current_view => 'JSON',
-        json         => { suggestions => \@results },
+        json => { suggestions => \@results },
     } );
 }
 

--- a/lib/MetaCPAN/Web/Controller/SysAdmin/DataCenters.pm
+++ b/lib/MetaCPAN/Web/Controller/SysAdmin/DataCenters.pm
@@ -10,6 +10,7 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 # /sysadmin/datacenters/list
 sub list_datacenters : Path('list') : Args(0) GET {
     my ( $self, $c ) = @_;
+    $c->stash( { current_view => 'JSON' } );
 
     # Fetch the data center info from fastly
     # XXX: will not work unless you have the credentials
@@ -28,7 +29,6 @@ sub list_datacenters : Path('list') : Args(0) GET {
     $c->browser_max_age('1d');
 
     $c->stash( { json => { success => $datacenters } } );
-    $c->detach( $c->view('JSON') );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Test.pm
+++ b/lib/MetaCPAN/Web/Test.pm
@@ -126,6 +126,8 @@ sub tx {
 sub test_cache_headers {
     my ( $res, $conf ) = @_;
 
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
     is(
         $res->header('Cache-Control'),
         $conf->{cache_control},

--- a/root/about/about.tx
+++ b/root/about/about.tx
@@ -19,7 +19,7 @@ MetaCPAN has two parts:
 * [fastapi.metacpan.org](https://fastapi.metacpan.org/) the API
 
 So
-[https://metacpan.org/module/Moose](https://metacpan.org/module/Moose)
+[https://metacpan.org/pod/Moose](/pod/Moose)
 vs [https://fastapi.metacpan.org/v1/module/Moose](https://fastapi.metacpan.org/v1/module/Moose)
 
 MetaCPAN is [a community effort](/about/contributors), with all the code freely

--- a/root/about/faq.tx
+++ b/root/about/faq.tx
@@ -126,7 +126,7 @@ Every CPAN module author has an account on [PAUSE](https://pause.perl.org/pause/
 That account has some profile data in it (full name, ascii name, e-mail, and homepage).
 Authors can edit those at [Edit Account Info](https://pause.perl.org/pause/authenquery?ACTION=edit_cred).
 This information is collected and distributed by PAUSE via the
-[00whois.xml](http://www.cpan.org/authors/00whois.xml) file.
+[00whois.xml](https://www.cpan.org/authors/00whois.xml) file.
 
 In addition PAUSE users can upload a file called author.json or author-1.0.json to the root
 of their PAUSE account with other information.
@@ -158,13 +158,13 @@ The PAUSE account information need to be updated manually via
 CPAN Distributions can be marked by their authors (or by the CPAN admins when the author is not available)
 to be "up for adoption". This can be done by adding one of the following PAUSE accounts
 as co-maintainers: ADOPTME, HANDOFF, or NEEDHELP. For a more detailed explanation
-read the post [Marking modules as 'available for adoption'](http://neilb.org/2013/08/07/adoptme.html).
+read the post [Marking modules as 'available for adoption'](https://neilb.org/2013/08/07/adoptme.html).
 
 
 ### How to become the maintainer or co-maintainer of a CPAN distribution?
 
-See the description how to [adopt a CPAN module](http://neilb.org/2013/07/24/adopt-a-module.html)
-and check out the [CPAN adoption request template](http://neilb.org/2014/01/31/adoption-request.html).
+See the description how to [adopt a CPAN module](https://neilb.org/2013/07/24/adopt-a-module.html)
+and check out the [CPAN adoption request template](https://neilb.org/2014/01/31/adoption-request.html).
 
 See also the list of [CPAN Adoption Candidates](https://neilb.org/adoption/).
 

--- a/root/pod.tx
+++ b/root/pod.tx
@@ -4,6 +4,7 @@
 %%    title             => $title ||
 %%      ($module.documentation || $module.module.0.name ) ~
 %%      ($module.abstract ? ' - ' ~ $module.abstract : ''),
+%%    page_class  => $page_class || 'page-pod',
 %%  }
 %%  override left_nav_lead -> {
   <li>

--- a/t/encoding.t
+++ b/t/encoding.t
@@ -90,14 +90,19 @@ foreach my $ctype ( 'text/plain', 'application/json' ) {
     # it should go through the same process as any other content type
     subtest "check raw responses from the api (content-type: $ctype)" => sub {
 
+        my $lax_perl_char = do {
+            no warnings qw(portable);
+            "\x{FFFF_FFFF}";
+        };
+
         # test that a raw, non-utf8 response is unchanged
         foreach my $bad (
             [
-                encode( utf8 => "foo\x{FFFF_FFFF}bar" ),
+                encode( utf8 => "foo${lax_perl_char}bar" ),
                 'encoded lax perl utf8 chars'
             ],
             [
-                encode( utf8 => "=encoding  utf8\n\nfoo\x{FFFF_FFFF}bar" ),
+                encode( utf8 => "=encoding  utf8\n\nfoo${lax_perl_char}bar" ),
                 '=encoding utf8 with bad chars'
             ],
             [ "\225 cp1252 bullet", 'invalid utf-8 bytes' ],


### PR DESCRIPTION
Expand perl tidy options to be more readable.

Return JSON from JSON end points even on errors.

Per-page classes should be part of the templates, not the controllers.

Improve a few links on the about page.

Silence a warning in the encoding test.