### PR TITLE
remove unused bootstrap less includes

### DIFF
--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -1,4 +1,63 @@
-@import "../modules/bootstrap-v3.4.1/less/bootstrap.less";
+/*
+ *  Bootstrap imports. We don't want everything bootstrap provides, so we
+ *  aren't using bootstrap.less
+ */
+
+// Core variables and mixins
+@import "../modules/bootstrap-v3.4.1/less/variables.less";
+@import "../modules/bootstrap-v3.4.1/less/mixins.less";
+
+// Reset and dependencies
+@import "../modules/bootstrap-v3.4.1/less/normalize.less";
+@import "../modules/bootstrap-v3.4.1/less/print.less";
+@import "../modules/bootstrap-v3.4.1/less/glyphicons.less";
+
+// Core CSS
+@import "../modules/bootstrap-v3.4.1/less/scaffolding.less";
+@import "../modules/bootstrap-v3.4.1/less/type.less";
+@import "../modules/bootstrap-v3.4.1/less/code.less";
+@import "../modules/bootstrap-v3.4.1/less/grid.less";
+@import "../modules/bootstrap-v3.4.1/less/tables.less";
+@import "../modules/bootstrap-v3.4.1/less/forms.less";
+@import "../modules/bootstrap-v3.4.1/less/buttons.less";
+
+// Components
+@import "../modules/bootstrap-v3.4.1/less/component-animations.less";
+@import "../modules/bootstrap-v3.4.1/less/dropdowns.less";
+@import "../modules/bootstrap-v3.4.1/less/button-groups.less";
+@import "../modules/bootstrap-v3.4.1/less/input-groups.less";
+@import "../modules/bootstrap-v3.4.1/less/navs.less";
+@import "../modules/bootstrap-v3.4.1/less/navbar.less";
+@import "../modules/bootstrap-v3.4.1/less/breadcrumbs.less";
+@import "../modules/bootstrap-v3.4.1/less/pagination.less";
+@import "../modules/bootstrap-v3.4.1/less/pager.less";
+@import "../modules/bootstrap-v3.4.1/less/labels.less";
+@import "../modules/bootstrap-v3.4.1/less/badges.less";
+@import "../modules/bootstrap-v3.4.1/less/jumbotron.less";
+@import "../modules/bootstrap-v3.4.1/less/thumbnails.less";
+@import "../modules/bootstrap-v3.4.1/less/alerts.less";
+@import "../modules/bootstrap-v3.4.1/less/progress-bars.less";
+@import "../modules/bootstrap-v3.4.1/less/media.less";
+@import "../modules/bootstrap-v3.4.1/less/list-group.less";
+@import "../modules/bootstrap-v3.4.1/less/panels.less";
+@import "../modules/bootstrap-v3.4.1/less/responsive-embed.less";
+@import "../modules/bootstrap-v3.4.1/less/wells.less";
+@import "../modules/bootstrap-v3.4.1/less/close.less";
+
+// Components w/ JavaScript
+@import "../modules/bootstrap-v3.4.1/less/modals.less";
+@import "../modules/bootstrap-v3.4.1/less/tooltip.less";
+@import "../modules/bootstrap-v3.4.1/less/popovers.less";
+@import "../modules/bootstrap-v3.4.1/less/carousel.less";
+
+// Utility classes
+@import "../modules/bootstrap-v3.4.1/less/utilities.less";
+@import "../modules/bootstrap-v3.4.1/less/responsive-utilities.less";
+
+/*
+ *  End Bootstrap imports
+ */
+
 @import "../modules/fontawesome-5.15.3/less/fontawesome.less";
 @import "../modules/fontawesome-5.15.3/less/regular.less";
 @import "../modules/fontawesome-5.15.3/less/solid.less";

--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -30,25 +30,17 @@
 @import "../modules/bootstrap-v3.4.1/less/navbar.less";
 @import "../modules/bootstrap-v3.4.1/less/breadcrumbs.less";
 @import "../modules/bootstrap-v3.4.1/less/pagination.less";
-@import "../modules/bootstrap-v3.4.1/less/pager.less";
 @import "../modules/bootstrap-v3.4.1/less/labels.less";
-@import "../modules/bootstrap-v3.4.1/less/badges.less";
 @import "../modules/bootstrap-v3.4.1/less/jumbotron.less";
-@import "../modules/bootstrap-v3.4.1/less/thumbnails.less";
 @import "../modules/bootstrap-v3.4.1/less/alerts.less";
-@import "../modules/bootstrap-v3.4.1/less/progress-bars.less";
-@import "../modules/bootstrap-v3.4.1/less/media.less";
 @import "../modules/bootstrap-v3.4.1/less/list-group.less";
 @import "../modules/bootstrap-v3.4.1/less/panels.less";
-@import "../modules/bootstrap-v3.4.1/less/responsive-embed.less";
 @import "../modules/bootstrap-v3.4.1/less/wells.less";
 @import "../modules/bootstrap-v3.4.1/less/close.less";
 
 // Components w/ JavaScript
 @import "../modules/bootstrap-v3.4.1/less/modals.less";
 @import "../modules/bootstrap-v3.4.1/less/tooltip.less";
-@import "../modules/bootstrap-v3.4.1/less/popovers.less";
-@import "../modules/bootstrap-v3.4.1/less/carousel.less";
 
 // Utility classes
 @import "../modules/bootstrap-v3.4.1/less/utilities.less";


### PR DESCRIPTION
This reduces the size of our generated CSS a bit, and also fixes a warning that always shows up in the browser console about using the 'zoom' property.