### PR TITLE
improve display when overflow scrolling

### DIFF
--- a/root/static/less/footer.less
+++ b/root/static/less/footer.less
@@ -5,6 +5,10 @@
   padding: 30px;
   width: 100%;
 }
+// for overflow scrolling
+html {
+    background-color: #e9e9e9;
+}
 
 .footer-container {
   display: grid;

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -354,6 +354,7 @@ h1, .h1, h2, .h2, h3, .h3 {
     grid-template-columns: @sidebar-width ~"calc(100vw -" @sidebar-width ~")";
     grid-template-rows: min-content 1fr;
     line-height: 1.54em;
+    margin-top: 60px;
 }
 
 @media (min-width: 0) and (max-width: @screen-sm-max) {
@@ -362,7 +363,6 @@ h1, .h1, h2, .h2, h3, .h3 {
             'breadcrumbs'
             'content';
         grid-template-columns: 1fr;
-        margin-top: 60px;
     }
 }
 

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -14,7 +14,7 @@
     border-radius: 0;
     box-shadow: 0 1px 13px 0 rgba(0,0,0,10%), 0 1px 5px 0 rgba(0,0,0,6%);
     margin-bottom: 0;
-    position: sticky;
+    position: fixed;
     top: 0;
     width: 100%;
     z-index: 10;


### PR DESCRIPTION
When scrolling past the top of the page, the header would move down from the top of the display, and show white behind it. And scrolling past the bottom would also show white.

Change the positioning of the header from sticky to fixed. This means it will always be attached to the top, even with overflow scrolling. sticky is more useful for things further down the page that you want to attach to the top once you've scrolled past them. Changing to fixed also results in the header not taking up any space in the layout. Adjust the top margin of the page content to accomodate for this. This is makes rules match for the desktop and mobile layout.

We can set the background color browsers use for overflow scrolling with the background on the html element. We're already setting the body background to white, so the html background won't be visible anywhere in the normal content. Browsers only seem to use the background color for overflow scrolling, so we can't use gradients or anything else. But since we've fixed the header to the top of the page, we only need to worry about matching the color of the footer.