### PR TITLE
update to new fontawesome icon names

### DIFF
--- a/root/account/identities.tx
+++ b/root/account/identities.tx
@@ -18,7 +18,7 @@
                 </form>
             %%  }
             %%  else {
-                <a class="btn btn-block btn-success" href="/login/[% $identity.lc() %]"><span class="fa fa-external-link"></span> Connect</a>
+                <a class="btn btn-block btn-success" href="/login/[% $identity.lc() %]"><span class="fa fa-external-link-alt"></span> Connect</a>
             %%  }
         </td>
     </tr>

--- a/root/account/profile.tx
+++ b/root/account/profile.tx
@@ -225,7 +225,7 @@
                         <div class="input-group">
                             <input class="small form-control" type="text" class="form-control" name="profile.id" value="[% $profile.id %]" />
                             <span class="input-group-btn">
-                            <a href="" class="btn btn-danger remove" onclick="return removeDiv(this.parentNode.parentNode.parentNode)"><i class="fa fa-trash"></i> remove</a>
+                            <a href="" class="btn btn-danger remove" onclick="return removeDiv(this.parentNode.parentNode.parentNode)"><i class="fa fa-trash-alt"></i> remove</a>
                             %%  if $known {
                             <a href="" class="btn search-btn" target="_blank" tmpl="[% $known.url_format %]" onclick="return rewriteURL(this)"><i class="fa fa-check-square"></i> check</a>
                             </span>
@@ -270,7 +270,7 @@ function addProfile(select) {
     html += '</label>'
     html += '<div class="col-sm-8 col-md-6"><div class="input-group">'
         + '<input type="text" class="form-control" name="profile.id" /> '
-        + '<span class="input-group-btn"><a href="" class="btn btn-danger" class="check" onclick="return removeDiv(this.parentNode.parentNode.parentNode)"><i class="fa fa-trash"></i> remove</a> ';
+        + '<span class="input-group-btn"><a href="" class="btn btn-danger" class="check" onclick="return removeDiv(this.parentNode.parentNode.parentNode)"><i class="fa fa-trash-alt"></i> remove</a> ';
     if (value) {
         html += '<a href="" class="btn search-btn" tmpl="' + profile.url + '" onclick="return rewriteURL(this)" target="_blank"><i class="fa fa-check-square"></i> check</a>';
     }

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -49,7 +49,7 @@
     </li>
     %%  if $release.resources.homepage.is_url() {
     <li>
-      <a rel="noopener nofollow" class="nopopup" href="[% $release.resources.homepage %]"><i class="fa fa-fw fa-external-link black"></i>Homepage</a>
+      <a rel="noopener nofollow" class="nopopup" href="[% $release.resources.homepage %]"><i class="fa fa-fw fa-external-link-alt black"></i>Homepage</a>
     </li>
     %%  }
     <li>
@@ -58,13 +58,13 @@
     %%  if $release.resources.repository {
     <li>
       %%  if $release.resources.repository.web.is_url() {
-        <a rel="noopener nofollow" data-keyboard-shortcut="g r" href="[% $release.resources.repository.web %]"><i class="fa fa-fw fa-code-fork black"></i>Repository</a>
+        <a rel="noopener nofollow" data-keyboard-shortcut="g r" href="[% $release.resources.repository.web %]"><i class="fa fa-fw fa-code-branch black"></i>Repository</a>
       %%  }
       %%  if $release.resources.repository.web.is_url() && $release.resources.repository.url.is_url() {
         (<a rel="noopener nofollow" href="[% $release.resources.repository.url %]">[% $release.resources.repository.type %] clone</a>)
       %%  }
       %%  else if $release.resources.repository.url.is_url() {
-        <a rel="noopener nofollow" href="[% $release.resources.repository.url %]"><i class="fa fa-fw fa-code-fork black"></i>Clone [% $release.resources.repository.type %] repository</a>
+        <a rel="noopener nofollow" href="[% $release.resources.repository.url %]"><i class="fa fa-fw fa-code-branch black"></i>Clone [% $release.resources.repository.type %] repository</a>
       %%  }
     </li>
     %%  }
@@ -82,11 +82,11 @@
         %%  }
     </li>
     <li>
-      <a rel="noopener nofollow" href="http://cpants.cpanauthors.org/release/[% $release.author %]/[% $release.name %]"><i class="fa fa-fw fa-line-chart black"></i>Kwalitee</a>
+      <a rel="noopener nofollow" href="http://cpants.cpanauthors.org/release/[% $release.author %]/[% $release.name %]"><i class="fa fa-fw fa-chart-line black"></i>Kwalitee</a>
     </li>
     %%  if $coverage.url {
     <li>
-      <i class="fa fa-fw fa-pie-chart black"></i><a rel="noopener nofollow" href="[% $coverage.url %]">[% $coverage.criteria.total %]% Coverage </a>
+      <i class="fa fa-fw fa-chart-pie black"></i><a rel="noopener nofollow" href="[% $coverage.url %]">[% $coverage.criteria.total %]% Coverage </a>
     </li>
     %%  }
     %%  if $release.license {

--- a/root/browse.tx
+++ b/root/browse.tx
@@ -17,7 +17,7 @@
   <li class="nav-header">Tools</li>
   <li><a data-keyboard-shortcut="g d" href="/release/[% $author %]/[% $release %]"><i class="fa fa-fw fa-info-circle black"></i>Release Info</a></li>
   <li><a data-keyboard-shortcut="g a" href="/author/[% $author %]"><i class="fa fa-user fa-fw black"></i>Author</a></li>
-  <li><a href="[% $source_host %]/source/[% [$author, $release].merge($directory).join('/') %]"><i class="fa fa-file-text fa-fw black"></i>Raw browser</a></li>
+  <li><a href="[% $source_host %]/source/[% [$author, $release].merge($directory).join('/') %]"><i class="fa fa-file-alt fa-fw black"></i>Raw browser</a></li>
   <li class="nav-header">Info</li>
   %%  my $folder_count = $files.map(-> $f { $f.directory ? 1 : 0 }).sum();
   %%  my $file_count = $files.size() - $folder_count;

--- a/root/inc/notification/base.tx
+++ b/root/inc/notification/base.tx
@@ -1,7 +1,7 @@
 <input id="[% $type %]" type="checkbox" class="notification-toggle-checkbox" />
 <div id="metacpan_notification" class="well collapsed notify-[% $type %]">
     <label class="remove-notification" for="[% $type %]" >
-      <i class="fa fa-fw fa-close black"></i>
+      <i class="fa fa-fw fa-times black"></i>
     </label>
     <div id="metacpan_notification-container">
       <h2>[% $title %]</h2>

--- a/root/login/openid.tx
+++ b/root/login/openid.tx
@@ -8,7 +8,7 @@
                 <input type="hidden" name="client_id" value="[% $consumer_key %]">
                 <div class="input-group">
                     <span class="input-group-addon">
-                        <i class="fa fa-openid fa-fw"></i>
+                        <i class="fab fa-openid fa-fw"></i>
                     </span>
                     <input type="text" class="form-control" name="openid_identifier">
                     <span class="input-group-btn">

--- a/root/source.tx
+++ b/root/source.tx
@@ -32,13 +32,13 @@
     <a data-keyboard-shortcut="g a" href="/author/[% $file.author %]"><i class="fa fa-user fa-fw black"></i>Author</a>
   </li>
   <li>&nbsp;</li>
-  <li><a href="[% $api_public ~ '/source/' ~ $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]"><i class="fa fa-file-text fa-fw black"></i>Raw code</a></li>
+  <li><a href="[% $api_public ~ '/source/' ~ $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]"><i class="fa fa-file-alt fa-fw black"></i>Raw code</a></li>
   <li><a href="/release/[% $file.author ~ '/' ~ $file.release ~ '/source/' ~ $file.path %]"><i class="fa fa-link fa-fw black"></i>Permalink</a></li>
   <li>
     <a href="/release/[% $file.author ~ '/' ~ $file.release ~ '/raw/' ~ $file.path %]?download=1"><i class="fa fa-download fa-fw black"></i>Download</a>
   </li>
   %%  if $file.sloc {
-  <li><button class="btn-link pod-toggle pod-hidden" onclick="togglePod()"><i class="fa fa-exchange fa-fw black"></i><span class="hide-pod">Hide</span><span class="show-pod">Show</span> Pod</button></li>
+  <li><button class="btn-link pod-toggle pod-hidden" onclick="togglePod()"><i class="fa fa-exchange-alt fa-fw black"></i><span class="hide-pod">Hide</span><span class="show-pod">Show</span> Pod</button></li>
   %%  }
   <li class="nav-header">Info</li>
   <li>[% $file.sloc %] lines of code</li>

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -342,7 +342,7 @@ $(document).ready(function() {
 
         var index_hidden = MetaCPAN.storage.getItem('hideTOC') == 1;
         index.before(
-            '<div class="index-header"><b>Contents</b>' + ' [ <button class="btn-link toggle-index"><span class="toggle-show">show</span><span class="toggle-hide">hide</span></button> ]' + ' <button class="btn-link toggle-index-right"><i class="fa fa-toggle-right"></i><i class="fa fa-toggle-left"></i></button>' + '</div>');
+            '<div class="index-header"><b>Contents</b>' + ' [ <button class="btn-link toggle-index"><span class="toggle-show">show</span><span class="toggle-hide">hide</span></button> ]' + ' <button class="btn-link toggle-index-right"><i class="fa fa-caret-square-right"></i><i class="fa fa-caret-square-left"></i></button>' + '</div>');
 
         $('.toggle-index').on('click', function(e) {
             e.preventDefault();

--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -117,7 +117,7 @@ ul#index, #index ul {
         margin: -6px -7px 0 -7px;
     }
 
-    .fa-toggle-left {
+    .fa-caret-square-left {
         display: none;
     }
 
@@ -128,11 +128,11 @@ ul#index, #index ul {
             overflow-x: auto;
         }
 
-        .fa-toggle-right {
+        .fa-caret-square-right {
             display: none;
             visibility: collapse;
         }
-        .fa-toggle-left {
+        .fa-caret-square-left {
             display: inline-block;
         }
     }


### PR DESCRIPTION
Some icon names have changed over time, or we were using aliases. Update
to the new names so we don't need the shims.