### PR TITLE
Add tooltip to release date (Issue #2518)

### DIFF
--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -41,7 +41,7 @@
     %%    : '/dist/' ~ $release.distribution;
     <li class="nav-header">
       <div class="ttip" data-toggle="tooltip" data-placement="right" title="The date that this version of [% $release.distribution %] was released.">
-      <span class="xxrelatize">[% datetime($release.date).to_http %]</span>
+      <span class="relatize">[% datetime($release.date).to_http %]</span>
     </li>
     %%  include inc::release_status { maturity => $release.maturity }
     %%  block left_nav_lead -> {


### PR DESCRIPTION
This addresses #2518, replicates the tooltip on Bus Factor on the
same page.

The relatize JS also shows a tooltip style element,  it might
be worth removing that and using the tooltip added here instead?