### PR TITLE
improve right aligned index toggle

### DIFF
--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -342,7 +342,7 @@ $(document).ready(function() {
 
         var index_hidden = MetaCPAN.storage.getItem('hideTOC') == 1;
         index.before(
-            '<div class="index-header"><b>Contents</b>' + ' [ <button class="btn-link toggle-index"><span class="toggle-show">show</span><span class="toggle-hide">hide</span></button> ]' + ' <button class="btn-link toggle-index-right"><i class="fa fa-caret-square-right"></i><i class="fa fa-caret-square-left"></i></button>' + '</div>');
+            '<div class="index-header"><b>Contents</b>' + ' [ <button class="btn-link toggle-index"><span class="toggle-show">show</span><span class="toggle-hide">hide</span></button> ]' + ' <button class="btn-link toggle-index-right"><i class="far fa-caret-square-right toggle-right"></i><i class="far fa-caret-square-left toggle-left"></i></button>' + '</div>');
 
         $('.toggle-index').on('click', function(e) {
             e.preventDefault();

--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -117,7 +117,7 @@ ul#index, #index ul {
         margin: -6px -7px 0 -7px;
     }
 
-    .fa-caret-square-left {
+    .toggle-left {
         display: none;
     }
 
@@ -128,11 +128,11 @@ ul#index, #index ul {
             overflow-x: auto;
         }
 
-        .fa-caret-square-right {
+        .toggle-right {
             display: none;
             visibility: collapse;
         }
-        .fa-caret-square-left {
+        .toggle-left {
             display: inline-block;
         }
     }

--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -1,5 +1,6 @@
 @import "../modules/bootstrap-v3.4.1/less/bootstrap.less";
 @import "../modules/fontawesome-5.15.3/less/fontawesome.less";
+@import "../modules/fontawesome-5.15.3/less/regular.less";
 @import "../modules/fontawesome-5.15.3/less/solid.less";
 @import "../modules/fontawesome-5.15.3/less/brands.less";
 


### PR DESCRIPTION
Most icons on the site are solid icons, but the toggle for the right
aligned index looks significantly better using the regular icon.

Also adjust the CSS to not rely on the fontawesome icon classes.