### PR TITLE
fix /dist/$dist/changes urls

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Changes.pm
+++ b/lib/MetaCPAN/Web/Controller/Changes.pm
@@ -52,7 +52,14 @@ sub get : Private {
     elsif ( $file->{documentation} ) {
 
         # Is there a better way to reuse the pod view?
-        $c->forward( '/view/release', [ $file->{path} ] );
+        $c->forward(
+            (
+                $c->{stash}->{distribution_name}
+                ? '/view/dist'
+                : '/view/release'
+            ),
+            [ $file->{path} ]
+        );
     }
     else {
         $c->stash( { file => $file } );


### PR DESCRIPTION
For changes urls under /dist/, it was forwarding to the /view/release
action, which expects the author and release in the stash. Instead,
forward to /view/dist, which works with the distribution name.