### PR TITLE
update-snapshot - Checkout and push as metacpan-bot

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -8,6 +8,8 @@ jobs:
         runs-on: "ubuntu-20.04"
         steps:
             - uses: actions/checkout@v2.3.4
+              with:
+                  token: ${{ secrets.METACPAN_BOT_TOKEN }}
             - name: Get cpm
               run: >
                   curl -sL -o $RUNNER_TEMP/cpm https://git.io/cpm;


### PR DESCRIPTION
When updating the cpanfile.snapshot, use the metacpan-bot user to clone
the repo. This means it will also push as metacpan-bot. This will
hopefully prevent the push from being sometimes attributed to whoever
initially created the scheduled action.