### PR TITLE
Prefixed all non-POD related ids with metacpan_

### DIFF
--- a/root/about/contributors.tx
+++ b/root/about/contributors.tx
@@ -23,7 +23,7 @@
       var done = 0;
       return {
         render: function() {
-          $('#author-result-loading').hide();
+          $('#metacpan_author-result-loading').hide();
           $('.author-results').html('<ul class="authors">');
           var el = $('ul.authors');
           var rows = [];
@@ -46,7 +46,7 @@
               +'('+ row.contributions +' '+ (row.contributions === 1 ? 'commit' : 'commits') +')</li>'
             );
           })
-          $('#author-count').html('Number of contributors: ' + rows.length);
+          $('#metacpan_author-count').html('Number of contributors: ' + rows.length);
         },
 
         fetch: function(url) {
@@ -96,8 +96,8 @@
 </script>
 
 <div class="content about">
-  <i class="fa fa-spinner fa-spin" id="author-result-loading"></i>
-  <div id="author-count"></div>
+  <i class="fa fa-spinner fa-spin" id="metacpan_author-result-loading"></i>
+  <div id="metacpan_author-count"></div>
   <div class="author-results"></div>
 </div>
 

--- a/root/account/profile.tx
+++ b/root/account/profile.tx
@@ -115,11 +115,11 @@
                     %%  my $donation = $author.donation.map(-> $d { $d.id }).grep.size();
                     <div class="col-sm-8 col-md-6">
                         <label class="checkbox">
-                            <input name="donations" type="checkbox"[% if $donation { %] checked="checked"[% } %] onchange="$('#donations').slideToggle()" /> Accept donations
+                            <input name="donations" type="checkbox"[% if $donation { %] checked="checked"[% } %] onchange="$('#metacpan_donations').slideToggle()" /> Accept donations
                         </label>
                     </div>
                 </div>
-                <div id="donations"[% if !$donation { %] style="display: none"[% } %]>
+                <div id="metacpan_donations"[% if !$donation { %] style="display: none"[% } %]>
                     %%  my $user_donations = $author.donation.indexed_by('name');
                     %%  for ['PayPal', 'Wishlist', 'Flattr'] -> $system {
                     %%      my $found = $user_donations[$system];
@@ -202,7 +202,7 @@
                     </select>
                 </div>
             </div>
-            <div id="profiles" class="profiles">
+            <div id="metacpan_profiles" class="profiles">
                 <div class="form-group profile profile-metacpan" title="You can use your user id with other services so they can retrieve information from your profile or your favorites here on metacpan.">
                     <label class="col-sm-4 col-md-4 control-label">metacpan</label>
                     <div class="col-sm-8 col-md-6">
@@ -255,7 +255,7 @@ function addProfile(select) {
     var value = select.value;
     var profile = value ? JSON.parse(value) : null;
     select.selectedIndex = 0;
-    var container = $('#profiles');
+    var container = $('#metacpan_profiles');
     var html = '<div style="display: none" class="form-group'
     if (value) {
         html += ' profile profile-' + profile.id;
@@ -320,13 +320,10 @@ function addField(id) {
 }
 
 function fillLocation() {
-    $('#busy').show();
     navigator.geolocation.getCurrentPosition(function(pos) {
-        $('#busy').hide();
         $('input[name="latitude"]').val(pos.coords.latitude);
         $('input[name="longitude"]').val(pos.coords.longitude);
     }, function(){
-        $('#busy').hide();
     });
     return false;
 }

--- a/root/author.tx
+++ b/root/author.tx
@@ -137,13 +137,13 @@
 %%  }
 %%  override content -> {
 <div class="content">
-    <div id="feed_subscription" class="page-header">
+    <div id="metacpan_feed_subscription" class="page-header">
         <p>[% if $releases.0 { $releases.size() } else { 'No' } %] distributions uploaded by <span class="author-name">[% $author.name %]</span> ([% $author.pauseid %])</p>
         <a href="/author/[% $author.pauseid %]/activity.rss"><i class="fa fa-rss fa-2x black"></i></a>
     </div>
     <div class="visible-xs inline-author-pic">[% include inc::author_pic %]</div>
     %%  if $releases.0 {
-        %%  include inc::release_table { header => 1, tablesorter => 1, table_id => 'author_releases' }
+        %%  include inc::release_table { header => 1, tablesorter => 1, table_id => 'metacpan_author_releases' }
     %%  }
     %%  else {
     <div class="message">

--- a/root/base.tx
+++ b/root/base.tx
@@ -183,7 +183,7 @@
                     <form action="/search" class="search-form form-horizontal">
                         <div class="form-group">
                             <div class="input-group">
-                                <input type="text" name="q" size="41" id="search-input" class="form-control" value="[% $search_query %]">
+                                <input type="text" name="q" size="41" id="metacpan_search-input" class="form-control" value="[% $search_query %]">
                                 <span class="input-group-btn">
                                     <button class="btn search-btn" type="submit">Search</button>
                                     <button class="btn search-btn help-btn">?</button>
@@ -262,7 +262,7 @@
             </div>
             %%  }
         </div>
-        <div class="modal fade" tabindex="-1" role="dialog" id="keyboard-shortcuts">
+        <div class="modal fade" tabindex="-1" role="dialog" id="metacpan_keyboard-shortcuts">
           <div class="modal-dialog">
             <div class="modal-content">
               <div class="modal-header">

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -141,7 +141,7 @@
       </a>
     </li>
     <li>
-      <button class="btn btn-link" data-toggle="modal" data-target="#install-instructions-dialog">
+      <button class="btn btn-link" data-toggle="modal" data-target="#metacpan_install-instructions-dialog">
         <i class="fa fa-terminal fa-fw black"></i>Install Instructions
       </button>
     </li>
@@ -200,8 +200,8 @@
     %%  }
 %%  }
 %%  override content -> {
-<button id="right-panel-toggle" class="btn-link" onclick="togglePanel('right'); return false;"><span class="panel-hidden">Show</span><span class="panel-visible">Hide</span> Right Panel</button>
-<div id="right-panel" class="pull-right">
+<button id="metacpan_right-panel-toggle" class="btn-link" onclick="togglePanel('right'); return false;"><span class="panel-hidden">Show</span><span class="panel-visible">Hide</span> Right Panel</button>
+<div id="metacpan_right-panel" class="pull-right">
   <div class="box-right hidden-phone">
     %%  include inc::plussers { plussers => $plussers };
 

--- a/root/home.tx
+++ b/root/home.tx
@@ -27,9 +27,9 @@
   <a href="/" class="big-logo" alt="meta::cpan"></a>
   <h4>A search engine for <a href="https://www.cpan.org">CPAN</a></h4>
   <form action="/search">
-    <input type="hidden" name="size" id="search-size" value="20">
+    <input type="hidden" name="size" id="metacpan_search-size" value="20">
     <div class="form-group">
-        <input type="text" name="q" size="41" autofocus="autofocus" autocorrect="off" autocapitalize="off" spellcheck="false" id="search-input" class="form-control home-search-input">
+        <input type="text" name="q" size="41" autofocus="autofocus" autocorrect="off" autocapitalize="off" spellcheck="false" id="metacpan_search-input" class="form-control home-search-input">
     </div>
     <div class="form-group">
         <button type="submit" class="btn search-btn">Search the CPAN</button>

--- a/root/inc/contributors.tx
+++ b/root/inc/contributors.tx
@@ -1,9 +1,9 @@
 %% if $contributors.size() {
-<div id="contributors">
+<div id="metacpan_contributors">
   <div class="contributors-header">and [% $contributors.size() %] contributors</div>
   <div align="right">
     <button class="btn-link"
-      onclick="$(this).hide(); $('#contributors ul').slideDown(); return false;"
+      onclick="$(this).hide(); $('#metacpan_contributors ul').slideDown(); return false;"
     >show them</button>
   </div>
   <ul class="nav nav-list box-right" style="display: none">

--- a/root/inc/favorite_table.tx
+++ b/root/inc/favorite_table.tx
@@ -7,7 +7,7 @@
   %%    $per_day && $day != datetime($~favorite.peek_next.date).strftime("%F");
 
   %%  if $day_start {
-<table id="author_favorites"
+<table id="metacpan_author_favorites"
   %%  if $tablesorter {
   data-default-sort="[% $default_sort || '0,0' %]"
   %%  }

--- a/root/inc/module_install.tx
+++ b/root/inc/module_install.tx
@@ -1,4 +1,4 @@
-<div id="install-instructions-dialog" class="modal fade">
+<div id="metacpan_install-instructions-dialog" class="modal fade">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/root/inc/notification/base.tx
+++ b/root/inc/notification/base.tx
@@ -1,9 +1,9 @@
 <input id="[% $type %]" type="checkbox" class="notification-toggle-checkbox" />
-<div id="notification" class="well collapsed notify-[% $type %]">
+<div id="metacpan_notification" class="well collapsed notify-[% $type %]">
     <label class="remove-notification" for="[% $type %]" >
       <i class="fa fa-fw fa-close black"></i>
     </label>
-    <div id="notification-container">
+    <div id="metacpan_notification-container">
       <h2>[% $title %]</h2>
       <div>
         %%  block text -> { }

--- a/root/no_result.tx
+++ b/root/no_result.tx
@@ -17,7 +17,7 @@
 %%  }
 %%  else {
   <div class="jumbotron">
-        <p class="nav-header" id="header-text-noresult">Something missing?
+        <p class="nav-header" id="metacpan_header-text-noresult">Something missing?
             <a href="/about/missing_modules">Find out why</a>
         </p>
         <h2>No result.</h2>

--- a/root/recent.tx
+++ b/root/recent.tx
@@ -5,7 +5,7 @@
 %%  }
 %%  override content -> {
 <div class="content">
-  <div id="feed_subscription" class="page-header">
+  <div id="metacpan_feed_subscription" class="page-header">
     <p>Recent Uploads</p>
       <a href="/recent.rss [% if $filter { '?f=' ~ $filter } %]"><i class="fa fa-rss fa-2x black"></i></a>
   </div>

--- a/root/release.tx
+++ b/root/release.tx
@@ -13,8 +13,8 @@
   %%  }
 </ul>
 %%  }
-<div id="last-changes" class="well">
-  <div id="last-changes-container">
+<div id="metacpan_last-changes" class="well">
+  <div id="metacpan_last-changes-container">
     %%  for $changes -> $rel {
     <h2 id="whatsnew">Changes for version [% $rel.version %][% if $rel.date && datetime($rel.date) { %] - [% datetime($rel.date).to_ymd() } if $rel.trial { %] (TRIAL RELEASE)[% } %]</h2>
     <div class="change-entries">
@@ -22,7 +22,7 @@
     </div>
     %%  }
   </div>
-  <button id="last-changes-toggle" class="btn-link" onclick="$('#last-changes').toggleClass('collapsed'); return false;">[ <span class="hide-more">Show less</span><span class="show-more">Show more</span> ]</button>
+  <button id="metacpan_last-changes-toggle" class="btn-link" onclick="$('#metacpan_last-changes').toggleClass('collapsed'); return false;">[ <span class="hide-more">Show less</span><span class="show-more">Show more</span> ]</button>
 </div>
 %%  }
 

--- a/root/source.tx
+++ b/root/source.tx
@@ -52,7 +52,7 @@
     [% $source | markdown | filter_html %]
   %%  }
   %%  else {
-<pre id="source" class="line-numbers pod-toggle[% if $file.sloc > 10 { " pod-hidden"; } %]" data-pod-lines="[%
+<pre id="metacpan_source" class="line-numbers pod-toggle[% if $file.sloc > 10 { " pod-hidden"; } %]" data-pod-lines="[%
   $file.pod_lines.map(-> $lines { $lines[0] ~ '-' ~ ($lines[0]+$lines[1]) }).join(', ');
 %]"><code class="language-[% $filetype %]">[% $source %]</code></pre>
   %%  }

