### PR TITLE
Remove sponsor logos from last meta::hack

### DIFF
--- a/root/home.tx
+++ b/root/home.tx
@@ -37,23 +37,5 @@
         <button class="btn search-btn help-btn">?</button>
     </div>
   </form>
-  <div class="news-highlight row">
-    <div class="col-xs-12 col-sm-8 col-sm-push-2 col-md-6 col-md-push-3">
-      <p>
-        MetaCPAN would like to thank the following sponsors of <a
-        href="/about/meta_hack">meta::hack v4</a>:
-      </p>
-      <div class="row sponsor-grid">
-        <div class="col-sm-4">
-          <!-- cPanel remains until Apr 1, 2020 -->
-          <a href="https://cpanel.com/" target="_blank" rel="noopener"><img src="/static/images/sponsors/cpanel.png" width="180"></a>
-        </div>
-        <div class="col-sm-4 col-sm-push-4">
-          <!-- booking remains until Apr 1, 2020 -->
-          <a href="https://booking.com" target="_blank" rel="noopener" class="pull-right"><img src="/static/images/sponsors/booking.png"></a>
-        </div>
-      </div>
-    </div>
-  </div>
 </div>
 %%  }


### PR DESCRIPTION
These were to have been removed in April of 2020.