### PR TITLE
update CSS used for release maturity banner to avoid page specific classes

### DIFF
--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -40,7 +40,7 @@
     %%    ? '/release/' ~ $release.author ~ '/' ~ $release.name
     %%    : '/dist/' ~ $release.distribution;
     <li class="nav-header"><span class="relatize">[% datetime($release.date).to_http %]</span></li>
-    %%  include inc::release_status { maturity => $release.maturity, banner_class => 'release-banner' }
+    %%  include inc::release_status { maturity => $release.maturity }
     %%  block left_nav_lead -> {
     <li><a href="[% $release_base %]/source"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="[% $release_base %]/source?raw=1">raw</a>)</li>
     %%  }

--- a/root/browse.tx
+++ b/root/browse.tx
@@ -13,7 +13,7 @@
 </div>
 %%  }
 %%  override left_nav_content -> {
-  %%  include inc::release_status { maturity => $maturity, banner_class => 'release-banner-source' }
+  %%  include inc::release_status { maturity => $maturity }
   <li class="nav-header">Tools</li>
   <li><a data-keyboard-shortcut="g d" href="/release/[% $author %]/[% $release %]"><i class="fa fa-fw fa-info-circle black"></i>Release Info</a></li>
   <li><a data-keyboard-shortcut="g a" href="/author/[% $author %]"><i class="fa fa-user fa-fw black"></i>Author</a></li>

--- a/root/inc/release_status.tx
+++ b/root/inc/release_status.tx
@@ -1,7 +1,5 @@
 %%  if $maturity == 'developer' {
-<li>
-  <span class="dist-release maturity-developer">
-    <b class="[% $banner_class %]">Development release</b>
-  </span>
+<li class="release-banner maturity-[% $maturity %]">
+  Development release
 </li>
 %%  }

--- a/root/source.tx
+++ b/root/source.tx
@@ -13,7 +13,7 @@
 </div>
 %%  }
 %%  override left_nav_content -> {
-  %%  include inc::release_status { maturity => $maturity, banner_class => 'release-banner-source' }
+  %%  include inc::release_status { maturity => $maturity }
   <li class="nav-header">Tools</li>
   <li>
     <a data-keyboard-shortcut="g d" href="/release/[% $file.author %]/[% $file.release %]"><i class="fa fa-info-circle fa-fw black"></i>Release Info</a>

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -559,19 +559,27 @@ form#metacpan_logout {
         font-weight: bold;
     }
 
-    &.maturity-developer .release-banner {
+}
+
+.release-banner {
+    padding: 0px 4px;
+    border-radius: 4px;
+    display: inline-block;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    font-weight: bold;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #fff;
+
+    &.maturity-developer {
         color: #fff;
         background-color: #D9534F;
-        padding: 0px 4px;
-        border-radius: 4px;
-        display: inline-block;
-        margin-top: 5px;
-        margin-bottom: 10px;
+        border-style: none;
     }
+}
 
-    &.maturity-developer .release-banner-source {
-        &:extend(.dist-release.maturity-developer .release-banner all);
-        margin-top: 10px;
-        margin-bottom: 5px;
-    }
+.nav-list li.nav-header + li.release-banner,
+.nav-list li.release-banner + li.nav-header {
+    margin-top: 5px;
 }


### PR DESCRIPTION
Rather than needing specific classes for different pages, use the
surrounding tags to adjust the padding. Move the related css out of the
breadcrumb related classes, since they have essentially nothing in
common. Also eliminates a use of .extend(), which is a potentially
confusing less feature which we should move away from.