### PR TITLE
clean up GitHub repository URLs

### DIFF
--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -58,16 +58,16 @@
     <li>
       <a class="nopopup" href="[% $release_base %]/contribute"><i class="fa fa-fw fa-plus-circle black"></i>How to Contribute</a>
     </li>
-    %%  if $release.resources.repository {
+    %%  if $repository && $repository.web || $repository.url {
     <li>
-      %%  if $release.resources.repository.web.is_url() {
-        <a rel="noopener nofollow" data-keyboard-shortcut="g r" href="[% $release.resources.repository.web %]"><i class="fa fa-fw fa-code-branch black"></i>Repository</a>
+      %%  if $repository.web.is_url() {
+        <a rel="noopener nofollow" data-keyboard-shortcut="g r" href="[% $repository.web %]"><i class="fa fa-fw fa-code-branch black"></i>Repository</a>
+        %%  if $repository.url.is_url() && $repository.url != ($repository.web ~ '.git') {
+          (<a rel="noopener nofollow" href="[% $repository.url %]">[% $repository.type %] clone</a>)
+        %%  }
       %%  }
-      %%  if $release.resources.repository.web.is_url() && $release.resources.repository.url.is_url() {
-        (<a rel="noopener nofollow" href="[% $release.resources.repository.url %]">[% $release.resources.repository.type %] clone</a>)
-      %%  }
-      %%  else if $release.resources.repository.url.is_url() {
-        <a rel="noopener nofollow" href="[% $release.resources.repository.url %]"><i class="fa fa-fw fa-code-branch black"></i>Clone [% $release.resources.repository.type %] repository</a>
+      %%  else if $repository.url.is_url() {
+        <a rel="noopener nofollow" href="[% $repository.url %]"><i class="fa fa-fw fa-code-branch black"></i>Clone [% $repository.type %] repository</a>
       %%  }
     </li>
     %%  }

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -151,9 +151,6 @@ test_psgi app, sub {
             optional_test repository => sub {
                 ok( $tx->find_value('//a[text()="Repository"]/@href'),
                     'link for resources.repository.web' );
-
-                ok( $tx->find_value('//a[text()="git clone"]/@href'),
-                    'link for resources.repository.url' );
             };
 
             optional_test issues => sub {


### PR DESCRIPTION
Authors will use various forms of URLs when including repository
metadata. For known git hosts (only GitHub so far) we can clean up those
URLs to be presented better in the UI.

One example of this is including just a clone URL using git://. This
isn't friendly to present in the UI to start with, since it doesn't lead
to a web page, but also GitHub no longer supports git:// cloning. There
is also little purpose of presenting a https web link with a second link
for cloning that includes .git at the end. Either one could be used for
cloning.