--- a/root/static/css/jquery.autocomplete.css
+++ b/root/static/css/jquery.autocomplete.css
@@ -51,6 +51,6 @@ div.autocomplete-suggestions div:nth-child(2n+2) {
     show them under "Authors"
     GH #1707, Dan McCormick
 */
-#autocomplete-direct-results:before {
+#metacpan_autocomplete-direct-results:before {
   content: 'Authors'
 }

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -37,7 +37,7 @@ $.extend({
 });
 
 function togglePanel(side, visible) {
-    var elements = $('#' + side + '-panel-toggle').add($('#' + side + '-panel'));
+    var elements = $('#metacpan_' + side + '-panel-toggle').add($('#metacpan_' + side + '-panel'));
     var className = 'panel-hide';
     if (typeof visible == "undefined") {
         visible = elements.first().hasClass(className);
@@ -91,17 +91,17 @@ $(document).ready(function() {
 
     $('.help-btn').each(function() {
         $(this).click(function(event) {
-            $('#keyboard-shortcuts').modal();
+            $('#metacpan_keyboard-shortcuts').modal();
             event.preventDefault();
         })
     });
 
     // Global keyboard shortcuts
     Mousetrap.bind('?', function() {
-        $('#keyboard-shortcuts').modal();
+        $('#metacpan_keyboard-shortcuts').modal();
     });
     Mousetrap.bind('s', function(e) {
-        $('#search-input').focus();
+        $('#metacpan_search-input').focus();
         e.preventDefault();
     });
 
@@ -144,7 +144,8 @@ $(document).ready(function() {
 
         var sortid;
         if (table.attr('id')) {
-            sortid = MetaCPAN.storage.getItem("tablesorter:" + table.attr('id'));
+            var storageid = table.attr('id').replace(/^metacpan_/, '');
+            sortid = MetaCPAN.storage.getItem("tablesorter:" + storageid);
         }
         if (!sortid && table.attr('data-default-sort')) {
             sortid = table.attr('data-default-sort');
@@ -192,7 +193,7 @@ $(document).ready(function() {
     $('.relatize').relatizeDate();
 
     // Search box: Feeling Lucky? Shift+Enter
-    $('#search-input').keydown(function(event) {
+    $('#metacpan_search-input').keydown(function(event) {
         if (event.keyCode == '13' && event.shiftKey) {
             event.preventDefault();
 
@@ -215,7 +216,7 @@ $(document).ready(function() {
     // #441 Allow more specific queries to send ("Ty", "Type::").
     // #744/#993 Don't select things if the mouse pointer happens to be over the dropdown when it appears.
     // Please don't steal ctrl-pg up/down.
-    var search_input = $("#search-input");
+    var search_input = $("#metacpan_search-input");
     var input_group = search_input.parent('.input-group');
     var ac_width = (input_group.length ? input_group : search_input).outerWidth();
     search_input.autocomplete({
@@ -263,7 +264,7 @@ $(document).ready(function() {
     $('.autocomplete-suggestions').off('mouseover.autocomplete');
     $('.autocomplete-suggestions').off('mouseout.autocomplete');
 
-    $('#search-input.autofocus').focus();
+    $('#metacpan_search-input.autofocus').focus();
 
     var items = $('.ellipsis');
     for (var i = 0; i < items.length; i++) {
@@ -302,7 +303,7 @@ $(document).ready(function() {
     }
     create_anchors($('.anchors'));
 
-    var module_source_href = $('#source-link').attr('href');
+    var module_source_href = $('#metacpan_source-link').attr('href');
     if (module_source_href) {
         $('.pod-errors-detail dt').each(function() {
             var $dt = $(this);
@@ -321,11 +322,12 @@ $(document).ready(function() {
 
     $('table.tablesorter th.header').on('click', function() {
         tableid = $(this).parents().eq(2).attr('id');
+        var storageid = tableid.replace(/^metacpan_/, '');
         setTimeout(function() {
             var sortParam = $.getUrlVar('sort');
             if (sortParam != null) {
                 sortParam = sortParam.slice(2, sortParam.length - 2);
-                MetaCPAN.storage.setItem("tablesorter:" + tableid, sortParam);
+                MetaCPAN.storage.setItem("tablesorter:" + storageid, sortParam);
             }
         }, 1000);
     });
@@ -381,7 +383,7 @@ $(document).ready(function() {
     });
     var size = MetaCPAN.storage.getItem('search_size');
     if (size) {
-        $('#search-size').val(size);
+        $('#metacpan_search-size').val(size);
     }
 
     // TODO use a more specific locator for /author/PAUSID/release ?
@@ -389,9 +391,9 @@ $(document).ready(function() {
     set_page_size('a[href*="/recent"]', 'recent_page_size');
     set_page_size('a[href*="/requires"]', 'requires_page_size');
 
-    var changes = $('#last-changes');
-    var changes_inner = $('#last-changes-container');
-    var changes_toggle = $("#last-changes-toggle");
+    var changes = $('#metacpan_last-changes');
+    var changes_inner = $('#metacpan_last-changes-container');
+    var changes_toggle = $("#metacpan_last-changes-toggle");
     changes.addClass(['collapsable', 'collapsed']);
     var changes_content_height = Math.round(changes_inner.prop('scrollHeight'));
     var changes_ui_height = Math.round(changes_inner.height() + changes_toggle.height());

--- a/root/static/less/author.less
+++ b/root/static/less/author.less
@@ -67,7 +67,7 @@
     }
 }
 
-#feed_subscription {
+#metacpan_feed_subscription {
     &.page-header {
         margin: 0 0 5px;
         font-weight: bold;

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -283,7 +283,7 @@ a.ellipsis:hover * {
 /* Contributors list on release pages
 * see /release/Plack for example
 */
-#contributors {
+#metacpan_contributors {
     min-height: 40px;
 
     > ul {
@@ -323,7 +323,7 @@ a.ellipsis:hover * {
     line-height: 2.5em;
 }
 
-#header-text-noresult {
+#metacpan_header-text-noresult {
     padding-left: 0px;
     font-size: 14px;
 }
@@ -357,7 +357,7 @@ h1, .h1, h2, .h2, h3, .h3 {
     -webkit-overflow-scrolling: touch;
 }
 
-input#search-input {
+input#metacpan_search-input {
     font-size: 16px;
     padding: 4px 12px;
     height: 30px;
@@ -389,7 +389,7 @@ input#search-input {
     font-style: italic;
 }
 
-form#logout {
+form#metacpan_logout {
     display: none;
 }
 
@@ -473,7 +473,7 @@ form#logout {
     .img-retina('/static/images/metacpan-logo.png', '/static/images/metacpan-logo@2x.png', 326px, 92px);
 }
 
-#right-panel-toggle {
+#metacpan_right-panel-toggle {
   position: absolute;
   top: -10px;
   right: 0;
@@ -525,7 +525,7 @@ form#logout {
   }
 }
 
-#right-panel.panel-hide {
+#metacpan_right-panel.panel-hide {
     display: none;
 }
 

--- a/root/static/less/home.less
+++ b/root/static/less/home.less
@@ -5,7 +5,7 @@
         font-size: 1.2em;
     }
 
-    #search-input {
+    #metacpan_search-input {
         width: 400px;
         margin: 0px;
         height: 30px;

--- a/root/static/less/lab.less
+++ b/root/static/less/lab.less
@@ -22,8 +22,3 @@
         color: #900;
     }
 }
-
-#lab {
-    margin-top: -25px;
-    margin-bottom: 50px;
-}

--- a/root/static/less/notification.less
+++ b/root/static/less/notification.less
@@ -1,4 +1,4 @@
-#notification {
+#metacpan_notification {
     margin-bottom: 15px;
     overflow: auto;
     position: relative;
@@ -8,7 +8,7 @@
     display: none;
 }
 
-.notification-toggle-checkbox:checked ~ #notification {
+.notification-toggle-checkbox:checked ~ #metacpan_notification {
     max-height: 0;
     border: none;
     min-height: 0;
@@ -24,7 +24,7 @@ label.remove-notification {
     cursor: pointer;
 }
 
-#notification h2 {
+#metacpan_notification h2 {
     display: block;
     font-weight: bold;
     font-size: 100%;

--- a/root/static/less/print.less
+++ b/root/static/less/print.less
@@ -12,7 +12,7 @@
         .footer + div,
         .footer + div + div,
         .toggle-index,
-        #right-panel-toggle,
+        #metacpan_right-panel-toggle,
         .toggle-index-right {
             display: none !important;
         }

--- a/root/static/less/release.less
+++ b/root/static/less/release.less
@@ -44,7 +44,7 @@
 /* Changes in release page
  * See /release/CPAN-Changes for example
  */
-#last-changes {
+#metacpan_last-changes {
     h2:extend(.content .file-group h2) {}
 
     ul {
@@ -60,7 +60,7 @@
     }
 
     &.collapsable {
-        #last-changes-toggle {
+        #metacpan_last-changes-toggle {
             display: inline-block;
         }
 
@@ -70,18 +70,18 @@
             .show-more { display: inline }
             .hide-more { display: none }
 
-            #last-changes-container {
+            #metacpan_last-changes-container {
                 overflow: hidden;
                 max-height: 20.02em;
             }
         }
     }
 
-    #last-changes-toggle {
+    #metacpan_last-changes-toggle {
         display: none;
     }
 
-    #last-changes-container {
+    #metacpan_last-changes-container {
         margin-bottom: 0.5em;
     }
     padding-bottom: 0.5em;

--- a/root/static/less/responsive.less
+++ b/root/static/less/responsive.less
@@ -134,7 +134,7 @@
         padding-top: 0px;
     }
 
-    body .home #search-input {
+    body .home #metacpan_search-input {
         width: 93%;
         font-size: 1.4em;
     }
@@ -197,10 +197,6 @@
 
     .pull-left-phone {
         float: left !important;
-    }
-
-    #map {
-        margin-right: 0px !important;
     }
 
     .releases td.name {

--- a/t/controller/author.t
+++ b/t/controller/author.t
@@ -24,7 +24,8 @@ test_psgi app, sub {
 
     ok(
         $tx->find_value(
-            '//table[@id="author_favorites"]//tbody/tr[1]/td[1]//a/@href'),
+            '//table[@id="metacpan_author_favorites"]//tbody/tr[1]/td[1]//a/@href'
+        ),
         'found a favorite'
     );
 

--- a/t/controller/changes.t
+++ b/t/controller/changes.t
@@ -12,7 +12,7 @@ test_psgi app, sub {
         is( $res->code, 200, "200 on $url" );
         my $tx = tx($res);
         $tx->like(
-            '//div[contains-token(@class, "content")]//pre[@id="source"]',
+            '//div[contains-token(@class, "content")]//pre[@id="metacpan_source"]',
             qr/^Revision history for File-Spec-Native/,
             'source view for plain text change log'
         );


### PR DESCRIPTION
Prefixed all non-POD related ids with metacpan_

Also left out #index* ids since those also come from pod2html according to discussion in the #metacpan channel on irc.perl.org

This is to address issue #1590