### PR TITLE
fix month in changelog parser calculations

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes/Parser.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes/Parser.pm
@@ -4,7 +4,7 @@ use Moose;
 use version qw();
 
 my @months = qw( Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec );
-my %months = map +( $months[$_] => $_ ), 0 .. $#months;
+my %months = map +( $months[$_] => $_ + 1 ), 0 .. $#months;
 my $months = join '|', @months;
 
 our $W3CDTF_REGEX = qr{


### PR DESCRIPTION
When parsing the date from a change log, the short month was being matched, and the index of the match was used as the month. Since the index starts at 0, this resulted in the month being off by one.

Add one to the index before using it in our short month to number hash.

Fixes #2780