### PR TITLE
Refactor URLs for more consistency

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -133,6 +133,10 @@ builder {
         );
     }
 
+    enable 'FixMissingBodyInRedirect';
+
+    enable '+MetaCPAN::Middleware::OldUrls';
+
     enable '+MetaCPAN::Middleware::Static' => (
         root     => $root_dir,
         dev_mode => $dev_mode,

--- a/cpanfile
+++ b/cpanfile
@@ -67,6 +67,7 @@ requires 'Plack::Middleware::Session::Cookie';
 requires 'Plack::Session';
 requires 'Plack::Test';
 requires 'Ref::Util', '>= 0.008';
+requires 'Router::Simple';
 requires 'Starman', '>= 0.4008';
 requires 'Term::Size::Any';
 requires 'Text::MultiMarkdown';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -5065,6 +5065,20 @@ DISTRIBUTIONS
     requirements:
       Exporter 5.57
       perl 5.006
+  Router-Simple-0.17
+    pathname: T/TO/TOKUHIROM/Router-Simple-0.17.tar.gz
+    provides:
+      Router::Simple 0.17
+      Router::Simple::Declare undef
+      Router::Simple::Route undef
+      Router::Simple::SubMapper undef
+    requirements:
+      Class::Accessor::Lite 0.05
+      List::Util 0
+      Module::Build 0.38
+      Scalar::Util 0
+      parent 0
+      perl 5.008_001
   Safe-Isa-1.000010
     pathname: E/ET/ETHER/Safe-Isa-1.000010.tar.gz
     provides:

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -87,6 +87,9 @@ sub _routes { (
     [ '/contributing-to/:author/:release',  '/release/:author/:release/contribute' ],
 
     [ '/river/gauge/:dist', '/dist/:dist/river.svg' ],
+
+    [ '/requires/distribution/:dist',   '/dist/:dist/requires' ],
+    [ '/requires/module/:module',       '/module/:module/requires' ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -121,6 +121,9 @@ sub _routes { (
             return 1;
         },
     ],
+
+    [ '/pod/release/:author/:release/:*file',   '/release/:author/:release/view/:file' ],
+    [ '/pod/distribution/:dist/:*file',         '/dist/:dist/view/:file' ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -32,11 +32,27 @@ sub _formatter {
     }
 }
 
+my $feed_type = sub {
+    my ( $env, $match ) = @_;
+    my $type
+        = lc( Plack::Request->new($env)->query_parameters->{type} || 'rdf' );
+    $match->{type}
+        = $type eq 'rss' || $type eq 'rdf' ? 'rss'
+        : $type eq 'atom'                  ? 'atom'
+        :                                    return 0;
+    return 1;
+};
+
 #<<<
 sub _routes { (
     [ '/permission/author/:author',         '/author/:author/permissions' ],
     [ '/permission/distribution/:dist',     '/dist/:dist/permissions' ],
     [ '/permission/module/:module',         '/module/:module/permissions' ],
+
+    [ '/feed/recent',             '/recent.:type',                  $feed_type ],
+    [ '/feed/news',               '/news.:type',                    $feed_type ],
+    [ '/feed/author/:author',     '/author/:author/activity.:type', $feed_type ],
+    [ '/feed/distribution/:dist', '/dist/:dist/releases.:type',     $feed_type ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -99,6 +99,28 @@ sub _routes { (
     [ '/source/:author/:release/:*file', '/release/:author/:release/source/:file' ],
 
     [ '/raw/:author/:release/:*file',   '/release/:author/:release/raw/:file' ],
+
+    [ '/diff/release/:before_author/:before_release/:after_author/:after_release',
+        '/release/:after_author/:after_release/diff/:before_author/:before_release' ],
+    [
+        '/diff/file',
+        '/release/:after_author/:after_release/diff/:before_author/:before_release/:path',
+        sub {
+            my ($env, $match) = @_;
+            my $q = Plack::Request->new($env)->query_parameters;
+            (
+                $match->{before_author},
+                $match->{before_release},
+            ) = split m{/}, $q->{source};
+            (
+                $match->{after_author},
+                $match->{after_release},
+                $match->{path},
+            ) = split m{/}, $q->{target}, 3;
+            $match->{path} //= '';
+            return 1;
+        },
+    ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -32,8 +32,13 @@ sub _formatter {
     }
 }
 
-sub _routes {
-}
+#<<<
+sub _routes { (
+    [ '/permission/author/:author',         '/author/:author/permissions' ],
+    [ '/permission/distribution/:dist',     '/dist/:dist/permissions' ],
+    [ '/permission/module/:module',         '/module/:module/permissions' ],
+) }
+#>>>
 
 sub prepare_app {
     my $self = shift;

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -84,6 +84,9 @@ sub prepare_app {
                             = $match->{splat}[$i];
                     }
                 }
+                if ( defined $match->{author} ) {
+                    $match->{author} = uc $match->{author};
+                }
                 $match->{url} = $formatter->($match);
                 if ( my $q = $match->{query} ) {
                     my $url = URI->new( $match->{url} );

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -79,6 +79,9 @@ sub _routes { (
     [ '/activity', '/module/:module/activity.svg',      $activity_type->('module') ],
     [ '/activity', '/activity/distributions.svg',       $activity_type->('new_dists') ],
     [ '/activity', '/activity/releases.svg',            $activity_type->() ],
+
+    [ '/changes/distribution/:dist',        '/dist/:dist/changes' ],
+    [ '/changes/release/:author/:release',  '/release/:author/:release/changes' ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -43,6 +43,26 @@ my $feed_type = sub {
     return 1;
 };
 
+my $activity_type = sub {
+    my $type = shift;
+    sub {
+        my ( $env, $match ) = @_;
+        my $q = Plack::Request->new($env)->query_parameters;
+        if ( !$type ) {
+        }
+        elsif ( $q->{$type} ) {
+            $match->{$type} = $q->{$type};
+        }
+        else {
+            return 0;
+        }
+        if ( $q->{res} ) {
+            $match->{query}{res} = $q->{res};
+        }
+        return 1;
+    };
+};
+
 #<<<
 sub _routes { (
     [ '/permission/author/:author',         '/author/:author/permissions' ],
@@ -53,6 +73,12 @@ sub _routes { (
     [ '/feed/news',               '/news.:type',                    $feed_type ],
     [ '/feed/author/:author',     '/author/:author/activity.:type', $feed_type ],
     [ '/feed/distribution/:dist', '/dist/:dist/releases.:type',     $feed_type ],
+
+    [ '/activity', '/author/:author/activity.svg',      $activity_type->('author') ],
+    [ '/activity', '/dist/:distribution/activity.svg',  $activity_type->('distribution') ],
+    [ '/activity', '/module/:module/activity.svg',      $activity_type->('module') ],
+    [ '/activity', '/activity/distributions.svg',       $activity_type->('new_dists') ],
+    [ '/activity', '/activity/releases.svg',            $activity_type->() ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -82,6 +82,9 @@ sub _routes { (
 
     [ '/changes/distribution/:dist',        '/dist/:dist/changes' ],
     [ '/changes/release/:author/:release',  '/release/:author/:release/changes' ],
+
+    [ '/contributing-to/:dist',             '/dist/:dist/contribute' ],
+    [ '/contributing-to/:author/:release',  '/release/:author/:release/contribute' ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -93,6 +93,10 @@ sub _routes { (
 
     [ '/release/:dist',                 '/dist/:dist' ],
     [ '/release/:dist/plussers',        '/dist/:dist/plussers' ],
+
+    [ '/release/:dist/source/:*file',   '/dist/:dist/source/:file' ],
+    [ '/source/:module',                '/module/:module/source' ],
+    [ '/source/:author/:release/:*file', '/release/:author/:release/source/:file' ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -85,6 +85,8 @@ sub _routes { (
 
     [ '/contributing-to/:dist',             '/dist/:dist/contribute' ],
     [ '/contributing-to/:author/:release',  '/release/:author/:release/contribute' ],
+
+    [ '/river/gauge/:dist', '/dist/:dist/river.svg' ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -1,0 +1,120 @@
+package MetaCPAN::Middleware::OldUrls;
+use strict;
+use warnings;
+
+use parent qw(Plack::Middleware);
+use Plack::Util::Accessor qw(router);
+
+use Plack::Request;
+use Router::Simple;
+use Ref::Util qw(is_hashref is_coderef);
+use URI;
+
+sub _formatter {
+    my $format = shift;
+    my @placeholders;
+    $format =~ s{%}{%%}g;
+    if (
+        $format =~ s{:(\w+)}{
+            push @placeholders, $1;
+            '%s'
+        }ge
+        )
+    {
+        return sub {
+            my ($arg)  = @_;
+            my @values = map $arg->{$_}, @placeholders;
+            sprintf $format, @values;
+        }
+    }
+    else {
+        return undef;
+    }
+}
+
+sub _routes {
+}
+
+sub prepare_app {
+    my $self = shift;
+
+    my $router = Router::Simple->new;
+    for my $r ( $self->_routes ) {
+        my $pattern = shift @$r;
+        my $dest    = shift @$r;
+
+        if ( !is_hashref($dest) ) {
+            $dest = { url => $dest, };
+        }
+
+        my %splat;
+        my $s = 0;
+        $pattern =~ s{\*|:\*(\w+)}{
+            if (defined $1) {
+                $splat{$s} = $1;
+            }
+            $s++;
+            '*';
+        }ge;
+
+        my $options;
+        $options = pop @$r
+            if is_hashref( $r->[-1] );
+        $options->{on_match} = pop @$r
+            if is_coderef( $r->[-1] );
+        $dest->{code} = pop @$r
+            if defined $r->[-1] && $r->[-1] =~ /\A[0-9]{3}\z/;
+
+        if (@$r) {
+            die "Invalid options for $pattern: " . join( ' ', @$r );
+        }
+
+        my $url       = $dest->{url};
+        my $formatter = ref $url eq 'CODE' ? $url : _formatter($url);
+        if ($formatter) {
+            my $on_match = $options->{on_match};
+            $options->{on_match} = sub {
+                my ( $env, $match ) = @_;
+                if ( defined $on_match && !$on_match->(@_) ) {
+                    return 0;
+                }
+                if ( keys %splat ) {
+                    for my $i ( 0 .. $#{ $match->{splat} } ) {
+                        $match->{ $splat{$i} || "splat$i" }
+                            = $match->{splat}[$i];
+                    }
+                }
+                $match->{url} = $formatter->($match);
+                if ( my $q = $match->{query} ) {
+                    my $url = URI->new( $match->{url} );
+                    $url->query_form( [
+                        $url->query_form,
+                        ( map +( $_ => $q->{$_} ), sort keys %$q ),
+                    ] );
+                    $match->{url} = $url->as_string;
+                }
+                return 1;
+            };
+        }
+        $router->connect( $pattern, $dest, $options );
+    }
+    $self->router($router);
+}
+
+sub call {
+    my ( $self, $env ) = @_;
+
+    my $router = $self->router;
+    if ( $env->{PATH_INFO} =~ m{\A(.+)/\z}s ) {
+        $env = { %$env, PATH_INFO => $1, };
+    }
+    if ( my $match = $router->match($env) ) {
+        my $url  = $match->{url};
+        my $code = $match->{code} // 301;
+        return [ $code, [ Location => $url ], [] ];
+    }
+
+    return $self->app->($env);
+}
+
+1;

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -90,6 +90,9 @@ sub _routes { (
 
     [ '/requires/distribution/:dist',   '/dist/:dist/requires' ],
     [ '/requires/module/:module',       '/module/:module/requires' ],
+
+    [ '/release/:dist',                 '/dist/:dist' ],
+    [ '/release/:dist/plussers',        '/dist/:dist/plussers' ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Middleware/OldUrls.pm
+++ b/lib/MetaCPAN/Middleware/OldUrls.pm
@@ -97,6 +97,8 @@ sub _routes { (
     [ '/release/:dist/source/:*file',   '/dist/:dist/source/:file' ],
     [ '/source/:module',                '/module/:module/source' ],
     [ '/source/:author/:release/:*file', '/release/:author/:release/source/:file' ],
+
+    [ '/raw/:author/:release/:*file',   '/release/:author/:release/raw/:file' ],
 ) }
 #>>>
 

--- a/lib/MetaCPAN/Web.pm
+++ b/lib/MetaCPAN/Web.pm
@@ -53,6 +53,11 @@ if ( !Term::Size::Perl::chars() ) {
     *Term::Size::Perl::chars = sub { $ENV{COLUMNS} || 80 };
 }
 
+after prepare_action => sub {
+    my ($self) = @_;
+    $self->req->final_args( $self->req->args );
+};
+
 __PACKAGE__->setup;
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/MetaCPAN/Web/Controller/Activity.pm
+++ b/lib/MetaCPAN/Web/Controller/Activity.pm
@@ -6,11 +6,46 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 use DateTime;
 
-sub index : Path : Args(0) {
+sub author : Chained('/author/root') PathPart('activity.svg') Args(0) {
+    my ( $self, $c ) = @_;
+    my $author = $c->stash->{pauseid};
+
+    $c->forward( 'activity', [ author => $author ] );
+}
+
+sub dist : Chained('/dist/root') PathPart('activity.svg') Args(0) {
+    my ( $self, $c ) = @_;
+    my $dist = $c->stash->{distribution_name};
+
+    $c->forward( 'activity', [ distribution => $dist ] );
+}
+
+sub module : Chained('/module/root') PathPart('activity.svg') Args(0) {
+    my ( $self, $c ) = @_;
+    my $module = $c->stash->{module_name};
+
+    $c->forward( 'activity', [ module => $module ] );
+}
+
+sub releases : Path('releases.svg') Args(0) {
     my ( $self, $c ) = @_;
 
-    my %args = map { $_ => $c->req->parameters->{$_} }
-        keys %{ $c->req->parameters };
+    $c->forward('activity');
+}
+
+sub distributions : Path('distributions.svg') Args(0) {
+    my ( $self, $c ) = @_;
+
+    $c->forward( 'activity', [ new_dists => 'n' ] );
+}
+
+sub activity : Private {
+    my ( $self, $c, %args ) = @_;
+
+    my $params = $c->req->parameters;
+    $args{res} = $params->{res}
+        if $params->{res};
+
     my $line = $c->model('API')->request( '/activity', undef, \%args )->get;
     return unless $line and exists $line->{activity};
 

--- a/lib/MetaCPAN/Web/Controller/Author.pm
+++ b/lib/MetaCPAN/Web/Controller/Author.pm
@@ -17,19 +17,18 @@ sub root : Chained('/') PathPart('author') CaptureArgs(1) {
     # force consistent casing in URLs
     if ( $id ne uc($id) ) {
 
-        # NOTE: This only works as long as we only use CaptureArgs
-        # and end the chain with PathPart('') and Args(0)
-        # (recommended by mst on #catalyst). If we deviate from that
-        # we may have to just do substitution on $req->uri
-        # because $c->req->args won't be what we expect.
-        # Just forget that Args exists (jedi hand wave).
+        $c->browser_max_age('1y');
+        $c->cdn_max_age('1y');
 
-        my $captures = $c->req->captures;
-        $captures->[0] = uc $captures->[0];
+        my @captures = @{ $c->req->captures };
+        $captures[0] = uc $id;
 
         $c->res->redirect(
-            $c->uri_for( $c->action, $captures, $c->req->params ),
-            301,    # Permanent
+            $c->uri_for(
+                $c->action,               \@captures,
+                @{ $c->req->final_args }, $c->req->params,
+            ),
+            301
         );
         $c->detach;
     }

--- a/lib/MetaCPAN/Web/Controller/Changes.pm
+++ b/lib/MetaCPAN/Web/Controller/Changes.pm
@@ -51,7 +51,7 @@ sub get : Private {
     elsif ( $file->{documentation} ) {
 
         # Is there a better way to reuse the pod view?
-        $c->forward( '/pod/release', [ @$file{qw( author release path )} ] );
+        $c->forward( '/view/release', [ $file->{path} ] );
     }
     else {
         $c->stash( { file => $file } );

--- a/lib/MetaCPAN/Web/Controller/Changes.pm
+++ b/lib/MetaCPAN/Web/Controller/Changes.pm
@@ -5,21 +5,16 @@ use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-sub distribution : Local Args(1) {
-    my ( $self, $c, $distribution ) = @_;
+sub distribution : Chained('/dist/root') PathPart('changes') Args(0) {
+    my ( $self, $c ) = @_;
+    my $dist = $c->stash->{distribution_name};
 
-    $c->forward( 'get', [$distribution] );
+    $c->forward( 'get', [$dist] );
 }
 
-sub release : Local Args(2) {
-    my ( $self, $c, $author, $release ) = @_;
-
-    # force consistent casing in URLs
-    if ( $author ne uc($author) ) {
-        $c->res->redirect(
-            $c->uri_for( $c->action, [ uc($author), $release ] ), 301 );
-        $c->detach();
-    }
+sub release : Chained('/release/root') PathPart('changes') Args(0) {
+    my ( $self,   $c )       = @_;
+    my ( $author, $release ) = $c->stash->@{qw(author_name release_name)};
 
     $c->forward( 'get', [ $author, $release ] );
 }

--- a/lib/MetaCPAN/Web/Controller/Changes.pm
+++ b/lib/MetaCPAN/Web/Controller/Changes.pm
@@ -34,7 +34,9 @@ sub get : Private {
             description => 'Try the release info page',
 
             # Is there a more Catalyst way to do this?
-            url       => $c->uri_for( '/release/' . $release ),
+            url => $c->uri_for(
+                ( @args == 1 ? '/dist/' : '/release/' ) . $release
+            ),
             link_text => $release,
         };
 

--- a/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
@@ -7,10 +7,9 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 use List::Util ();
 
-sub index : Chained('/') : PathPart('contributing-to') : CaptureArgs(0) { }
-
-sub dist : Chained('index') : PathPart('') : Args(1) {
-    my ( $self, $c, $dist ) = @_;
+sub dist : Chained('/dist/root') PathPart('contribute') Args(0) {
+    my ( $self, $c ) = @_;
+    my $dist = $c->stash->{distribution_name};
 
     my $release = $c->model('API::Release')->find($dist)->get->{release};
     if ( $release && $release->{author} && $release->{name} ) {
@@ -19,15 +18,9 @@ sub dist : Chained('index') : PathPart('') : Args(1) {
     $c->detach('/not_found');
 }
 
-sub release : Chained('index') : PathPart('') : Args(2) {
-    my ( $self, $c, $author, $release ) = @_;
-
-    # force consistent casing in URLs
-    if ( $author ne uc($author) ) {
-        $c->res->redirect(
-            $c->uri_for( $c->action, [ uc($author), $release ] ), 301 );
-        $c->detach();
-    }
+sub release : Chained('/release/root') PathPart('contribute') Args(0) {
+    my ( $self,   $c )       = @_;
+    my ( $author, $release ) = $c->stash->@{qw(author_name release_name)};
 
     $c->forward( 'get', [ $author, $release ] );
 }

--- a/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
@@ -53,14 +53,13 @@ sub get : Private {
         $c->response->status(404);
     }
     else {
-        my @path = split m{/}, $file->{path};
         if ( $file->{pod_lines} && @{ $file->{pod_lines} } ) {
             $c->forward( "/pod/release",
                 [ $file->{author}, $file->{release}, @path ] );
         }
         else {
-            $c->forward( "/source/index",
-                [ $file->{author}, $file->{release}, @path ] );
+            $c->forward( "/source/view",
+                [ $file->{author}, $file->{release}, $file->{path} ] );
         }
     }
 }

--- a/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
+++ b/lib/MetaCPAN/Web/Controller/ContributingDoc.pm
@@ -27,26 +27,18 @@ sub release : Chained('/release/root') PathPart('contribute') Args(0) {
 
 # /contributing-to/$name
 sub get : Private {
-    my ( $self, $c, @args ) = @_;
+    my ( $self, $c, $author, $release ) = @_;
 
     my $contributing_re = qr/CONTRIBUTING|HACKING/i;
     my $files
-        = $c->model('API::Release')->interesting_files(@args)->get->{files};
+        = $c->model('API::Release')->interesting_files( $author, $release )
+        ->get->{files};
 
     my $file = List::Util::first { $_->{name} =~ /$contributing_re/ } @$files;
 
     if ( !exists $file->{path} ) {
-        my $pod_file = $c->stash->{module}
-            = $c->model('API::Module')->find(@args)->get;
-
-        my @ri_request_info = @$pod_file{qw(author release)};
-        if ( !grep !defined, @ri_request_info ) {
-            my $release_info
-                = $c->model('ReleaseInfo')->get(@ri_request_info)
-                ->else( sub { Future->done( {} ) } );
-            $c->stash( $release_info->get );
-        }
-
+        my $release_info = $c->model('ReleaseInfo')->get( $author, $release );
+        $c->stash( $release_info->get );
         $c->stash( {
             template => 'contributing_not_found.tx',
         } );
@@ -54,8 +46,11 @@ sub get : Private {
     }
     else {
         if ( $file->{pod_lines} && @{ $file->{pod_lines} } ) {
-            $c->forward( "/pod/release",
-                [ $file->{author}, $file->{release}, @path ] );
+            $c->stash(
+                author_name  => $author,
+                release_name => $release,
+            );
+            $c->forward( "/view/release", [ $file->{path} ] );
         }
         else {
             $c->forward( "/source/view",

--- a/lib/MetaCPAN/Web/Controller/Diff.pm
+++ b/lib/MetaCPAN/Web/Controller/Diff.pm
@@ -5,22 +5,46 @@ use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-sub index : PathPart('diff') : Chained('/') : CaptureArgs(0) {
+sub release : Chained('/release/root') PathPart('diff') Args {
+    my ( $self, $c, $source_author, $source_release, @path ) = @_;
+    my ( $author, $release ) = $c->stash->@{qw(author_name release_name)};
+
+    $c->forward( 'view',
+        [ $source_author, $source_release, $author, $release, @path ] );
 }
 
-sub release : Local : Args(4) {
-    my ( $self, $c, @path ) = @_;
-    my $diff = $c->model('API::Diff')->releases(@path)->get;
-    $c->stash( {
-        diff     => $diff,
-        template => 'diff.tx',
-    } );
+sub dist : Chained('/dist/root') PathPart('raw') Args {
+    my ( $self, $c, $source_author, $source_release, @path ) = @_;
+    my $dist    = $c->stash->{distribution_name};
+    my $release = $c->model('API::Release')->find($dist)->get->{release}
+        or $c->detach('/not_found');
+    $c->forward(
+        'view',
+        [
+            $source_author,   $source_release, $release->{author},
+            $release->{name}, @path
+        ]
+    );
 }
 
-sub file : Local : Args(0) {
-    my ( $self, $c ) = @_;
-    my $diff = $c->model('API::Diff')
-        ->files( $c->req->params->{source}, $c->req->params->{target} )->get;
+sub view : Private {
+    my ( $self, $c, $source_author, $source_release, $target_author,
+        $target_release, @path )
+        = @_;
+
+    my $diff;
+    if (@path) {
+        $diff = $c->model('API::Diff')->files(
+            join( '/', $source_author, $source_release, @path ),
+            join( '/', $target_author, $target_release, @path ),
+        )->get;
+    }
+    else {
+        $diff = $c->model('API::Diff')->releases(
+            $source_author, $source_release,
+            $target_author, $target_release,
+        )->get;
+    }
     $c->stash( {
         diff     => $diff,
         template => 'diff.tx',

--- a/lib/MetaCPAN/Web/Controller/Dist.pm
+++ b/lib/MetaCPAN/Web/Controller/Dist.pm
@@ -1,0 +1,15 @@
+package MetaCPAN::Web::Controller::Dist;
+
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'MetaCPAN::Web::Controller' }
+
+sub root : Chained('/') PathPart('dist') CaptureArgs(1) {
+    my ( $self, $c, $dist ) = @_;
+    $c->stash( { distribution_name => $dist } );
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/MetaCPAN/Web/Controller/Dist.pm
+++ b/lib/MetaCPAN/Web/Controller/Dist.pm
@@ -10,6 +10,22 @@ sub root : Chained('/') PathPart('dist') CaptureArgs(1) {
     $c->stash( { distribution_name => $dist } );
 }
 
+sub dist_view : Chained('root') PathPart('') Args(0) {
+    my ( $self, $c ) = @_;
+    my $dist = $c->stash->{distribution_name};
+
+    $c->stash( release_info =>
+            $c->model( 'ReleaseInfo', full_details => 1 )->find($dist) );
+    $c->forward('/release/view');
+}
+
+sub plussers : Chained('root') PathPart('plussers') Args(0) {
+    my ( $self, $c ) = @_;
+    my $dist = $c->stash->{distribution_name};
+    $c->stash( $c->model('API::Favorite')->find_plussers($dist)->get );
+    $c->stash( { template => 'plussers.tx' } );
+}
+
 __PACKAGE__->meta->make_immutable;
 
 1;

--- a/lib/MetaCPAN/Web/Controller/Permission.pm
+++ b/lib/MetaCPAN/Web/Controller/Permission.pm
@@ -6,8 +6,10 @@ use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-sub author : Local Args(1) {
-    my ( $self, $c, $pause_id ) = @_;
+sub author : Chained('/author/root') : PathPart('permissions') Args(0) {
+    my ( $self, $c ) = @_;
+
+    my $pause_id = $c->stash->{pauseid};
 
     my $perms = $c->model('API::Permission')->by_author($pause_id)->get;
     $c->stash( {
@@ -16,8 +18,9 @@ sub author : Local Args(1) {
     $c->forward('view');
 }
 
-sub distribution : Local Args(1) {
-    my ( $self, $c, $distribution ) = @_;
+sub distribution : Chained('/dist/root') : PathPart('permissions') Args(0) {
+    my ( $self, $c ) = @_;
+    my $distribution = $c->stash->{distribution_name};
 
     my $perms = $c->model('API::Permission')->by_dist($distribution)->get;
 
@@ -39,8 +42,9 @@ sub distribution : Local Args(1) {
     $c->forward('view');
 }
 
-sub module : Local Args(1) {
-    my ( $self, $c, $module ) = @_;
+sub module : Chained('/module/root') : PathPart('permissions') Args(0) {
+    my ( $self, $c ) = @_;
+    my $module = $c->stash->{module_name};
 
     my $perms = $c->model('API::Permission')->by_module($module)->get;
     $c->stash( {

--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -9,25 +9,9 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 sub bare : Chained('/') PathPart('release') CaptureArgs(0) { }
 
-sub distribution_view : Chained('bare') PathPart('') Args(1) {
-    my ( $self, $c, $distribution ) = @_;
-
-    $c->stash( release_info =>
-            $c->model( 'ReleaseInfo', full_details => 1 )->find($distribution)
-    );
-    $c->forward('view');
-}
-
 sub index : Chained('/') PathPart('release') CaptureArgs(1) {
     my ( $self, $c, $distribution ) = @_;
     $c->stash( distribution => $distribution );
-}
-
-sub plusser_display : Chained('index') PathPart('plussers') Args(0) {
-    my ( $self, $c ) = @_;
-    my $dist = $c->stash->{distribution};
-    $c->stash( $c->model('API::Favorite')->find_plussers($dist)->get );
-    $c->stash( { template => 'plussers.tx' } );
 }
 
 sub root : Chained('bare') PathPart('') CaptureArgs(2) {

--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -54,15 +54,6 @@ sub release_view : Chained('root') PathPart('') Args(0) {
     $c->forward('view');
 }
 
-sub source : Chained('index') PathPart('source') Args {
-    my ( $self, $c, @path ) = @_;
-    my $dist    = $c->stash->{distribution};
-    my $release = $c->model('API::Release')->find($dist)->get->{release}
-        or $c->detach('/not_found');
-    $c->forward( '/source/index',
-        [ $release->{author}, $release->{name}, @path ] );
-}
-
 sub view : Private {
     my ( $self, $c ) = @_;
 

--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -7,17 +7,14 @@ use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-sub root : Chained('/') PathPart('release') CaptureArgs(0) {
-    my ( $self, $c ) = @_;
+sub bare : Chained('/') PathPart('release') CaptureArgs(0) { }
 
-    $c->stash->{current_model_instance}
-        = $c->model( 'ReleaseInfo', full_details => 1 );
-}
-
-sub by_distribution : Chained('root') PathPart('') Args(1) {
+sub distribution_view : Chained('bare') PathPart('') Args(1) {
     my ( $self, $c, $distribution ) = @_;
 
-    $c->stash( release_info => $c->model->find($distribution) );
+    $c->stash( release_info =>
+            $c->model( 'ReleaseInfo', full_details => 1 )->find($distribution)
+    );
     $c->forward('view');
 }
 
@@ -33,19 +30,42 @@ sub plusser_display : Chained('index') PathPart('plussers') Args(0) {
     $c->stash( { template => 'plussers.tx' } );
 }
 
-sub by_author_and_release : Chained('root') PathPart('') Args(2) {
+sub root : Chained('bare') PathPart('') CaptureArgs(2) {
     my ( $self, $c, $author, $release ) = @_;
 
     # force consistent casing in URLs
     if ( $author ne uc($author) ) {
+
+        $c->browser_max_age('1y');
+        $c->cdn_max_age('1y');
+
+        my @captures = @{ $c->req->captures };
+        $captures[0] = uc $author;
+
         $c->res->redirect(
-            $c->uri_for_action( $c->action, uc($author), $release ), 301 );
-        $c->detach();
+            $c->uri_for(
+                $c->action,               \@captures,
+                @{ $c->req->final_args }, $c->req->params,
+            ),
+            301
+        );
+        $c->detach;
     }
+
+    $c->stash( {
+        author_name  => $author,
+        release_name => $release,
+    } );
+}
+
+sub release_view : Chained('root') PathPart('') Args(0) {
+    my ( $self,   $c )       = @_;
+    my ( $author, $release ) = $c->stash->@{qw(author_name release_name)};
 
     $c->stash(
         permalinks   => 1,
-        release_info => $c->model->get( $author, $release ),
+        release_info => $c->model( 'ReleaseInfo', full_details => 1 )
+            ->get( $author, $release ),
     );
     $c->forward('view');
 }

--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -7,14 +7,7 @@ use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-sub bare : Chained('/') PathPart('release') CaptureArgs(0) { }
-
-sub index : Chained('/') PathPart('release') CaptureArgs(1) {
-    my ( $self, $c, $distribution ) = @_;
-    $c->stash( distribution => $distribution );
-}
-
-sub root : Chained('bare') PathPart('') CaptureArgs(2) {
+sub root : Chained('/') PathPart('release') CaptureArgs(2) {
     my ( $self, $c, $author, $release ) = @_;
 
     # force consistent casing in URLs

--- a/lib/MetaCPAN/Web/Controller/Requires.pm
+++ b/lib/MetaCPAN/Web/Controller/Requires.pm
@@ -20,16 +20,17 @@ __PACKAGE__->config(
     }
 );
 
-sub distribution : Local : Args(1) : Does('Sortable') {
-    my ( $self, $c, $distribution, $sort ) = @_;
+sub distribution : Chained('/dist/root') PathPart('requires') Args(0)
+    Does('Sortable') {
+    my ( $self, $c, $sort ) = @_;
+    my $dist = $c->stash->{distribution_name};
 
     my $page      = $c->req->page;
     my $page_size = $c->req->get_page_size(50);
 
     my $data
         = $c->model('API::Release')
-        ->reverse_dependencies( $distribution, $page, $page_size, $sort )
-        ->get;
+        ->reverse_dependencies( $dist, $page, $page_size, $sort )->get;
 
     my $pageset = Data::Pageset->new( {
         current_page     => $page,
@@ -42,14 +43,16 @@ sub distribution : Local : Args(1) : Does('Sortable') {
     $c->stash( {
         %{$data},
         type_of_required => 'dist',
-        required         => $distribution,
+        required         => $dist,
         pageset          => $pageset,
         template         => 'requires.tx',
     } );
 }
 
-sub module : Local : Args(1) : Does('Sortable') {
-    my ( $self, $c, $module, $sort ) = @_;
+sub module : Chained('/module/root') PathPart('requires') Args(0)
+    Does('Sortable') {
+    my ( $self, $c, $sort ) = @_;
+    my $module = $c->stash->{module_name};
 
     my $page      = $c->req->page;
     my $page_size = $c->req->get_page_size(50);

--- a/lib/MetaCPAN/Web/Controller/Requires.pm
+++ b/lib/MetaCPAN/Web/Controller/Requires.pm
@@ -41,7 +41,7 @@ sub distribution : Local : Args(1) : Does('Sortable') {
 
     $c->stash( {
         %{$data},
-        type_of_required => 'distribution',
+        type_of_required => 'dist',
         required         => $distribution,
         pageset          => $pageset,
         template         => 'requires.tx',

--- a/lib/MetaCPAN/Web/Controller/River.pm
+++ b/lib/MetaCPAN/Web/Controller/River.pm
@@ -3,26 +3,25 @@ use Moose;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-sub root : Chained('/') PathPart('river') CaptureArgs(0) { }
+sub gauge : Chained('/dist/root') PathPart('river.svg') Args(0) {
+    my ( $self, $c ) = @_;
+    my $dist = $c->stash->{distribution_name};
 
-sub gauge : Chained('root') PathPart('gauge') Args(1) {
-    my ( $self, $c, $name ) = @_;
-
-    my $dist = $c->model('API::Distribution')->get($name)->get;
+    my $dist_info = $c->model('API::Distribution')->get($dist)->get;
 
     # Lack of river data for a dist is handled differently in the template.
     $c->detach('/not_found')
-        unless $dist->{name};
+        unless $dist_info->{name};
 
     $c->res->content_type('image/svg+xml');
     $c->stash( {
-        distribution => $dist,
+        distribution => $dist_info,
         template     => 'river/gauge.svg.tx',
     } );
 
     $c->cdn_max_age('1y');
     $c->browser_max_age('7d');
-    $c->add_dist_key( $dist->{name} );
+    $c->add_dist_key( $dist_info->{name} );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Controller/View.pm
+++ b/lib/MetaCPAN/Web/Controller/View.pm
@@ -1,0 +1,60 @@
+package MetaCPAN::Web::Controller::View;
+
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'MetaCPAN::Web::Controller' }
+
+sub dist : Chained('/dist/root') PathPart('view') Args {
+    my ( $self, $c, @path ) = @_;
+    my $dist = $c->stash->{distribution_name};
+
+    $c->browser_max_age('1h');
+
+    $c->detach('/not_found')
+        if !defined $dist || !@path;
+
+# TODO: Could we do this with one query?
+# filter => { path => join('/', @path), distribution => $dist, status => latest }
+
+    # Get latest "author/release" of dist so we can use it to find the file.
+    # TODO: Pass size param so we can disambiguate?
+    my $release_data = try {
+        $c->model('ReleaseInfo')->find($dist)->get;
+    } or $c->detach('/not_found');
+
+    unshift @path, @{ $release_data->{release} }{qw( author name )};
+
+    $c->stash( {
+        %$release_data, pod_file => $c->model('API::Module')->get(@path)->get,
+    } );
+
+    $c->forward( '/pod/view', [@path] );
+}
+
+sub release : Chained('/release/root') PathPart('view') Args {
+    my ( $self, $c, @path ) = @_;
+    my ( $author, $release ) = $c->stash->@{qw(author_name release_name)};
+
+    if ( !@path ) {
+        $c->detach('/not_found');
+    }
+    $c->browser_max_age('1d');
+
+    my $pod_file
+        = $c->model('API::Module')->get( $author, $release, @path )->get;
+    my $release_data
+        = $c->model('ReleaseInfo')->get( $author, $release, $pod_file )
+        ->else_done( {} );
+    $c->stash( {
+        pod_file => $pod_file,
+        %{ $release_data->get },
+        permalinks => 1,
+    } );
+
+    $c->forward( '/pod/view', [ $author, $release, @path ] );
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/MetaCPAN/Web/Role/Request.pm
+++ b/lib/MetaCPAN/Web/Role/Request.pm
@@ -8,6 +8,8 @@ use Try::Tiny qw( catch try );
 
 use namespace::autoclean;
 
+has final_args => ( is => 'rw' );
+
 sub page {
     my $self = shift;
     my $page = $self->param('p');

--- a/root/author.tx
+++ b/root/author.tx
@@ -77,7 +77,11 @@
         %%  }
     %%  } }
     <li class="nav-header">Activity</li>
-    <li>[% include inc::activity { query => 'author=' ~ $author.pauseid } %]</li>
+    <li>
+      %%  include inc::activity {
+      %%    url => '/author/' ~ $author.pauseid ~ '/activity.svg',
+      %%  }
+    </li>
     %%  if $latest.date {
     <li class="nav-header">Latest Release</li>
     <li>

--- a/root/author.tx
+++ b/root/author.tx
@@ -1,6 +1,6 @@
 %%  cascade base {
 %%      title     => $title     || $author.name ~ ' (' ~ $author.pauseid ~ ')',
-%%      rss       => $rss       || 'author/' ~ $author.pauseid,
+%%      rss       => $rss       || '/author/' ~ $author.pauseid ~ '/activity.rss',
 %%      rss_title => $rss_title || 'Recent CPAN Activity of ' ~ $author.pauseid ~ ' - MetaCPAN',
 %%      twitter_card_inc => $twitter_card_inc || 'inc/twitter/author.tx',
 %%  }
@@ -135,7 +135,7 @@
 <div class="content">
     <div id="feed_subscription" class="page-header">
         <p>[% if $releases.0 { $releases.size() } else { 'No' } %] distributions uploaded by <span class="author-name">[% $author.name %]</span> ([% $author.pauseid %])</p>
-        <a href="/feed/author/[% $author.pauseid %]"><i class="fa fa-rss fa-2x black"></i></a>
+        <a href="/author/[% $author.pauseid %]/activity.rss"><i class="fa fa-rss fa-2x black"></i></a>
     </div>
     <div class="visible-xs inline-author-pic">[% include inc::author_pic %]</div>
     %%  if $releases.0 {

--- a/root/author.tx
+++ b/root/author.tx
@@ -86,7 +86,7 @@
     <li class="nav-header">Latest Release</li>
     <li>
         <div>
-            <a href="/release/[% if $latest.status == 'latest' { $latest.distribution } else { $latest.author ~ '/' ~ $latest.name } %]" class="ellipsis" title="[% $latest.name %]">
+            <a href="[% if $latest.status == 'latest' { '/dist/' ~ $latest.distribution } else { '/release/' ~ $latest.author ~ '/' ~ $latest.name } %]" class="ellipsis" title="[% $latest.name %]">
             [% $latest.name %]
             </a>
         </div>

--- a/root/author.tx
+++ b/root/author.tx
@@ -125,7 +125,7 @@
         <a href="[% $author.links.cpan_directory %]">CPAN directory</a> ([% $author.release_count.cpan + $author.release_count.latest %])
     </li>
     <li>
-        <a href="/permission/author/[% $author.pauseid %]">Module permissions</a>
+        <a href="/author/[% $author.pauseid %]/permissions">Module permissions</a>
     </li>
     <li>
         <a href="[% $author.links.backpan_directory %]" title="See all releases ever done by [% $author.pauseid %], not just those currently on CPAN.">BackPAN directory</a> ([% $author.release_count['backpan-only'] %])

--- a/root/base.tx
+++ b/root/base.tx
@@ -4,7 +4,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
         <title>[% $title || 'Search the CPAN' %] - metacpan.org</title>
         %%  if $rss {
-        <link rel="alternate" type="application/rss+xml" title="[% $rss_title || 'RSS'; %]" href="/feed/[% $rss %]" />
+        <link rel="alternate" type="application/rss+xml" title="[% $rss_title || 'RSS'; %]" href="[% $rss %]" />
         %%  }
         %%  for $assets.grep(rx('\.css$')) -> $css {
         <link href="[% $css %]" rel="stylesheet" type="text/css">

--- a/root/base/recent.tx
+++ b/root/base/recent.tx
@@ -1,5 +1,5 @@
 %%  cascade base {
-%%      rss       => $rss || 'recent',
+%%      rss       => $rss || '/recent.rss',
 %%      rss_title => $rss_title || 'Recent CPAN Uploads - MetaCPAN',
 %%      title     => $title || 'Recent',
 %%  }

--- a/root/base/recent.tx
+++ b/root/base/recent.tx
@@ -19,7 +19,9 @@
 %%  }
     <li class="nav-header">Activity</li>
     <li>
-        %%  include inc::activity { query => $filter || 'l' }
+        %%  include inc::activity {
+        %%    url => (($filter || 'l') == 'l' ? '/activity/releases.svg' : '/activity/distributions.svg'),
+        %%  }
     </li>
     <li class="nav-header">Recent Uploads</li>
     %%  sidebar_group($filter, [

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -116,7 +116,9 @@
     %%  }
     <li class="nav-header">Activity</li>
     <li>
-      %%  include inc::activity { query => 'distribution=' ~ $release.distribution };
+      %%  include inc::activity {
+      %%    url => '/dist/' ~ $release.distribution ~ '/activity.svg',
+      %%  }
     </li>
     <li class="nav-header">Tools</li>
     <li>

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -188,7 +188,7 @@
     %%  }
     <li class="nav-header">Permalinks</li>
     <li>
-      <a href="/[% $module ? 'pod/release' : 'release' %]/[% $release.author %]/[% $release.name %][% if $module { '/' ~ $module.path } %]">This version</a>
+      <a href="/release/[% $release.author %]/[% $release.name %][% if $module { '/view/' ~ $module.path } %]">This version</a>
     </li>
     %%  if $canonical {
       %%  my $has_latest = $versions.map(-> $v { $v.status == 'latest' ? 1 : 0 }).sum();

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -36,6 +36,9 @@
 </div>
 %%  }
 %%  override left_nav_content -> {
+    %%  my $release_base = $permalinks || $release.status != 'latest'
+    %%    ? '/release/' ~ $release.author ~ '/' ~ $release.name
+    %%    : '/dist/' ~ $release.distribution;
     <li class="nav-header"><span class="relatize">[% datetime($release.date).to_http %]</span></li>
     %%  include inc::release_status { maturity => $release.maturity, banner_class => 'release-banner' }
     %%  block left_nav_lead -> {
@@ -45,7 +48,7 @@
     <li><a href="[% $source_base %]"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="[% $source_base %]?raw=1">raw</a>)</li>
     %%  }
     <li>
-      <a data-keyboard-shortcut="g c" href="/changes/[% if $permalinks { 'release/' ~ $release.author ~ '/' ~ $release.name } else { 'distribution/' ~ $release.distribution } %]"><i class="fa fa-fw fa-cogs black"></i>Changes</a>
+      <a data-keyboard-shortcut="g c" href="[% $release_base %]/changes"><i class="fa fa-fw fa-cogs black"></i>Changes</a>
     </li>
     %%  if $release.resources.homepage.is_url() {
     <li>

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -42,10 +42,7 @@
     <li class="nav-header"><span class="relatize">[% datetime($release.date).to_http %]</span></li>
     %%  include inc::release_status { maturity => $release.maturity, banner_class => 'release-banner' }
     %%  block left_nav_lead -> {
-    %%    my $source_base = $permalinks || $release.status != 'latest'
-    %%      ? '/source/' ~ $release.author ~ '/' ~ $release.name
-    %%      : '/release/' ~ $release.distribution ~ '/source';
-    <li><a href="[% $source_base %]"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="[% $source_base %]?raw=1">raw</a>)</li>
+    <li><a href="[% $release_base %]/source"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="[% $source_base %]/source?raw=1">raw</a>)</li>
     %%  }
     <li>
       <a data-keyboard-shortcut="g c" href="[% $release_base %]/changes"><i class="fa fa-fw fa-cogs black"></i>Changes</a>

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -129,7 +129,7 @@
       </a>
     </li>
     <li>
-      <a href="/permission/distribution/[% $release.distribution %]">
+      <a href="/dist/[% $release.distribution %]/permissions">
         <i class="fa fa-key fa-fw black"></i>Permissions
       </a>
     </li>

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -56,7 +56,7 @@
     </li>
     %%  }
     <li>
-      <a class="nopopup" href="/contributing-to/[% $permalinks ? $release.author ~ '/' ~ $release.name : $release.distribution %]"><i class="fa fa-fw fa-plus-circle black"></i>How to Contribute</a>
+      <a class="nopopup" href="[% $release_base %]/contribute"><i class="fa fa-fw fa-plus-circle black"></i>How to Contribute</a>
     </li>
     %%  if $release.resources.repository {
     <li>

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -2,7 +2,7 @@
 %%    title     => $title     || $release.name ~ ' - ' ~ $release.abstract,
 %%    rss       => $rss       || '/dist/' ~ $release.distribution ~ '/releases.rss',
 %%    rss_title => $rss_title || 'Recent CPAN Uploads of ' ~ $release.distribution ~ ' - MetaCPAN',
-%%    canonical => $canonical || '/release/' ~ $release.distribution,
+%%    canonical => $canonical || '/dist/' ~ $release.distribution,
 %%    meta_description => $meta_description || $release.abstract,
 %%    twitter_card_inc => $twitter_card_inc || 'inc/twitter/release.tx',
 %%  }
@@ -16,7 +16,7 @@
     <span class="dropdown"><b class="caret"></b></span>
     %%  include inc::version_select { class => $module ? '' : 'extend' };
     %%  if $module {
-    <a data-keyboard-shortcut="g d" class="release-name" href="/release/[% if $permalinks || $release.status != 'latest' { $module.author ~ '/' ~ $module.release } else { $release.distribution } %]">[% $release.name %]</a>
+    <a data-keyboard-shortcut="g d" class="release-name" href="/[% if $permalinks || $release.status != 'latest' { '/release/' ~ $module.author ~ '/' ~ $module.release } else { '/dist/' ~ $release.distribution } %]">[% $release.name %]</a>
     %%  }
     %%  else {
     <span class="release-name">[% $release.name %]</span>
@@ -26,7 +26,7 @@
     %%  }
   </div>
   %%  if $release.status != 'latest' && $versions.map(-> $v { $v.status == 'latest' ? 1 : 0 }).sum() {
-    <a class="latest" href="[% if $module { %]/pod/[% $module.documentation %][% } else { %]/release/[% $release.distribution %][% } %]" title="[% if $release.maturity == 'developer' { 'dev release, ' } %]go to latest"><span class="fa fa-step-forward"></span></a>
+    <a class="latest" href="[% if $module { '/pod/' ~ $module.documentation } else { '/dist/' ~ $release.distribution } %]" title="[% if $release.maturity == 'developer' { 'dev release, ' } %]go to latest"><span class="fa fa-step-forward"></span></a>
   %%  }
   %%  include inc::river_gauge { river => $distribution.river, distribution => $release.distribution };
   %%  include inc::favorite;

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -1,6 +1,6 @@
 %%  cascade base {
 %%    title     => $title     || $release.name ~ ' - ' ~ $release.abstract,
-%%    rss       => $rss       || 'distribution/' ~ $release.distribution,
+%%    rss       => $rss       || '/dist/' ~ $release.distribution ~ '/releases.rss',
 %%    rss_title => $rss_title || 'Recent CPAN Uploads of ' ~ $release.distribution ~ ' - MetaCPAN',
 %%    canonical => $canonical || '/release/' ~ $release.distribution,
 %%    meta_description => $meta_description || $release.abstract,
@@ -134,7 +134,7 @@
       </a>
     </li>
     <li>
-      <a href="/feed/distribution/[% $release.distribution %]">
+      <a href="/dist/[% $release.distribution %]/releases.rss">
         <i class="fa fa-rss-square fa-fw black"></i>Subscribe to distribution
       </a>
     </li>

--- a/root/browse.tx
+++ b/root/browse.tx
@@ -3,10 +3,12 @@
 %%  }
 %%  override breadcrumbs -> {
 <div class="breadcrumbs">
-  <a href="/source/[% $author %]/[% $release %]">[% $author %] / [% $release %]</a>
+  <a href="/release/[% $author %]/[% $release %]/source">[% $author %] / [% $release %]</a>
+
+
   %%  for $directory -> $part {
-    %%  my $link = $base ~ '/' ~ $directory.slice(0, $~part).join('/')
-    / [% if $~part.is_last { $part } else { %]<a href="/source/[% $link %]">[% $part %]</a>[% } %]
+    %%  my $link = $directory.slice(0, $~part).join('/')
+    / [% if $~part.is_last { $part } else { %]<a href="/release/[% $author %]/[% $release %]/source/[% $link %]">[% $part %]</a>[% } %]
   %%  }
 </div>
 %%  }
@@ -36,7 +38,7 @@
 <tbody>
 %% for $files -> $file {
 <tr>
-  <td class="name" sort="[% ( $file.directory == 1 ? "!" : '' ) ~ $file.name %]"><a href="/source/[% $author %]/[% $release %]/[% $file.path %]" class="[%
+  <td class="name" sort="[% ( $file.directory == 1 ? "!" : '' ) ~ $file.name %]"><a href="/release/[% $author %]/[% $release %]/source/[% $file.path %]" class="[%
     $file.directory             ? 'silk-folder'
   : $file.mime.match("perl")    ? 'silk-page-white-code'
   : $file.mime.match("x-c")     ? 'silk-page-white-c'

--- a/root/browse.tx
+++ b/root/browse.tx
@@ -44,7 +44,7 @@
   : $file.mime.match("x-c")     ? 'silk-page-white-c'
                                 : 'silk-page-white'
 %]" title="[% $file.path %]">[% $file.name %]</a></td>
-  <td class="documentation"><strong><a href="/pod/release/[% $author %]/[% $release %]/[% $file.path %]" title="[% $file.path %]" class="ellipsis">[% $file.slop ? $file.documentation ? $file.documentation : $file.name : "" %]</a></strong></td>
+  <td class="documentation"><strong><a href="/release/[% $author %]/[% $release %]/view/[% $file.path %]" title="[% $file.path %]" class="ellipsis">[% $file.slop ? $file.documentation ? $file.documentation : $file.name : "" %]</a></strong></td>
   <!-- [% $file | dump %] -->
   <td class="size" sort="[% $file.directory ? 0 : $file.stat.size %]">[% $file.directory ? '' : format_bytes($file.stat.size) %]</td>
   %%  my $date = datetime($file.stat.mtime).to_http;

--- a/root/contributing_not_found.tx
+++ b/root/contributing_not_found.tx
@@ -29,7 +29,7 @@ For larger dists, you can also add a `Contributing.pod` to further
 elaborate on your contributing process; see
 [Moose::Manual::Contributing][moose] as an example.
 
-[moose]: /contributing-to/Moose
+[moose]: /dist/Moose/contribute
 
 #### For module users
 

--- a/root/diff.tx
+++ b/root/diff.tx
@@ -11,13 +11,13 @@
   <li class="nav-header">Tools</li>
     %%  if $diff.source.file {
       <li>
-        <a href="?source=[% $diff.source.author %]/[% $diff.source.release %]&target=[% $diff.target.author %]/[% $diff.target.release %]">
+        <a href="/release/[% $diff.source.author %]/[% $diff.source.release %]/diff/[% $diff.target.author %]/[% $diff.target.release %]">
           Diff full distribution
         </a>
       </li>
     %%  }
     <li>
-      <a href="?target=[% $diff.source.path %]&amp;source=[% $diff.target.path %]">
+      <a href="/release/[% $diff.source.author %]/[% $diff.source.release %]/diff/[% $diff.target.author %]/[% $diff.target.release %][% if $diff.source.file { '/' ~ $diff.source.file } %]">
         Reverse diff
       </a>
     </li>

--- a/root/diff.tx
+++ b/root/diff.tx
@@ -2,9 +2,9 @@
 %%  }
 %%  override breadcrumbs -> {
 <div class="breadcrumbs">
-  Diff <a href="/[% $diff.source.file ? 'source' : 'release' %]/[% $diff.source.path %]">[% $diff.source.author %] / [% $diff.source.release %]</a>
+  Diff <a href="/release/[% $diff.source.author %]/[% $diff.source.release %][% if $diff.source.file { '/source/' ~ $diff.source.file } %]">[% $diff.source.author %] / [% $diff.source.release %]</a>
   &nbsp;/&nbsp;
-  <a href="/[% $diff.target.file ? 'source' : 'release' %]/[% $diff.target.path %]">[% $diff.target.author %] / [% $diff.target.release %]</a>
+  <a href="/release/[% $diff.target.author %]/[% $diff.target.release %][% if $diff.target.file { '/source/' ~ $diff.target.file } %]">[% $diff.target.author %] / [% $diff.target.release %]</a>
 </div>
 %%  }
 %%  override left_nav_content -> {
@@ -60,7 +60,7 @@
         <a name="[% $file.file %]"></a>
         <div class="diff-container">
             <div class="diff-header">
-                <a href="/source/[% $diff.target.author %]/[% $diff.target.release %]/[% $file.file %]">[% $file.file %]</a>
+                <a href="/release/[% $diff.target.author %]/[% $diff.target.release %]/source/[% $file.file %]">[% $file.file %]</a>
             </div>
             <pre><code class="language-diff">[% $file.diff %]</code></pre>
         </div>

--- a/root/favorite/leaderboard.tx
+++ b/root/favorite/leaderboard.tx
@@ -15,7 +15,7 @@
   %%  for $leaders -> $leader {
     <tr>
       <td class="number[% if $~leader.index < 5 { " strong" } %]">[% $~leader.index + 1 %]</td>
-      <td class="name"><a href="/release/[% $leader.key %]">[% $leader.key %]</a></td>
+      <td class="name"><a href="/dist/[% $leader.key %]">[% $leader.key %]</a></td>
       <td class="number">[% $leader.doc_count %] ++</td>
     </tr>
   %%  }

--- a/root/home.tx
+++ b/root/home.tx
@@ -1,6 +1,6 @@
 %%  cascade base {
 %%      canonical   => $canonical || '/',
-%%      rss         => $rss || 'recent',
+%%      rss         => $rss || '/recent.rss',
 %%      rss_title   => $rss_title || 'Recent CPAN Uploads - MetaCPAN',
 %%  }
 %%  override left_nav -> { }

--- a/root/inc/activity.tx
+++ b/root/inc/activity.tx
@@ -1,4 +1,4 @@
 <div class="activity-graph">
-    <img src="/activity?res=month[% if $query { '&' ~ $query } %]" width="170" height="22" />
+    <img src="[% $url %]?res=month" width="170" height="22" />
     <div align="right"><small class="comment">24 month</small></div>
 </div>

--- a/root/inc/dependencies.tx
+++ b/root/inc/dependencies.tx
@@ -17,7 +17,7 @@
   %%  }
   <li><hr /></li>
   <li>
-    <a href="/requires/[% $module ? 'module/' ~ ($module.documentation || $module.module.0.name ) : 'distribution/' ~ $release.distribution %]"><i class="fa fa-share fa-fw black"></i>Reverse dependencies</a>
+    <a href="[% $module ? '/module/' ~ ($module.documentation || $module.module.0.name ) : '/dist/' ~ $release.distribution %]/requires"><i class="fa fa-share fa-fw black"></i>Reverse dependencies</a>
   </li>
   <li>
     <a href="http://deps.cpantesters.org/?module=[% $module.documentation || $module.module.0.name || $release.main_module %]"><i class="fa fa-retweet fa-fw black"></i>CPAN Testers List</a>

--- a/root/inc/favorite_table.tx
+++ b/root/inc/favorite_table.tx
@@ -24,7 +24,7 @@
 <tr>
   <td>
     <strong>
-        <a href="/release/[% $favorite.distribution %]" class="ellipsis" title="[% $favorite.author ~ '/' ~ $favorite.distribution %]">[% $favorite.distribution %]</a>
+        <a href="/dist/[% $favorite.distribution %]" class="ellipsis" title="[% $favorite.author ~ '/' ~ $favorite.distribution %]">[% $favorite.distribution %]</a>
     </strong>
   </td>
   %%  if $author {

--- a/root/inc/link_to_file.tx
+++ b/root/inc/link_to_file.tx
@@ -4,7 +4,7 @@ my $title = $file.documentation || $file.path;
 # If there is pod for this file...
 if $file.documentation || $file.pod_lines.size() || $file.module.map(-> $m { $m.associated_pod ? 1 : 0 }).sum() {
 -%]
-<a href="/pod/[%
+<a href="[%
   if !$permalinks {
     # If it's a PAUSE-indexed module (02packages)...
     if $file.documentation
@@ -12,16 +12,16 @@ if $file.documentation || $file.pod_lines.size() || $file.module.map(-> $m { $m.
         && $file.indexed
         && $file.module.map(-> $m { $m.authorized && $m.indexed }).sum() {
       # Use /pod/$name.
-      $file.documentation;
+      '/pod/' ~ $file.documentation;
     }
     else {
       # Use distribution (version-independent) url.
-      'distribution/' ~ $file.distribution ~ '/' ~ $file.path;
+      '/dist/' ~ $file.distribution ~ '/view/' ~ $file.path;
     }
   }
   else {
     # Else use versioned url.
-    'release/' ~ $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path;
+    '/release/' ~ $file.author ~ '/' ~ $file.release ~ '/view/' ~ $file.path;
   }
 %]">[% $linktext || $title %]</a>
 [%-

--- a/root/inc/link_to_source.tx
+++ b/root/inc/link_to_source.tx
@@ -1,5 +1,4 @@
-<a href="/[%
-    'source/' ~ $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path;
+<a href="/release/[% $file.author %]/[% $file.release %]/source/[% $file.path %][%
     if $file.module_name {
         '#P' ~ $file.module_name;
     }

--- a/root/inc/module_install.tx
+++ b/root/inc/module_install.tx
@@ -8,7 +8,7 @@
       <div class="modal-body">
         %%  my $name = $release.main_module || $module.documentation || $module.module.0.name || $module.package;
         <p>To install [% $name %], copy and paste the appropriate command in to your terminal.</p>
-        <p><a href="/pod/distribution/App-cpanminus/bin/cpanm">cpanm</a></p>
+        <p><a href="/dist/App-cpanminus/view/bin/cpanm">cpanm</a></p>
         <pre><code>cpanm [% $name || ($release.author ~ '/' ~ $release.archive) %]</code></pre>
         <p><a href="/pod/CPAN">CPAN shell</a></p>
         <pre><code>perl -MCPAN -e shell

--- a/root/inc/plussers.tx
+++ b/root/inc/plussers.tx
@@ -11,7 +11,7 @@
 </div>
 <!-- Display counts of plussers-->
 <div>
-    <a href="/release/[% $plussers.distribution %]/plussers">[% pluralize("%d PAUSE user(s)", $plussers.authors.size()) %]</a>
+    <a href="/dist/[% $plussers.distribution %]/plussers">[% pluralize("%d PAUSE user(s)", $plussers.authors.size()) %]</a>
 </div>
 %%  }
 %%  if $plussers.others {

--- a/root/inc/release_table.tx
+++ b/root/inc/release_table.tx
@@ -24,7 +24,7 @@
 %%  }
     <tr>
       <td class="river-gauge" sort="[% $release.river.total || 0 %]">[% include inc::river_gauge { distribution => $release.distribution, river => $release.river } %]</td>
-      <td class="name"><strong><a href="/release/[% $release.status == 'latest' ? $release.distribution : $release.author ~ '/' ~ $release.name %]" class="ellipsis" title="[% $release.author ~ '/' ~ $release.name %]">[% $release.name %]</a></strong></td>
+      <td class="name"><strong><a href="[% $release.status == 'latest' ? '/dist/' ~ $release.distribution : '/release/' ~ $release.author ~ '/' ~ $release.name %]" class="ellipsis" title="[% $release.author ~ '/' ~ $release.name %]">[% $release.name %]</a></strong></td>
       <td class="abstract">[% $release.abstract %]</td>
       <td class="date relatize" sort="[% $date %]">[% $date %]</td>
     </tr>

--- a/root/inc/river_gauge.tx
+++ b/root/inc/river_gauge.tx
@@ -6,7 +6,7 @@
 </span>
 %%  }
 %%  else {
-<object data="/river/gauge/[% $distribution | uri %]"
+<object data="/dist/[% $distribution | uri %]/river.svg"
   type="image/svg+xml"
   width="24px"
   height="15px"

--- a/root/inc/version_select.tx
+++ b/root/inc/version_select.tx
@@ -1,8 +1,9 @@
 <select onchange="document.location.href=[%
 block navigate -> {
-  $module
-    ? "'/pod/release/'+this.value+'/" ~ $module.path ~ "'"
-    : "'/release/'+this.value";
+  "'/release/'+this.value";
+  if $module {
+    "+'/" ~ $module.path ~ "'";
+  }
 }
 %]" class="[% $class %]">
 %%  if $head {

--- a/root/inc/version_select/diff.tx
+++ b/root/inc/version_select/diff.tx
@@ -2,5 +2,5 @@
 %%    head => 'Diff with version',
 %%  }
 %%  override navigate -> {
-'/diff/file/?target=[% uri_escape($release.author ~ '/' ~ $release.name ~ '/' ~ $module.path) %]&amp;source=' + encodeURIComponent(this.value)[% $module ? " + '" ~ uri_escape('/' ~ $module.path) ~ "'" : '' %]
+'/release/[% $release.author %]/[% $release.name %]/diff/' + encodeURIComponent(this.value)[% if $module { %] + '/[% $module.path %]'[% } %]
 %%  }

--- a/root/news.tx
+++ b/root/news.tx
@@ -1,10 +1,10 @@
 %%  cascade base {
 %%      title     => $title || 'News',
-%%      rss       => $rss || 'news',
+%%      rss       => $rss || '/news.rss',
 %%      rss_title => $rss_title || 'Recent MetaCPAN News',
 %%  }
 %%  override content -> {
-<a class="news_feed" href="/feed/news"><i class="fa fa-rss fa-2x"></i></a>
+<a class="news_feed" href="/news.rss"><i class="fa fa-rss fa-2x"></i></a>
 <div class="content news anchors">
 %%  block news | markdown -> {
 %%      $news

--- a/root/pod.tx
+++ b/root/pod.tx
@@ -15,23 +15,23 @@
     Module version: [% $documented_module.version %]
   </li>
   %%  }
-  %%  my $source_base = $permalinks || $release.status != 'latest'
-  %%    ? '/source/' ~ $release.author ~ '/' ~ $release.name
-  %%    : '/release/' ~ $release.distribution ~ '/source';
+  %%  my $release_base = $permalinks || $release.status != 'latest'
+  %%    ? '/release/' ~ $release.author ~ '/' ~ $release.name
+  %%    : '/dist/' ~ $release.distribution;
   <li>
-    <a data-keyboard-shortcut="g s" href="[% $source_base %]/[% $module.path %]"><i class="fa fa-fw fa-file-code black"></i>Source</a>
-    (<a href="[% $source_base %]/[% $module.path %]?raw=1">raw</a>)
+    <a data-keyboard-shortcut="g s" href="[% $release_base %]/source/[% $module.path %]"><i class="fa fa-fw fa-file-code black"></i>Source</a>
+    (<a href="[% $release_base %]/source/[% $module.path %]?raw=1">raw</a>)
   </li>
   %%  if $module.pod_path {
   <li>
-    <a data-keyboard-shortcut="g p" href="[% $source_base %]/[% $module.pod_path %]"><i class="fa fa-fw fa-file-code black"></i>Pod Source</a>
-    (<a href="[% $source_base %]/[% $module.pod_path %]?raw=1">raw</a>)
+    <a data-keyboard-shortcut="g p" href="[% $release_base %]/source/[% $module.pod_path %]"><i class="fa fa-fw fa-file-code black"></i>Pod Source</a>
+    (<a href="[% $release_base %]/source/[% $module.pod_path %]?raw=1">raw</a>)
   </li>
   %%  }
   <li>
     %%  my $parent_path = $module.path.replace(rx('/[^/]*'),'');
-    <a data-keyboard-shortcut="g b" href="[% $source_base %]/[% $parent_path %]"><i class="fa fa-fw fa-folder-open black"></i>Browse</a>
-    (<a href="[% $source_base %]/[% $parent_path %]?raw=1">raw</a>)
+    <a data-keyboard-shortcut="g b" href="[% $release_base %]/source/[% $parent_path %]"><i class="fa fa-fw fa-folder-open black"></i>Browse</a>
+    (<a href="[% $release_base %]/source/[% $parent_path %]?raw=1">raw</a>)
   </li>
 %%  }
 %%  override page_content -> {
@@ -46,7 +46,7 @@
   %%  else {
   <p class="pod-error">
     No POD found for <code>[% $module.name %]</code>.
-    Time to <a href="/source/[% $module.author %]/[% $module.release %]/[% $module.path %]">read the source</a>?
+    Time to <a href="[% $release_base %]/source/[% $module.path %]">read the source</a>?
   </p>
   %%  }
 </div>

--- a/root/raw.tx
+++ b/root/raw.tx
@@ -2,7 +2,7 @@
 %%  override content -> {
 
 <p>
-  <a href="/raw/[% $module.author %]/[% $module.release %]/[% $module.path %]?download=1">download</a>
+  <a href="/release/[% $module.author %]/[% $module.release %]/raw/[% $module.path %]?download=1">download</a>
 </p>
 
 <pre>[% $source %]</pre>

--- a/root/recent.tx
+++ b/root/recent.tx
@@ -1,13 +1,13 @@
 %%  cascade base::recent {
 %%      title     => $title || 'Recent',
-%%      rss       => $rss || 'recent?f=' ~ $filter,
+%%      rss       => $rss || '/recent.rss' ~ ( $filter ? '?f=' ~ $filter : ''),
 %%      rss_title => $rss_title || 'Recent CPAN Uploads - MetaCPAN',
 %%  }
 %%  override content -> {
 <div class="content">
   <div id="feed_subscription" class="page-header">
     <p>Recent Uploads</p>
-      <a href="/feed/recent"><i class="fa fa-rss fa-2x black"></i></a>
+      <a href="/recent.rss [% if $filter { '?f=' ~ $filter } %]"><i class="fa fa-rss fa-2x black"></i></a>
   </div>
 %%  include inc::release_table { releases => $recent, per_day => 1 }
 %%  include inc::pager

--- a/root/requires.tx
+++ b/root/requires.tx
@@ -4,13 +4,15 @@
 %%  override left_nav_content -> {
 <li class="nav-header">Activity</li>
 <li>
-%%  include inc::activity { query => $type_of_required ~ "=" ~ $required }
+%%  include inc::activity {
+%%    url => '/' ~ $type_of_required ~ '/' ~ $required ~ '/activity.svg',
+%%  }
 </li>
 %%  }
 %%  override content -> {
 
 <div class="content">
-    <strong>Distributions Which Depend on <a href="/[% $type_of_required == 'distribution' ? 'release' : 'module' %]/[% $required %]">[% $required %]</a></strong>
+    <strong>Distributions Which Depend on <a href="/[% $type_of_required == 'dist' ? 'release' : 'module' %]/[% $required %]">[% $required %]</a></strong>
     %%  if $releases.size() {
         %%  include inc::release_table {
         %%      header          => 1,
@@ -21,7 +23,7 @@
         %%  include inc::pager;
     %%  }
     %%  else {
-    <p>No distributions depending on <a href="/[% $type_of_required == 'distribution' ? 'release' : 'module' %]/[% $required %]">[% $required %]</a> could be found</p>
+    <p>No distributions depending on <a href="/[% $type_of_required == 'dist' ? 'release' : 'module' %]/[% $required %]">[% $required %]</a> could be found</p>
     %%  }
 </div>
 

--- a/root/requires.tx
+++ b/root/requires.tx
@@ -12,7 +12,7 @@
 %%  override content -> {
 
 <div class="content">
-    <strong>Distributions Which Depend on <a href="/[% $type_of_required == 'dist' ? 'release' : 'module' %]/[% $required %]">[% $required %]</a></strong>
+    <strong>Distributions Which Depend on <a href="/[% $type_of_required %]/[% $required %]">[% $required %]</a></strong>
     %%  if $releases.size() {
         %%  include inc::release_table {
         %%      header          => 1,
@@ -23,7 +23,7 @@
         %%  include inc::pager;
     %%  }
     %%  else {
-    <p>No distributions depending on <a href="/[% $type_of_required == 'dist' ? 'release' : 'module' %]/[% $required %]">[% $required %]</a> could be found</p>
+    <p>No distributions depending on <a href="/[% $type_of_required %]/[% $required %]">[% $required %]</a> could be found</p>
     %%  }
 </div>
 

--- a/root/search.tx
+++ b/root/search.tx
@@ -30,7 +30,7 @@
     %%  if $first.description {
     <p class="description">[% $first.description.substr(0, 250) ~ '...' %]</p>
     %%  }
-    <a class="author" href="/author/[% $first.author | uri %]">[% $first.author %]</a><a href="/release/[% if $first.status == 'latest' { $first.distribution } else { $first.author ~ '/' ~ $first.release } %]">/[% $first.release %]</a>
+    <a class="author" href="/author/[% $first.author | uri %]">[% $first.author %]</a><a href="[% if $first.status == 'latest' { '/dist/' ~ $first.distribution } else { '/release/' ~ $first.author ~ '/' ~ $first.release } %]">/[% $first.release %]</a>
     -
     <span class="relatize">[% datetime($first.date).to_http %]</span>
     %%  if !$single_dist {

--- a/root/source.tx
+++ b/root/source.tx
@@ -1,6 +1,6 @@
 %%  cascade base {
 %%      title       => $title || $file.path,
-%%      rss         => $rss || 'distribution/' ~ $file.distribution,
+%%      rss         => $rss || '/dist/' ~ $file.distribution ~ '/releases.rss',
 %%      rss_title   => $rss_title || 'Recent CPAN Uploads of ' ~ $file.distribution ~ ' - MetaCPAN',
 %%  }
 %%  override breadcrumbs -> {

--- a/root/source.tx
+++ b/root/source.tx
@@ -25,7 +25,7 @@
   %%  }
   %%  else if $file.slop {
   <li>
-    <a href="/pod/release/[% $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]"><i class="fa fa-book fa-fw black"></i>Documentation View</a>
+    <a href="/release/[% $file.author ~ '/' ~ $file.release ~ '/view/' ~ $file.path %]"><i class="fa fa-book fa-fw black"></i>Documentation View</a>
   </li>
   %%  }
   <li>

--- a/root/source.tx
+++ b/root/source.tx
@@ -35,7 +35,7 @@
   <li><a href="[% $api_public ~ '/source/' ~ $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]"><i class="fa fa-file-text fa-fw black"></i>Raw code</a></li>
   <li><a href="/release/[% $file.author ~ '/' ~ $file.release ~ '/source/' ~ $file.path %]"><i class="fa fa-link fa-fw black"></i>Permalink</a></li>
   <li>
-    <a href="/raw/[% $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]?download=1"><i class="fa fa-download fa-fw black"></i>Download</a>
+    <a href="/release/[% $file.author ~ '/' ~ $file.release ~ '/raw/' ~ $file.path %]?download=1"><i class="fa fa-download fa-fw black"></i>Download</a>
   </li>
   %%  if $file.sloc {
   <li><button class="btn-link pod-toggle pod-hidden" onclick="togglePod()"><i class="fa fa-exchange fa-fw black"></i><span class="hide-pod">Hide</span><span class="show-pod">Show</span> Pod</button></li>

--- a/root/source.tx
+++ b/root/source.tx
@@ -5,10 +5,10 @@
 %%  }
 %%  override breadcrumbs -> {
 <div class="breadcrumbs">
-  <a data-keyboard-shortcut="g s" href="/source/[% $file.author ~ '/' ~ $file.release %]">[% $file.author %] / [% $file.release %]</a>
+  <a data-keyboard-shortcut="g s" href="/release/[% $file.author ~ '/' ~ $file.release %]/source">[% $file.author %] / [% $file.release %]</a>
   %%  my $parts = $file.path.split('/');
   %%  for $parts -> $part {
-    / [% if $~part.is_last { $part } else { %]<a href="/source/[% $file.author ~ '/' ~ $file.release ~ '/' ~ $parts.slice(0, $~part).join('/') %]">[% $part %]</a>[% } %]
+    / [% if $~part.is_last { $part } else { %]<a href="/release/[% $file.author ~ '/' ~ $file.release %]/source/[% $parts.slice(0, $~part).join('/') %]">[% $part %]</a>[% } %]
   %%  }
 </div>
 %%  }
@@ -33,7 +33,7 @@
   </li>
   <li>&nbsp;</li>
   <li><a href="[% $api_public ~ '/source/' ~ $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]"><i class="fa fa-file-text fa-fw black"></i>Raw code</a></li>
-  <li><a href="/source/[% $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]"><i class="fa fa-link fa-fw black"></i>Permalink</a></li>
+  <li><a href="/release/[% $file.author ~ '/' ~ $file.release ~ '/source/' ~ $file.path %]"><i class="fa fa-link fa-fw black"></i>Permalink</a></li>
   <li>
     <a href="/raw/[% $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]?download=1"><i class="fa fa-download fa-fw black"></i>Download</a>
   </li>

--- a/t/controller/activity.t
+++ b/t/controller/activity.t
@@ -4,7 +4,7 @@ use Test::More;
 use MetaCPAN::Web::Test qw( app GET test_psgi tx );
 
 my @tests
-    = qw(/activity /activity?author=PERLER /activity?distribution=Moose);
+    = qw(/activity/releases.svg /author/PERLER/activity.svg /dist/Moose/activity.svg);
 
 test_psgi app, sub {
     my $cb = shift;

--- a/t/controller/changes.t
+++ b/t/controller/changes.t
@@ -7,7 +7,7 @@ use MetaCPAN::Web::Test qw( app GET test_psgi tx );
 test_psgi app, sub {
     my $cb = shift;
     {
-        my $url = '/changes/release/RWSTAUNER/File-Spec-Native-1.003';
+        my $url = '/release/RWSTAUNER/File-Spec-Native-1.003/changes';
         my $res = $cb->( GET $url );
         is( $res->code, 200, "200 on $url" );
         my $tx = tx($res);
@@ -19,7 +19,7 @@ test_psgi app, sub {
     }
 
     {
-        my $url = '/changes/release/SHAY/perl-5.22.2';
+        my $url = '/release/SHAY/perl-5.22.2/changes';
         my $res = $cb->( GET $url );
         is( $res->code, 200, "200 on $url" );
         my $tx = tx($res);
@@ -32,7 +32,7 @@ test_psgi app, sub {
 
     {
         my $missing = 'test-dist-name-that-does-not-exist-i-hope';
-        my $url     = "/changes/distribution/$missing";
+        my $url     = "/dist/$missing/changes";
         my $res     = $cb->( GET $url );
         is( $res->code, 404, "404 on $url" );
         my $tx = tx($res);

--- a/t/controller/contributing-to.t
+++ b/t/controller/contributing-to.t
@@ -21,7 +21,7 @@ test_psgi app, sub {
     );
     ok(
         $tx->find_value(
-            '//a[@href="/pod/distribution/Moose/lib/Moose/Manual/Contributing.pod"]'
+            '//a[@href="/dist/Moose/view/lib/Moose/Manual/Contributing.pod"]'
         ),
         'contains permalink to Contributing doc'
     );

--- a/t/controller/contributing-to.t
+++ b/t/controller/contributing-to.t
@@ -6,11 +6,11 @@ use MetaCPAN::Web::Test qw( app GET test_psgi tx );
 test_psgi app, sub {
     my $cb = shift;
 
-    ok( my $res = $cb->( GET '/contributing-to/DOESNTEXIST' ),
-        'GET /contributing-to/DOESNTEXIST' );
+    ok( my $res = $cb->( GET '/dist/DOESNTEXIST/contribute' ),
+        'GET /dist/DOESNTEXIST/contribute' );
     is( $res->code, 404, 'code 404' );
-    ok( $res = $cb->( GET '/contributing-to/Moose' ),
-        'GET /contributing-to/Moose' );
+    ok( $res = $cb->( GET '/dist/Moose/contribute' ),
+        'GET /dist/Moose/contribute' );
     is( $res->code, 200, 'code 200' );
 
     my $tx = tx($res);
@@ -28,9 +28,9 @@ test_psgi app, sub {
 
     ok(
         $res = $cb->(
-            GET '/contributing-to/Acme-Test-MetaCPAN-NoContributingDoc'
+            GET '/dist/Acme-Test-MetaCPAN-NoContributingDoc/contribute'
         ),
-        'GET /contributing-to/Acme-Test-MetaCPAN-NoContributingDoc'
+        'GET /dist/Acme-Test-MetaCPAN-NoContributingDoc/contribute'
     );
     is( $res->code, 404, 'code 404' );
 

--- a/t/controller/diff.t
+++ b/t/controller/diff.t
@@ -6,9 +6,9 @@ use MetaCPAN::Web::Test qw( app GET test_psgi tx );
 test_psgi app, sub {
     my $cb = shift;
 
-    my $mod_diff = '/diff/file/?target=ETHER/Moose-2.1605/lib/Moose.pm'
-        . '&source=ETHER/Moose-2.1604/lib/Moose.pm';
-    my $rel_diff = '/diff/release/ETHER/Moose-2.1604/ETHER/Moose-2.1605';
+    my $mod_diff
+        = '/release/ETHER/Moose-2.1605/diff/ETHER/Moose-2.1604/lib/Moose.pm';
+    my $rel_diff = '/release/ETHER/Moose-2.1605/diff/ETHER/Moose-2.1604';
 
     ok( my $res = $cb->( GET $mod_diff ), 'GET module diff' );
     is( $res->code, 200, 'code 200' );

--- a/t/controller/favorite/leaderboard.t
+++ b/t/controller/favorite/leaderboard.t
@@ -18,7 +18,7 @@ test_psgi app, sub {
                 my $anchor = shift;
                 $anchor->is(
                     './@href',
-                    '/release/' . $anchor->node->textContent,
+                    '/dist/' . $anchor->node->textContent,
                     'href points to release'
                 );
             },

--- a/t/controller/permission.t
+++ b/t/controller/permission.t
@@ -7,36 +7,36 @@ test_psgi app, sub {
     my $cb = shift;
 
     {
-        ok( my $res = $cb->( GET '/permission/module/DOESNTEXIST' ),
-            'GET /permission/module/DOESNTEXIST' );
+        ok( my $res = $cb->( GET '/module/DOESNTEXIST/permissions' ),
+            'GET /module/DOESNTEXIST/permissions' );
         is( $res->code, 404, 'not found' );
     }
     {
-        ok( my $res = $cb->( GET '/permission/module/Moose' ),
-            'GET /permission/module/Moose' );
+        ok( my $res = $cb->( GET '/module/Moose/permissions' ),
+            'GET /module/Moose/permissions' );
         is( $res->code, 200, 'found' );
         like( $res->content, qr{ETHER}, 'ETHER in content' );
     }
     {
-        ok( my $res = $cb->( GET '/permission/distribution/DOESNTEXIST' ),
-            'GET /permission/distribution/DOESNTEXIST' );
+        ok( my $res = $cb->( GET '/dist/DOESNTEXIST/permissions' ),
+            'GET /dist/DOESNTEXIST/permissions' );
         is( $res->code, 404, 'not found' );
     }
     {
-        ok( my $res = $cb->( GET '/permission/distribution/Moose' ),
-            'GET /permission/distribution/Moose' );
+        ok( my $res = $cb->( GET '/dist/Moose/permissions' ),
+            'GET /dist/Moose/permission' );
         is( $res->code, 200, 'found' );
         like( $res->content, qr{ETHER}, 'ETHER in content' );
     }
 
     {
-        ok( my $res = $cb->( GET '/permission/author/!!!DOESNTEXIST' ),
-            'GET /permission/author/DOESNTEXIST' );
+        ok( my $res = $cb->( GET '/author/!!!DOESNTEXIST/permissions' ),
+            'GET /author/DOESNTEXIST/permissions' );
         is( $res->code, 404, 'not found' );
     }
     {
-        ok( my $res = $cb->( GET '/permission/author/OALDERS' ),
-            'GET /permission/author/OALDERS' );
+        ok( my $res = $cb->( GET '/author/OALDERS/permissions' ),
+            'GET /author/OALDERS/permissions' );
         is( $res->code, 200, 'found' );
         like( $res->content, qr{OALDERS},        'OALDERS in content' );
         like( $res->content, qr{HTML::Restrict}, 'owner in content' );

--- a/t/controller/pod.t
+++ b/t/controller/pod.t
@@ -10,7 +10,8 @@ test_psgi app, sub {
     is( $res->code, 404, 'code 404' );
 
     subtest 'coverage' => sub {
-        my $res = $cb->( GET '/pod/release/ETHER/Moose-2.2010/lib/Moose.pm' );
+        my $res
+            = $cb->( GET '/release/ETHER/Moose-2.2010/view/lib/Moose.pm' );
         is( $res->code, 200, 'found older Moose pod' );
         like( $res->content, qr{92\.19% Coverage}, 'coverage in sidebar' );
     };
@@ -51,8 +52,7 @@ test_psgi app, sub {
     );
 
     # Request with lowercase author redirects to uppercase author.
-    ( my $lc_this = $this )
-        =~ s{(/pod/release/)([^/]+)}{$1\L$2};    # lc author name
+    ( my $lc_this = $this ) =~ s{(/release/)([^/]+)}{$1\L$2}; # lc author name
     ok( $res = $cb->( GET $lc_this ), "GET $lc_this" );
     is( $res->code, 301, '301 on lowercase author name' );
     my $location = $res->headers->header('location') =~ s{^http://[^/]+}{}r;

--- a/t/controller/release.t
+++ b/t/controller/release.t
@@ -5,8 +5,7 @@ use MetaCPAN::Web::Test qw( app GET test_psgi tx );
 
 test_psgi app, sub {
     my $cb = shift;
-    ok( my $res = $cb->( GET '/release/DOESNTEXIST' ),
-        'GET /release/DOESNTEXIST' );
+    ok( my $res = $cb->( GET '/dist/DOESNTEXIST' ), 'GET /dist/DOESNTEXIST' );
     is( $res->code, 404, 'code 404' );
 
     ok( $res = $cb->( GET '/release/AUTHORDOESNTEXIST/DOESNTEXIST' ),
@@ -17,12 +16,12 @@ test_psgi app, sub {
         'GET /release/PERLER/DOESNTEXIST' );
     is( $res->code, 404, 'code 404' );
 
-    ok( $res = $cb->( GET '/release/Moose' ), 'GET /release/Moose' );
+    ok( $res = $cb->( GET '/dist/Moose' ), 'GET /dist/Moose' );
     is( $res->code, 200, 'code 200' );
 
     my $tx = tx($res);
     $tx->like( '/html/head/title', qr/Moose/, 'title includes Moose' );
-    ok( $tx->find_value('//a[@href="/release/Moose"]'),
+    ok( $tx->find_value('//a[@href="/dist/Moose"]'),
         'contains permalink to resource' );
 
     # Moose 2.1201 has no more Examples and breaks this test,

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -185,10 +185,10 @@ test_psgi app, sub {
             # TODO: search
             # TODO: toggle table of contents (module only)
 
-            my $revdep = $type eq 'module' ? 'module' : 'distribution';
+            my $revdep = $type eq 'module' ? 'module' : 'dist';
             ok(
                 $tx->find_value(
-                    "//a[starts-with(\@href, \"/requires/$revdep/$name\")]"),
+                    "//a[starts-with(\@href, \"/$revdep/$name/requires\")]"),
                 "reverse deps link uses $revdep name"
             );
 

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -89,7 +89,7 @@ test_psgi app, sub {
             my $name = $test->{$type};
             $current = { desc => "$type $name", test => $test };
 
-            my $req_uri = $type eq 'module' ? "/pod/$name" : "/release/$name";
+            my $req_uri = $type eq 'module' ? "/pod/$name" : "/dist/$name";
 
             ok( my $res = $cb->( GET $req_uri ), "GET $req_uri" );
             is( $res->code, 200, 'code 200' );

--- a/t/controller/source.t
+++ b/t/controller/source.t
@@ -31,7 +31,7 @@ test_psgi app, sub {
 
     {
         # Check a URL that is the 'latest', e.g. no version num
-        my $uri = '/source/Moose';
+        my $uri = '/module/Moose/source';
         ok( my $res = $cb->( GET $uri ), "GET $uri" );
         is( $res->code, 200, 'code 200' );
         test_cache_headers(
@@ -61,7 +61,7 @@ test_psgi app, sub {
 
             {
                 xpath    => '//a[text()="Permalink"]/@href',
-                expected => qr{\bsource/[^/]+/Moose-\d+(?:\.\d+){0,}/},
+                expected => qr{\brelease/[^/]+/Moose-\d+(?:\.\d+){0,}/source},
                 desc     => 'Permalink includes specific version'
             },
         );
@@ -83,13 +83,13 @@ test_psgi app, sub {
         # different filetypes below.
         my @tests = (
             {
-                uri      => '/source/RJBS/Dist-Zilla-5.043/bin/dzil',
+                uri      => '/release/RJBS/Dist-Zilla-5.043/source/bin/dzil',
                 xpath    => '//div[@class="content"]/pre/code/@class',
                 expected => qr/\blanguage-perl\b/,
                 desc     => 'has pre-block with expected syntax brush',
             },
             {
-                uri      => '/source/ETHER/Moose-2.1005/README.md',
+                uri      => '/release/ETHER/Moose-2.1005/source/README.md',
                 xpath    => '//h1[@id="moose"]',
                 expected => qr/^Moose$/,
                 desc     => 'markdown rendered as HTML',


### PR DESCRIPTION
This refactors the URLs of the site to be based on the object is is related to, rather than the operation it is. So rather than:

/permission/author/AUTHOR
/permission/distribution/My-Dist
/changes/distribution/My-Dist
/changes/release/AUTHOR/My-Dist-0.01
/contributing-to/My-Dist
/contributing-to/AUTHOR/My-Dist-0.01

The new URLs look like 

/author/AUTHOR/permissions
/dist/My-Dist/permissions
/dist/My-Dist/changes
/dist/My-Dist/contribute
/release/AUTHOR/My-Dist-0.01/changes
/release/AUTHOR/My-Dist-0.01/contributing

This provides better consistency on how to construct future URLs.

The new roots are `/author/$AUTHOR`, `/dist/$dist`, `/release/$AUTHOR/$release`, and `/module/$module`.

`/dist/$dist` serves as the home both for things that are related to the distribution itself, and the latest release. Generally, anything available under `/release/$AUTHOR/$release` is also available under `/dist/$dist`.

This chaining also provides a common place to attach behavior, such as redirecting to upper case authors, instead of needing to replicate that in many actions.

Pod viewing URLs previously all started with `/pod/`. Rather than retaining this naming, the new URLs use `*/view/`. This will allow it to be used for viewing other file types, such as markdown, which currently is done by taking over the source page. The `/pod/` root is maintained for modules, because they will always be using pod.