### PR TITLE
Use flex instead of inline

### DIFF
--- a/root/static/less/breadcrumbs.less
+++ b/root/static/less/breadcrumbs.less
@@ -20,8 +20,9 @@
     }
 
     .release {
+        display: flex;
+        gap: 5px;
         position: relative;
-        display: inline;
 
         select {
             position: absolute;


### PR DESCRIPTION
Original bug:
<img width="400" alt="Screen Shot 2022-10-05 at 5 30 23 PM" src="https://user-images.githubusercontent.com/52248962/194167666-0afb9373-1a57-4e31-bb93-0bbaea7a49b8.png">

Fixed version:

<img width="463" alt="Screen Shot 2022-10-05 at 5 21 00 PM" src="https://user-images.githubusercontent.com/52248962/194167470-c068017b-47f4-41d5-8af0-7aeb5618cbd4.png">
