### PR TITLE
Add no sidebar class

### DIFF
--- a/root/author/releases.tx
+++ b/root/author/releases.tx
@@ -1,7 +1,10 @@
 %%  cascade base {
-%%      title => $title || "All releases by " ~ $author.pauseid,
+%%      title      => $title || "All releases by " ~ $author.pauseid,
+%%      body_class => 'no-sidebar',
 %%  }
 %%  override content -> {
-%%  include inc::release_table { header => 1, tablesorter => 0 }
-%%  include inc::pager
+<div class="content">
+  %%  include inc::release_table { header => 1, tablesorter => 0 }
+  %%  include inc::pager
+</div>
 %%  }

--- a/root/base.tx
+++ b/root/base.tx
@@ -147,9 +147,9 @@
                     </ul>
                 </li>
                 %% if ! $current['/'] {
-                    <li class="visible-xs visible-sm">
+                    <li class="icon-slidepanel visible-xs visible-sm">
                       <button data-toggle="slidepanel" data-target=".slidepanel">
-                        <i class="fa fa-bars icon-slidepanel"></i>
+                        <i class="fa fa-bars"></i>
                       </button>
                     </li>
                 %% }

--- a/root/base.tx
+++ b/root/base.tx
@@ -125,7 +125,9 @@
                 <form action="/account/logout" method="POST" id="metacpan-logout"></form>
                 <li class="dropdown logged_in" style="display: none;">
                     <button type="button" class="dropdown-toggle" data-toggle="dropdown">
-                      <img class="logged-in-gravatar" src="[% gravatar_image($author) %]">
+                      <!--Add the below back in once we have a way to store a logged in user's gravatar-->
+                      <!--<img class="logged-in-gravatar" src="[% gravatar_image() %]">-->
+                      <i class="fa fa-user button-fa-icon" aria-hidden="true"></i>
                       <i class="fas fa-chevron-down"></i>
                     </button>
                     <ul class="dropdown-menu">

--- a/root/base.tx
+++ b/root/base.tx
@@ -153,6 +153,11 @@
                         %%  }
                     </ul>
                 </li>
+                <li class="dropdown logged_placeholder">
+                    <button>
+                      <i class="fa fa-user button-fa-icon" aria-hidden="true"></i>
+                    </button>
+                </li>
             </ul>
         </nav>
 

--- a/root/base.tx
+++ b/root/base.tx
@@ -126,6 +126,7 @@
                 <li class="dropdown logged_in" style="display: none;">
                     <button type="button" class="dropdown-toggle" data-toggle="dropdown">
                       <img class="logged-in-gravatar" src="[% gravatar_image($author) %]">
+                      <i class="fas fa-chevron-down"></i>
                     </button>
                     <ul class="dropdown-menu">
                         <li><a href="/account/identities">Identities</a></li>
@@ -141,6 +142,7 @@
                 <li class="dropdown logged_out" style="display: none;">
                     <button type="button" class="dropdown-toggle" data-toggle="dropdown">
                       <i class="fa fa-user button-fa-icon" aria-hidden="true"></i>
