### PR TITLE
Revert "Mark flaky Moose Pod content comparison test as TODO"

### DIFF
--- a/t/controller/pod.t
+++ b/t/controller/pod.t
@@ -44,15 +44,11 @@ test_psgi app, sub {
     my $tx2 = tx($res);
     ok( $tx->find_value('//div[contains(@class, "content")]'),
         'page has content' );
-
-TODO: {
-        local $TODO = 'Very flaky content check';
-        is(
-            $tx2->find_value('//div[contains(@class, "content")]'),
-            $tx->find_value('//div[contains(@class, "content")]'),
-            'content of both urls is exactly the same'
-        );
-    }
+    is(
+        $tx2->find_value('//div[contains(@class, "content")]'),
+        $tx->find_value('//div[contains(@class, "content")]'),
+        'content of both urls is exactly the same'
+    );
 
     # Request with lowercase author redirects to uppercase author.
     ( my $lc_this = $this )


### PR DESCRIPTION
This test should always pass, and always seems to. This generates noise
about a passing TODO test. The logs of it failing are no longer
available, making debugging difficult.

The restored check will either continue to work, or will help reveal the
failure and allow a proper fix.

This reverts commit 8821b4a8f0be06ffd332be68d48cf0c4e9e38be5.