### PR TITLE
Make scrollable area larger for pod pre areas

### DIFF
--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -57,6 +57,10 @@
         margin-right: 0;
         padding: 10px;
         overflow-x: auto;
+        
+        .syntaxhighlighter {
+            overflow-x: none !important;
+        }
     }
 }
 

--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -56,11 +56,7 @@
         margin-left: 0;
         margin-right: 0;
         padding: 10px;
-        overflow-x: auto;
-        
-        .syntaxhighlighter {
-            overflow-x: none !important;
-        }
+        overflow-x: auto;        
     }
 }
 

--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -56,7 +56,7 @@
         margin-left: 0;
         margin-right: 0;
         padding: 10px;
-        overflow-x: auto;        
+        overflow-x: auto;
     }
 }
 

--- a/root/static/less/syntaxhighlighter.less
+++ b/root/static/less/syntaxhighlighter.less
@@ -1,6 +1,7 @@
 html body .syntaxhighlighter {
     font-size: 100% !important;
     margin: 0 !important;
+    overflow: visible !important;
     /* needs higher specificity than the syntax highligher's rules */
     &, *, * *, * * *, * * * * {
         font-family: inherit !important;


### PR DESCRIPTION
The problem is that `.pod pre` and `.syntaxhighlighter` both apply `overflow` in some way. By turning off `overflow-x` on `.syntaxhighlighter`, we end up with the outer `.pod pre` scroll area, which is larger, since that is the one that applies `padding`. This makes it easier to scroll horizontally on one-line code blocks on mobile.

I noticed this on https://metacpan.org/dist/App-perlimports/view/script/perlimports, it has a lot of examples in the SYNOPSIS that are hard for me with my fat fingers to scroll on my mobile.