### PR TITLE
Fix case of "GitHub"

### DIFF
--- a/root/static/js/github.js
+++ b/root/static/js/github.js
@@ -93,7 +93,7 @@
 
                             +'  <tr><th>Pull Requests:</th><td><a href="'+ data.html_url +'/pulls">'+ data.html_url + '/pulls' + '</a></td></tr>'
                             +'  <tr><th>Clone URL:</th><td><a href="'+ data.clone_url +'">'+ data.clone_url +'</a></td></tr>'
-                            +'  <tr><th>Github URL:</th><td><a href="'+ data.html_url +'">'+ data.html_url +'</a></td></tr>'
+                            +'  <tr><th>GitHub URL:</th><td><a href="'+ data.html_url +'">'+ data.html_url +'</a></td></tr>'
                             +'  <tr><th>SSH URL:</th><td><a href="'+ data.ssh_url.replace(/^(\w+\@)?([^:\/]+):/,'ssh://$1$2/') +'">'+ data.ssh_url +'</a></td></tr>'
                             +'  <tr><th>Last Commit:</th><td><span class="relatize">'+ data.pushed_at +'</span></td></tr>'
                             +'</table>';
@@ -175,7 +175,7 @@
                         },
                     },
                     text: '<i class="fa fa-spinner fa-spin"></i>',
-                    title: 'Github Info'
+                    title: 'GitHub Info'
                 },
                 hide: {
                     event: 'mouseleave',


### PR DESCRIPTION
Hello, this PR is bit nitpicky but just fixes the word "GitHub" to have the correct case ("Github" -> "GitHub") on the small tooptip window on the left sidebar of metacapan website. 

Here are the screenshots of the change (this example is https://metacpan.org/dist/XML-LibXSLT):

**before**
<img width="773" alt="metacpan-before" src="https://user-images.githubusercontent.com/1425259/170242809-a6db996a-bb20-423a-82c5-06cc1d242ac2.png">

**after** (tested on my dev environment)
<img width="777" alt="metacpan-after" src="https://user-images.githubusercontent.com/1425259/170242799-e350d095-fc4f-4e9a-b0a0-e87045d4b404.png">

