### PR TITLE
refactor ReleaseInfo to specify release first and requested data later

### DIFF
--- a/lib/MetaCPAN/Web/API/RequestInfo/Orchestrator.pm
+++ b/lib/MetaCPAN/Web/API/RequestInfo/Orchestrator.pm
@@ -1,0 +1,155 @@
+package MetaCPAN::Web::API::RequestInfo::Orchestrator;
+use Moo;
+use List::Util qw( max );
+use namespace::clean;
+
+has model => (
+    is       => 'ro',
+    required => 1,
+);
+
+has dist => ( is => 'ro' );
+
+has author  => ( is => 'ro' );
+has release => ( is => 'ro' );
+
+sub BUILD {
+    my $self = shift;
+    die "dist or author and release must be provided"
+        if $self->dist
+        ? ( $self->author || $self->release )
+        : !( $self->author && $self->release );
+}
+
+has [qw(_with_release _with_dist _with_release_detail _then)] => (
+    is      => 'ro',
+    default => sub { [] },
+);
+
+sub with_release {
+    my ( $self, @cb ) = @_;
+    $self->new( %$self, _with_release => [ @{ $self->_with_release }, @cb ] );
+}
+
+sub with_dist {
+    my ( $self, @cb ) = @_;
+    $self->new( %$self, _with_dist => [ @{ $self->_with_dist }, @cb ] );
+}
+
+sub with_release_detail {
+    my ( $self, @cb ) = @_;
+    $self->new( %$self,
+        _with_release_detail => [ @{ $self->_with_release_detail }, @cb ] );
+}
+
+sub then {
+    my ( $self, $then ) = @_;
+    $self->new( %$self, _then => [ @{ $self->_then }, $then ] );
+}
+
+sub _to_future {
+    my @in = @_;
+    Future->wait_all(
+        map {
+            my ( $to, $future, $from ) = @$_;
+            $from ||= $to;
+            $future->then( sub {
+                my $data = shift;
+                if ( my $sub = $data->{$from} ) {
+                    return Future->done( {
+                        $to => $sub,
+                        (
+                            exists $data->{took}
+                            ? ( took => $data->{took} )
+                            : ()
+                        ),
+                    } );
+                }
+                else {
+                    return Future->fail($data);
+                }
+            } );
+        } @in
+    );
+}
+
+sub _unwrap {
+    Future->done( map $_->result, @_ );
+}
+
+# this should be directly in the release model methods
+sub _fail_without_release {
+    my $data = shift;
+    return Future->fail( { code => 404, message => 'Not found' } )
+        unless $data->{release};
+    Future->done($data);
+}
+
+sub _via_dist {
+    my ( $self, $dist ) = @_;
+    my $model = $self->model;
+
+    Future->wait_all(
+        $model->find($dist)->then( \&_fail_without_release )->then( sub {
+            my $data         = shift;
+            my $release_data = $data->{release};
+            my $author       = $release_data->{author};
+            my $release      = $release_data->{name};
+
+            _to_future(
+                ( map $_->( $author, $release ), @{ $self->_with_release } ),
+                ( map $_->($release_data), @{ $self->_with_release_detail } ),
+                [ release => Future->done($data) ],
+            );
+        } ),
+        _to_future(
+            ( map $_->($dist), @{ $self->_with_dist } ),
+        ),
+    )->then( \&_unwrap );
+}
+
+sub _via_release {
+    my ( $self, $author, $release ) = @_;
+    my $model = $self->model;
+
+    Future->wait_all(
+        $model->get( $author, $release )->then( \&_fail_without_release )
+            ->then( sub {
+            my $data         = shift;
+            my $release_data = $data->{release};
+            my $dist         = $release_data->{distribution};
+
+            _to_future(
+                ( map $_->($dist), @{ $self->_with_dist } ),
+                ( map $_->($release_data), @{ $self->_with_release_detail } ),
+                [ release => Future->done($data) ],
+            );
+            } ),
+        _to_future(
+            ( map $_->( $author, $release ), @{ $self->_with_release } ),
+        ),
+    )->then( \&_unwrap );
+}
+
+sub fetch {
+    my $self = shift;
+    my $result
+        = $self->dist
+        ? $self->_via_dist( $self->dist )
+        : $self->_via_release( $self->author, $self->release );
+
+    $result = $result->then( sub {
+        my @res = map $_->else_done( {} )->get, @_;
+
+        Future->done( {
+            ( map %$_, @res ),
+            took => max( grep defined, map $_->{took}, values @res ),
+        } );
+    } );
+    for my $then ( @{ $self->_then } ) {
+        $result = $result->then($then);
+    }
+    return $result;
+}
+
+1;

