### PR TITLE
Shorten nav height and specify specific styling for Safari

### DIFF
--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -548,7 +548,7 @@ form#metacpan_logout {
 }
 
 * {
-  scroll-margin-top: 80px;
+  scroll-margin-top: 60px;
 }
 
 .no-sidebar .nav-list-container,

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -3,7 +3,6 @@
     border-color: @gray-darker;
     border-radius: 0;
     box-shadow: 0 1px 13px 0 ~"rgb(0 0 0 / 10%)", 0 1px 5px 0 ~"rgb(0 0 0 / 6%)";
-    height: 80px;
     margin-bottom: 0;
     position: sticky;
     top: 0;
@@ -88,7 +87,7 @@ nav {
     column-gap: 40px;
     grid-template-areas: 'logo menu icons';
     grid-template-columns: 1fr 1fr 1fr;
-    padding: 20px 40px;
+    padding: 10px 40px;
 }
 
 .navbar-nav {
@@ -102,10 +101,12 @@ nav {
   grid-area: icons;
   justify-self: end;
   margin: 0;
+  overflow-y: hidden;
 
   button {
     background-color: transparent;
     border: 0;
+    padding: 0 6px;
 
     .button-fa-icon,
     .logged-in-avatar {
@@ -136,7 +137,7 @@ nav {
       padding: 5px;
       position: absolute;
       right: 0;
-      top: 25px;
+      top: 22px;
     }
   }
 

--- a/root/static/less/responsive.less
+++ b/root/static/less/responsive.less
@@ -132,7 +132,7 @@
 @import "bootstrap-slidepanel.less";
 
     .slidepanel {
-        margin-top: 80px;
+        margin-top: 58px;
         padding: 10px;
         border-right: 1px solid #e5e5e5;
         line-height: 25px;

--- a/root/static/less/search.less
+++ b/root/static/less/search.less
@@ -60,12 +60,12 @@
   z-index: 100;
 
   input[type="text"] {
-    height: 50px;
+    height: 40px;
     padding-left: 45px !important;
   }
 
   .fa-search {
-    margin: 18px !important;
+    margin: 14px !important;
   }
 }
 


### PR DESCRIPTION
- There is some default styling that gets applied in the Chrome and Firefox browsers, but not in Safari (particularly on the an actual mobile device). I explicitly set some of that styling so that the spacing of the navbar icons on Safari look similar to how they look in the other two browsers.
- The navbar height looked a tad too tall on a mobile device, so I shortened it a bit. This should enhance the mobile experience a bit by providing more room for content reading. Shortening the height wasn't too noticeable on a larger desktop, so I kept the same height for both mobile and desktop.

To confirm everything looked ok, here are screenshots with the changes directly from my iPhone in Safari (ignore the white lines around the nav icons, those are just a result of modifying the elements using the inspector tool).

![IMG_9865](https://user-images.githubusercontent.com/52248962/193945544-a27a6540-9ca8-4426-b0d0-89dee1d0951f.jpeg)

![IMG_9866](https://user-images.githubusercontent.com/52248962/193945576-348efb86-51cc-4d24-959b-f9fddea643cc.jpeg)
