### PR TITLE
cope with authors with nothing visible in their name

### DIFF
--- a/root/author.tx
+++ b/root/author.tx
@@ -1,5 +1,6 @@
 %%  cascade base {
-%%      title     => $title     || $author.name ~ ' (' ~ $author.pauseid ~ ')',
+%%      title     => $title     ||
+%%          $author.display_name ~ ( $author.has_display_name ? ' (' ~ $author.pauseid ~ ')' : '' ),
 %%      rss       => $rss       || '/author/' ~ $author.pauseid ~ '/activity.rss',
 %%      rss_title => $rss_title || 'Recent CPAN Activity of ' ~ $author.pauseid ~ ' - MetaCPAN',
 %%      twitter_card_inc => $twitter_card_inc || 'inc/twitter/author.tx',
@@ -127,7 +128,11 @@
 %%  override content -> {
 <div class="content">
     <div id="metacpan_feed_subscription" class="page-header">
-        <p>[% if $releases.0 { $releases.size() } else { 'No' } %] distributions uploaded by <span class="author-name">[% $author.name %]</span> ([% $author.pauseid %])</p>
+        <p>
+          [% if $releases.0 { $releases.size() } else { 'No' } %] distributions uploaded by
+          <span class="author-name">[% $author.display_name %]</span>
+          [% if $author.has_display_name { %] ([% $author.pauseid %])[% } %]
+        </p>
         <a href="/author/[% $author.pauseid %]/activity.rss"><i class="fa fa-rss fa-2x black"></i></a>
     </div>
     <div class="toolbar-search-form">

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -9,7 +9,7 @@
 %%  override breadcrumbs -> {
 <div class="breadcrumbs">
   <span>
-    <a data-keyboard-shortcut="g a" rel="author" href="/author/[% $release.author %]" title="[% $author.asciiname %]" class="author-name">[% $author.name %]</a>
+    <a data-keyboard-shortcut="g a" rel="author" href="/author/[% $release.author %]" class="author-name">[% $author.display_name %]</a>
   </span>
   <span>&nbsp;/&nbsp;</span>
   <div class="release status-[% $release.status %] maturity-[% $release.maturity %][% if $mark_unauthorized_releases && !$release.authorized { ' unauthorized' } %]">

--- a/root/inc/author_pic.tx
+++ b/root/inc/author_pic.tx
@@ -5,5 +5,7 @@
 <strong>
   <a rel="author" href="/author/[% $author.pauseid %]">[% $author.pauseid %]</a>
 </strong>
-<span title="[% $author.asciiname %]">[% $author.name %]</span>
+%%  if $author.has_display_name {
+<span>[% $author.display_name %]</span>
+%%  }
 </div>

--- a/root/inc/twitter/author.tx
+++ b/root/inc/twitter/author.tx
@@ -1,6 +1,6 @@
 <meta name="twitter:card"           content="summary" />
 <meta name="twitter:url"            content="[% $page_url() %]" />
-<meta name="twitter:title"          content="[% $author.name %]" />
+<meta name="twitter:title"          content="[% $author.display_name %]" />
 <meta name="twitter:description"    content="CPAN Author" />
 <meta name="twitter:site"           content="metacpan" />
 %%  for $author.profile -> $profile {

--- a/root/recent/topuploaders.tx
+++ b/root/recent/topuploaders.tx
@@ -13,7 +13,7 @@
     <strong class="pauseid">
         <a rel="author" href="/author/[% $author.pauseid %]">[% $author.pauseid %]</a>
     </strong>
-    <span class="name" title="[% $author.asciiname %]">[% $author.name %]</span>
+    <span class="name">[% $author.display_name %]</span>
     <strong class="count">[% $author.releases %] release[% if $author.releases > 1 { %]s[% } %]</strong>
 </div>
 %%  }

--- a/root/search.tx
+++ b/root/search.tx
@@ -9,9 +9,9 @@
     <ul class="authors clearfix">
     %% for $authors.authors -> $author {
       <li>
-        <a href="/author/[% $author.id %]" title="Author page for [% $author.name %]">
+        <a href="/author/[% $author.id %]" title="Author page for [% $author.display_name %]">
           <img src="[% gravatar_image($author, 30) %]">
-          [% $author.name %] ([% $author.pauseid %])
+          [% $author.display_name %][% if $author.has_display_name { %] ([% $author.pauseid %])[% } %]
         </a>
       </li>
     %% }


### PR DESCRIPTION
In an author has an "empty" name set, various parts of the UI will not have anything to click on, breaking navigation.

Detect this by checking for word characters in the author name, and falling back to the PAUSE id if there are none. If the API were to provide a display_name, either through a similar check like we are using or as a field that can be filled in, it would be preferred over either the name or the PAUSE id.