### PR TITLE
Fix logged in status icon dropdown

### DIFF
--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -438,7 +438,7 @@ form#metacpan_logout {
             'breadcrumbs'
             'content';
         grid-template-columns: 1fr;
-        margin-top: 80px;
+        margin-top: 60px;
     }
 }
 

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -1,3 +1,13 @@
+// For some reason in Safari, the .clearfix() styling
+// is causing the icons to be outside of the viewport.
+.nav {
+  &:before,
+  &:after {
+    content: "" !important;
+    display: block !important;
+  }
+}
+
 .navbar {
     background-color: @gray-darker;
     border-color: @gray-darker;
@@ -101,7 +111,6 @@ nav {
   grid-area: icons;
   justify-self: end;
   margin: 0;
-  overflow-y: hidden;
 
   button {
     background-color: transparent;


### PR DESCRIPTION
In https://github.com/metacpan/metacpan-web/pull/2767, I introduced a bug where I set `overflow-y: hidden` for the `navbar-right` in order to get the nav icons to show in the viewport on Safari mobile. I was so focused on fixing that, that I didn't realize the dropdown menu won't appear when the logged in / out icon is clicked.

Fixed issue:
![IMG_9868](https://user-images.githubusercontent.com/52248962/194051042-10fc999a-031d-47b8-a146-64e19e242a01.jpg)