+                      <i class="fas fa-chevron-down"></i>
                     </button>
                     <ul class="dropdown-menu">
                         %%  for ['GitHub', 'Twitter', 'Google'] -> $identity {

--- a/root/base.tx
+++ b/root/base.tx
@@ -104,7 +104,7 @@
             </ul>
             <ul class="nav navbar-nav navbar-right">
                 <button type="button" class="searchbar-btn visible-xs visible-sm">
-                    <i class="fa fa-search"></i>
+                    <i class="fa fa-search button-fa-icon"></i>
                 </button>
                 <form action="/search" class="searchbar-form visible-md visible-lg search-form form-horizontal">
                    <input type="hidden" name="size" id="metacpan_search-size" value="20">
@@ -115,10 +115,17 @@
                       </div>
                   </div>
                 </form>
+                %% if ! $current['/'] {
+                    <li class="icon-slidepanel visible-xs visible-sm">
+                      <button data-toggle="slidepanel" data-target=".slidepanel">
+                        <i class="fa fa-bars button-fa-icon"></i>
+                      </button>
+                    </li>
+                %% }
                 <form action="/account/logout" method="POST" id="metacpan-logout"></form>
                 <li class="dropdown logged_in" style="display: none;">
                     <button type="button" class="dropdown-toggle" data-toggle="dropdown">
-                      <i class="fa fa-user" aria-hidden="true"></i>
+                      <img class="logged-in-gravatar" src="[% gravatar_image($author) %]">
                     </button>
                     <ul class="dropdown-menu">
                         <li><a href="/account/identities">Identities</a></li>
@@ -133,7 +140,7 @@
                 </li>
                 <li class="dropdown logged_out" style="display: none;">
                     <button type="button" class="dropdown-toggle" data-toggle="dropdown">
-                      <i class="fa fa-user" aria-hidden="true"></i>
+                      <i class="fa fa-user button-fa-icon" aria-hidden="true"></i>
                     </button>
                     <ul class="dropdown-menu">
                         %%  for ['GitHub', 'Twitter', 'Google'] -> $identity {
@@ -146,13 +153,6 @@
                         %%  }
                     </ul>
                 </li>
-                %% if ! $current['/'] {
-                    <li class="icon-slidepanel visible-xs visible-sm">
-                      <button data-toggle="slidepanel" data-target=".slidepanel">
-                        <i class="fa fa-bars"></i>
-                      </button>
-                    </li>
-                %% }
             </ul>
         </nav>
 

--- a/root/base/search.tx
+++ b/root/base/search.tx
@@ -1,9 +1,1 @@
 %%  cascade base
-%%  override left_nav_content -> {
-    <li class="nav-header">Something missing?</li>
-    <li>
-        <div>
-          <a href="/about/missing_modules">Find out why</a>
-        </div>
-    </li>
-%%  }

--- a/root/inc/release_table.tx
+++ b/root/inc/release_table.tx
@@ -6,30 +6,33 @@
   %%  my $day_end = $~release.is_last ||
   %%    $per_day && $day != datetime($~release.peek_next.date).strftime("%F");
 
-%%  if $day_start {
-<table [% if $table_id { %] id="[% $table_id %]"[% } %]
-  %%  if $tablesorter {
-  data-default-sort="[% $default_sort || '1,0' %]"
+  %%  if $day_start {
+    %% if $author {
+      <h3>All Releases by [% $author.name %]</h3>
+    %% }
+    <table [% if $table_id { %] id="[% $table_id %]"[% } %]
+      %%  if $tablesorter {
+      data-default-sort="[% $default_sort || '1,0' %]"
+      %%  }
+      class="table table-condensed table-striped table-releases[% if $tablesorter { %] tablesorter[% } %]">
+      <thead>
+        <tr>
+          <th class="river-gauge"><span class="sr-only">River gauge</span></th>
+          <th class="name pull-left-phone">Release</th>
+          <th class="hidden-phone invisible no-sort"></th>
+          <th class="date">[% $per_day ? datetime($release.date).strftime("%A, %e %B %Y") : "Uploaded" %]</th>
+        </tr>
+      </thead>
+      <tbody>
+    %%  }
+        <tr>
+          <td class="river-gauge" sort="[% $release.river.total || 0 %]">[% include inc::river_gauge { distribution => $release.distribution, river => $release.river } %]</td>
+          <td class="name"><strong><a href="[% $release.status == 'latest' ? '/dist/' ~ $release.distribution : '/release/' ~ $release.author ~ '/' ~ $release.name %]" class="ellipsis" title="[% $release.author ~ '/' ~ $release.name %]">[% $release.name %]</a></strong></td>
+          <td class="abstract">[% $release.abstract %]</td>
+          <td class="date relatize" sort="[% $date %]">[% $date %]</td>
+        </tr>
+    %%  if $day_end {
+      </tbody>
+    </table>
   %%  }
-  class="content table table-condensed table-striped table-releases[% if $tablesorter { %] tablesorter[% } %]">
-  <thead>
-    <tr>
-      <th class="river-gauge"><span class="sr-only">River gauge</span></th>
-      <th class="name pull-left-phone">Release</th>
-      <th class="hidden-phone invisible no-sort"></th>
-      <th class="date">[% $per_day ? datetime($release.date).strftime("%A, %e %B %Y") : "Uploaded" %]</th>
-    </tr>
-  </thead>
-  <tbody>
-%%  }
-    <tr>
-      <td class="river-gauge" sort="[% $release.river.total || 0 %]">[% include inc::river_gauge { distribution => $release.distribution, river => $release.river } %]</td>
-      <td class="name"><strong><a href="[% $release.status == 'latest' ? '/dist/' ~ $release.distribution : '/release/' ~ $release.author ~ '/' ~ $release.name %]" class="ellipsis" title="[% $release.author ~ '/' ~ $release.name %]">[% $release.name %]</a></strong></td>
-      <td class="abstract">[% $release.abstract %]</td>
-      <td class="date relatize" sort="[% $date %]">[% $date %]</td>
-    </tr>
-%%  if $day_end {
-  </tbody>
-</table>
-%%  }
 %%  }

--- a/root/login/pause.tx
+++ b/root/login/pause.tx
@@ -1,4 +1,6 @@
-%%  cascade base
+%%  cascade base {
+%%      body_class => 'no-sidebar',
+%%  }
 %%  override content -> {
 <div class="jumbotron">
     <div class="container-fluid">

--- a/root/no_result.tx
+++ b/root/no_result.tx
@@ -1,13 +1,9 @@
 %%  cascade base::error {
-%%      title => $title || 'Search for "' ~ $search_query ~ '"',
-%%  }
-%%  override left_nav -> {
-%%    if $suggest {
-%%      super;
-%%    }
+%%      title      => $title || 'Search for "' ~ $search_query ~ '"',
+%%      body_class => 'no-sidebar',
 %%  }
 %%  override content -> {
-    <div class="content no-results">
+    <div class="content no-results text-center">
     <h3 class="search-results-header">No search results for [% $search_query %]</h3>
     %%  if $suggest {
             <div class="alert alert-danger">

--- a/root/search.tx
+++ b/root/search.tx
@@ -1,5 +1,6 @@
 %%  cascade base::search {
-%%      title => $title || 'Search for "' ~ $search_query ~ '"',
+%%      title      => $title || 'Search for "' ~ $search_query ~ '"',
+%%      body_class => 'no-sidebar',
 %%  }
 %%  override content -> {
 <div class="content search-results">

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -504,6 +504,7 @@ function processUserData() {
 function showUserData(user_data) {
     // User is logged in, so show it
     $('.logged_in').css('display', 'grid');
+    $('.logged_placeholder').css('display', 'none');
 
     // process users current favs
     $.each(user_data.faves, function(index, value) {
@@ -533,10 +534,12 @@ function getFavDataFromServer() {
             } else {
                 $('.logged_out').css('display', 'inline');
             }
+            $('.logged_placeholder').css('display', 'none');
         },
         error: function() {
             // Can't be logged in, should be getting 403
             $('.logged_out').css('display', 'inline');
+            $('.logged_placeholder').css('display', 'none');
         }
     });
     return true;

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -503,7 +503,7 @@ function processUserData() {
 
 function showUserData(user_data) {
     // User is logged in, so show it
-    $('.logged_in').css('display', 'inline');
+    $('.logged_in').css('display', 'grid');
 
     // process users current favs
     $.each(user_data.faves, function(index, value) {

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -551,8 +551,9 @@ form#metacpan_logout {
   scroll-margin-top: 80px;
 }
 
-.no-sidebar .nav-list-container {
-    display: none;
+.no-sidebar .nav-list-container,
+.no-sidebar .icon-slidepanel {
+    display: none !important;
 }
 
 .no-sidebar .page-content {

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -493,6 +493,12 @@ form#metacpan_logout {
     width: 100%;
 }
 
+// Nested content classes create too much padding
+// especially on mobile devices
+.content .content {
+  padding: 0;
+}
+
 .site-alert-message {
     text-align: center;
     margin: 1px 15% 20px;
@@ -543,4 +549,15 @@ form#metacpan_logout {
 
 * {
   scroll-margin-top: 80px;
+}
+
+.no-sidebar .nav-list-container {
+    display: none;
+}
+
+.no-sidebar .page-content {
+    align-items: center;
+    grid-template-areas: 'content';
+    grid-template-columns: 1fr;
+    justify-content: center;
 }

--- a/root/static/less/home.less
+++ b/root/static/less/home.less
@@ -16,6 +16,7 @@
 
 .home {
     display: grid;
+    margin: 50px 0;
 
     .home-hero {
       display: grid;

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -149,6 +149,10 @@ nav {
     place-content: center;
   }
 
+  .logged_in .fa-user {
+    color: #da2037;
+  }
+
   .logged_placeholder .button-fa-icon {
     background-color: @gray-darker;
     border: 2px solid @gray-darker;

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -127,6 +127,22 @@ nav {
         background-color: #e9e9e9;
       }
     }
+
+    .fa-chevron-down {
+      background-color: @gray-darker;
+      border-radius: 25px;
+      color: #e9e9e9;
+      font-size: 10px;
+      padding: 5px;
+      position: absolute;
+      right: 0;
+      top: 25px;
+    }
+  }
+
+  .dropdown-menu {
+    border-radius: 5px !important;
+    margin-top: 4px !important;
   }
 
   .logged_in {

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -103,6 +103,7 @@ nav {
   gap: 0;
   grid-area: icons;
   justify-self: end;
+  margin: 0;
 
   button {
     background-color: transparent;
@@ -114,7 +115,7 @@ nav {
       border-radius: 5px;
       color: @list-group-link-color;
       cursor: pointer;
-      font-size: 18px;
+      font-size: 14px;
       padding: 10px;
 
       &:hover {
@@ -145,4 +146,10 @@ nav {
 .menu-items {
   grid-area: menu;
   justify-self: center;
+}
+
+@media only screen and (min-width: @screen-xs-max) {
+  button .fa {
+    font-size: 18px !important;
+  }
 }

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -31,6 +31,7 @@
         }
 
         > li > a {
+            border-bottom: 2px solid transparent;
             padding: 0;
             white-space: nowrap;
             > img {
@@ -76,9 +77,6 @@ ul.nav-pills.affix {
 }
 
 .navbar-right .fa-search {
-  display: grid;
-  place-content: center;
-
   &:hover {
     cursor: pointer;
   }
@@ -109,24 +107,30 @@ nav {
     background-color: transparent;
     border: 0;
 
-    .fa {
-      background-color: @body-bg;
+    .button-fa-icon,
+    .logged-in-gravatar {
       border: 1px solid @list-group-border;
-      border-radius: 5px;
-      color: @list-group-link-color;
+      border-radius: 25px;
       cursor: pointer;
-      font-size: 14px;
+      display: grid;
+      height: 35px;
+      place-content: center;
+      width: 35px;
+    }
+
+    .button-fa-icon {
+      background-color: @body-bg;
+      color: @list-group-link-color;
       padding: 10px;
 
       &:hover {
         background-color: #e9e9e9;
-        border-radius: 4px;
       }
     }
   }
 
-  .logged_in .fa-user {
-    color: #da2037;
+  .logged_in {
+    place-content: center;
   }
 }
 
@@ -146,10 +150,4 @@ nav {
 .menu-items {
   grid-area: menu;
   justify-self: center;
-}
-
-@media only screen and (min-width: @screen-xs-max) {
-  button .fa {
-    font-size: 18px !important;
-  }
 }

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -132,6 +132,12 @@ nav {
   .logged_in {
     place-content: center;
   }
+
+  .logged_placeholder .button-fa-icon {
+    background-color: @gray-darker;
+    border: 2px solid @gray-darker;
+    color: @gray-darker;
+  }
 }
 
 .header-logo-large,

--- a/root/static/less/search.less
+++ b/root/static/less/search.less
@@ -23,10 +23,6 @@
     }
 }
 
-.search-results-header {
-    margin-top: 0;
-}
-
 .page-home .navbar-right {
     .searchbar-form,
     .searchbar-btn {

--- a/root/static/less/search.less
+++ b/root/static/less/search.less
@@ -45,6 +45,7 @@
     }
 
     input[type="text"] {
+      border-radius: 50px;
       padding-left: 40px;
     }
 }

--- a/t/controller/search/suggestion.t
+++ b/t/controller/search/suggestion.t
@@ -18,7 +18,7 @@ test_psgi app, sub {
         my $tx = tx($res);
         my $module
             = $tx->find_value(
-            '//div[@class="content no-results"]//div[@class="alert alert-danger"]//a[1]'
+            '//div[contains(@class, "no-results")]//div[@class="alert alert-danger"]//a[1]'
             );
         is( $module, $v, 'get no result page with suggestion' );
     }


### PR DESCRIPTION
- Do not display sidebar and slidepanel icon in header if there is a `no-sidebar` class added to the body tag. As described in https://github.com/metacpan/metacpan-web/issues/2749
- Ensure icons stay in viewport on an actual mobile device (for some reason the nav looks OK in Chrome dev tools, but not when actually viewing on a mobile device)
- ~~Use gravatar for a logged in user icon as described in https://github.com/metacpan/metacpan-web/issues/2757~~ This will be done in a separate PR.
- Stop the shifting of the nav links in the navbar as the page is checking for logged in status: https://github.com/metacpan/metacpan-web/issues/2752
- Round the corner of the button icons and search bar in the navbar
- Add dropdown / chevron icon to the logged in / logged out icons

**Mobile device bug**:

<img width="470" alt="Screen Shot 2022-10-01 at 9 48 52 AM" src="https://user-images.githubusercontent.com/52248962/193412668-a01a6723-fe38-49e5-8370-c56cde93ec67.png">

**Some updated screenshots**:

<img width="813" alt="Screen Shot 2022-10-01 at 7 11 45 PM" src="https://user-images.githubusercontent.com/52248962/193431636-b0158683-309a-48cf-9719-cbe3bfe6c573.png">
<img width="813" alt="Screen Shot 2022-10-01 at 7 11 57 PM" src="https://user-images.githubusercontent.com/52248962/193431637-eedbf248-ecc2-46b2-9583-6cb2ab4dbb5a.png">
<img width="1491" alt="Screen Shot 2022-10-01 at 7 12 11 PM" src="https://user-images.githubusercontent.com/52248962/193431642-21e577f4-092f-44d9-b2c9-14397a0386c2.png">
<img width="1491" alt="Screen Shot 2022-10-01 at 7 12 21 PM" src="https://user-images.githubusercontent.com/52248962/193431643-761fd2a5-8ac5-4bbc-8109-cb340171595b.png">