--- a/t/controller/release.t
+++ b/t/controller/release.t
@@ -5,6 +5,7 @@ use MetaCPAN::Web::Test qw( app GET test_psgi tx );
 
 test_psgi app, sub {
     my $cb = shift;
+
     ok( my $res = $cb->( GET '/dist/DOESNTEXIST' ), 'GET /dist/DOESNTEXIST' );
     is( $res->code, 404, 'code 404' );
 

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -6,7 +6,7 @@ use MetaCPAN::Web::Test qw( app GET test_psgi tx );
 use Module::Runtime qw( use_module );
 
 my $model     = use_module('MetaCPAN::Web::Model::ReleaseInfo');
-my $rt_prefix = $model->rt_url_prefix;
+my $rt_prefix = $model->RT_URL_PREFIX;
 
 # Test various aspects that should be similar
 # among controllers that show release info (in the side bar).

--- a/t/model/release-info.t
+++ b/t/model/release-info.t
@@ -7,15 +7,15 @@ use Module::Runtime qw( use_module );
 
 my $model = use_module('MetaCPAN::Web::Model::ReleaseInfo')->new;
 
-my $rt_prefix = $model->rt_url_prefix;
+my $rt_prefix = $model->RT_URL_PREFIX;
 
 sub bugtracker {
     return { resources => { bugtracker => {@_} } };
 }
 
-sub normalize_issues_ok {
+sub get_issues_ok {
     my ( $release, $bugs, $exp, $desc ) = @_;
-    my $normalized = $model->normalize_issues(
+    my $normalized = $model->_get_issues(
         { distribution => 'X', %$release },
 
         # Default to rt url, but let data override.
@@ -24,9 +24,9 @@ sub normalize_issues_ok {
     is_deeply $normalized, $exp, $desc;
 }
 
-subtest 'normalize_issues' => sub {
+subtest 'get_issues' => sub {
 
-    normalize_issues_ok(
+    get_issues_ok(
         {},
         { active => 11 },
         { url    => "${rt_prefix}X", active => 11 },
@@ -39,7 +39,7 @@ subtest 'normalize_issues' => sub {
             mailto => 'foo@example.com',
         };
 
-        normalize_issues_ok(
+        get_issues_ok(
             bugtracker(%$bt),
             { active => 9 },
             { url    => $bt->{web} },
@@ -48,7 +48,7 @@ subtest 'normalize_issues' => sub {
 
         delete $bt->{web};
 
-        normalize_issues_ok(
+        get_issues_ok(
             bugtracker(%$bt),
             { active => 9 },
             { url    => 'mailto:' . $bt->{mailto} },
@@ -57,7 +57,7 @@ subtest 'normalize_issues' => sub {
 
         delete $bt->{mailto};
 
-        normalize_issues_ok(
+        get_issues_ok(
             bugtracker(%$bt),
             { active => 9 },
             { url    => "${rt_prefix}X", active => 9 },
@@ -83,7 +83,7 @@ subtest 'normalize_issues' => sub {
         http://rt.cpan.org/Ticket/Create.html?Queue=X
     ) )
     {
-        normalize_issues_ok(
+        get_issues_ok(
             bugtracker( web => $url ),
             { active => 12 },
             { url    => $url, active => 12 },
@@ -91,7 +91,7 @@ subtest 'normalize_issues' => sub {
         );
     }
 
-    normalize_issues_ok(
+    get_issues_ok(
         bugtracker( web => 'http://canhaz' ),
         { source => 'http://canhaz', active => 13 },
         { url    => 'http://canhaz', active => 13 },
@@ -99,7 +99,7 @@ subtest 'normalize_issues' => sub {
     );
 
     # If a dist specifies a web, and then later removes it.
-    normalize_issues_ok(
+    get_issues_ok(
         {},
         { source => 'anything://else', active => 13 },
         { url    => "${rt_prefix}X" },
@@ -114,7 +114,7 @@ subtest 'normalize_issues' => sub {
         https://www.github.com/user/repo/tree
     ) )
     {
-        normalize_issues_ok(
+        get_issues_ok(
             bugtracker( web => $url ),
             { source => 'https://github.com/user/repo', active => 3 },
             { url    => $url,                           active => 3 },


### PR DESCRIPTION
A substantial refactoring of ReleaseInfo to allow creating a requesting
object, then later deciding what information to request.

The existing APIs are maintained for now, but in the future users will
be adapted to use the `->via_dist` and `->via_release` methods. The
`full_details` option will go away, with the extra details being attached
by the release controller. This ReleaseInfo object can be placed in the
stash immediately, rather than needing the pass the dist, author, or
release information on.

The Orchestrator object coordinates fetching in two batches, info based
on the dist and info based on the release. The order of these depends on
which information you start with. Additional information can be
requested using the `->with_*` methods before calling fetch.