### PR TITLE
Fixed source highlighting/line number links not showing due to a miss…

### DIFF
--- a/root/static/js/syntaxhighlighter.js
+++ b/root/static/js/syntaxhighlighter.js
@@ -99,7 +99,7 @@ $(function () {
     };
 
 
-    var source = $("#source");
+    var source = $("#metacpan_source");
     if (source.length) {
         var lineMatch;
         var packageMatch;


### PR DESCRIPTION
…ed prefix for #source in syntaxhighlighter.js

Related to issue #1590 and pull #2530