### PR TITLE
Refactor handling of file data

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -24,7 +24,7 @@ sub find : Path : Args(1) {
 
     my $release_info
         = $c->model('ReleaseInfo')
-        ->get( $pod_file->{author}, $pod_file->{release}, $pod_file )
+        ->get( $pod_file->{author}, $pod_file->{release} )
         ->else( sub { Future->done( {} ) } );
     $c->stash( $release_info->get );
 
@@ -92,6 +92,10 @@ sub view : Private {
     $c->cdn_max_age('1y');
     $c->add_dist_key( $release->{distribution} );
     $c->add_author_key( $release->{author} );
+
+    if ( $data->{deprecated} ) {
+        $c->stash->{notification} ||= { type => 'MODULE_DEPRECATED' };
+    }
 
     $c->stash( {
         canonical         => $canonical,

--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -16,7 +16,7 @@ sub find : Path : Args(1) {
     $c->browser_max_age('1h');
 
     # TODO: Pass size param so we can disambiguate?
-    my $pod_file = $c->stash->{pod_file}
+    my $pod_file = $c->stash->{file}
         = $c->model('API::Module')->find(@path)->get;
 
     $c->detach('/not_found')
@@ -36,7 +36,7 @@ sub find : Path : Args(1) {
 sub view : Private {
     my ( $self, $c, @path ) = @_;
 
-    my $data       = $c->stash->{pod_file};
+    my $data       = $c->stash->{file};
     my $permalinks = $c->stash->{permalinks};
 
     if ( $data->{directory} ) {
@@ -100,7 +100,6 @@ sub view : Private {
     $c->stash( {
         canonical         => $canonical,
         documented_module => $documented_module,
-        module            => $data,
         pod               => $pod_html,
         template          => 'pod.tx',
     } );

--- a/lib/MetaCPAN/Web/Controller/View.pm
+++ b/lib/MetaCPAN/Web/Controller/View.pm
@@ -28,7 +28,7 @@ sub dist : Chained('/dist/root') PathPart('view') Args {
     unshift @path, @{ $release_data->{release} }{qw( author name )};
 
     $c->stash( {
-        %$release_data, pod_file => $c->model('API::Module')->get(@path)->get,
+        %$release_data, file => $c->model('API::File')->get(@path)->get,
     } );
 
     $c->forward( '/pod/view', [@path] );
@@ -43,12 +43,11 @@ sub release : Chained('/release/root') PathPart('view') Args {
     }
     $c->browser_max_age('1d');
 
-    my $pod_file
-        = $c->model('API::Module')->get( $author, $release, @path )->get;
+    my $file = $c->model('API::File')->get( $author, $release, @path )->get;
     my $release_data
         = $c->model('ReleaseInfo')->get( $author, $release )->else_done( {} );
     $c->stash( {
-        pod_file => $pod_file,
+        file => $file,
         %{ $release_data->get },
         permalinks => 1,
     } );

--- a/lib/MetaCPAN/Web/Controller/View.pm
+++ b/lib/MetaCPAN/Web/Controller/View.pm
@@ -46,8 +46,7 @@ sub release : Chained('/release/root') PathPart('view') Args {
     my $pod_file
         = $c->model('API::Module')->get( $author, $release, @path )->get;
     my $release_data
-        = $c->model('ReleaseInfo')->get( $author, $release, $pod_file )
-        ->else_done( {} );
+        = $c->model('ReleaseInfo')->get( $author, $release )->else_done( {} );
     $c->stash( {
         pod_file => $pod_file,
         %{ $release_data->get },

--- a/lib/MetaCPAN/Web/Model/API/File.pm
+++ b/lib/MetaCPAN/Web/Model/API/File.pm
@@ -1,10 +1,12 @@
 package MetaCPAN::Web::Model::API::File;
 use Moose;
 extends 'MetaCPAN::Web::Model::API';
+with 'MetaCPAN::Web::Role::FileData';
 
 sub get {
     my ( $self, @path ) = @_;
-    $self->request( '/file/' . join( '/', @path ) );
+    $self->request( '/file/' . join( '/', @path ) )
+        ->then( $self->_groom_fileinfo );
 }
 
 sub source {
@@ -29,7 +31,7 @@ sub dir {
             }
             return $dir;
         }
-    );
+    )->then( $self->_groom_fileinfo('dir') );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Model/API/Module.pm
+++ b/lib/MetaCPAN/Web/Model/API/Module.pm
@@ -26,7 +26,8 @@ it under the same terms as Perl itself.
 
 sub find {
     my ( $self, @path ) = @_;
-    $self->request( '/module/' . join( '/', @path ) );
+    $self->request( '/module/' . join( '/', @path ) )
+        ->then( $self->_groom_fileinfo );
 }
 
 sub autocomplete {
@@ -44,7 +45,8 @@ sub search_web {
     my ( $self, $query, $from, $page_size ) = @_;
     $self->request( '/search/web', undef,
         { q => $query, size => $page_size // 20, from => $from // 0 } )
-        ->then( $self->add_river( sub { @{ $_[0]{results} || [] } } ) );
+        ->then( $self->add_river( sub { @{ $_[0]{results} || [] } } ) )
+        ->then( $self->_groom_fileinfo( 'results', 'hits' ) );
 }
 
 sub first {

--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -4,6 +4,7 @@ use namespace::autoclean;
 
 extends 'MetaCPAN::Web::Model::API';
 with 'MetaCPAN::Web::Role::RiverData';
+with 'MetaCPAN::Web::Role::FileData';
 
 use CPAN::DistnameInfo ();
 use Future             ();
@@ -79,7 +80,7 @@ sub modules {
             $data->{modules} = $modules;
         }
         Future->done($data);
-    } );
+    } )->then( $self->_groom_fileinfo('modules') );
 }
 
 sub find {
@@ -116,7 +117,8 @@ sub reverse_dependencies {
 
 sub interesting_files {
     my ( $self, $author, $release ) = @_;
-    $self->request("/release/interesting_files/$author/$release");
+    $self->request("/release/interesting_files/$author/$release")
+        ->then( $self->_groom_fileinfo('files') );
 }
 
 sub versions {

--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -57,7 +57,7 @@ sub find {
 }
 
 sub get {
-    my ( $self, $author, $release_name, $module_info ) = @_;
+    my ( $self, $author, $release_name ) = @_;
     my $release      = $self->_release->get( $author, $release_name );
     my %release_data = $self->_release_data( $author, $release_name );
     $release->then( sub {
@@ -70,7 +70,7 @@ sub get {
             release => $data,
             %release_data,
             notification =>
-                $self->_get_notifications( $data->{release}, $module_info ),
+                $self->_get_notifications( $data->{release} ),
             $self->_dist_data( $data->{release}{distribution} ),
         );
     } )->then( $self->normalize );
@@ -340,7 +340,7 @@ sub normalize_issue_url {
 }
 
 sub _get_notifications {
-    my ( $self, $release, $module ) = @_;
+    my ( $self, $release ) = @_;
     return $self->_permission->get_notification_info(
         $release->{main_module} )->then( sub {
         my $data = shift;
@@ -350,9 +350,6 @@ sub _get_notifications {
         unless ( $data->{notification} ) {
             if ( $release->{deprecated} ) {
                 $data->{notification} = { type => 'DEPRECATED' };
-            }
-            elsif ( $module && $module->{deprecated} ) {
-                $data->{notification} = { type => 'MODULE_DEPRECATED' };
             }
         }
 

--- a/lib/MetaCPAN/Web/Role/FileData.pm
+++ b/lib/MetaCPAN/Web/Role/FileData.pm
@@ -1,0 +1,97 @@
+package MetaCPAN::Web::Role::FileData;
+use Moose::Role;
+use Future    ();
+use Ref::Util qw(is_arrayref);
+use namespace::autoclean;
+
+# the MIME type coming from the API is not always useful. Use our own mapping
+# of extensions to override what the API gives us.
+my %ext_mime_map = qw(
+    pl          text/x-script.perl
+    t           text/x-script.perl
+    pod         text/x-pod
+    pm          text/x-script.perl-module
+    yaml        text/yaml
+    yml         text/yaml
+    js          application/javascript
+    json        application/json
+    c           text/x-c
+    h           text/x-c
+    xs          text/x-c
+    md          text/markdown
+    mkd         text/markdown
+    md          text/markdown
+    mkd         text/markdown
+    mdwn        text/markdown
+    mdown       text/markdown
+    mdtxt       text/markdown
+    mdtext      text/markdown
+    markdown    text/markdown
+);
+
+my %file_mime_map = qw(
+    alienfile   text/x-script.perl
+    cpanfile    text/x-script.perl
+    Changes     text/x-cpan-changelog
+);
+
+my ($EXT_RE) = map qr{$_}i, join '|', sort keys %ext_mime_map;
+
+sub _groom_fileinfo {
+    my ( $self, @sub ) = @_;
+    sub {
+        my $data  = shift;
+        my $files = $data;
+        $files = [ $files // () ]
+            if !is_arrayref $files;
+        for my $sub (@sub) {
+            $files = [
+                map {
+                    my $file = $_->{$sub};
+                    is_arrayref($file)  ? @$file
+                        : defined $file ? $file
+                        :                 ();
+                } @$files
+            ];
+        }
+
+        for my $file (@$files) {
+            %$file = %{ $self->_groom_file($file) };
+        }
+        return Future->done($data);
+    };
+}
+
+sub _groom_file {
+    my ( $self, $file ) = @_;
+
+    $file = {%$file};
+    if ( $file->{directory} ) {
+        delete $file->{mime};
+        return $file;
+    }
+    elsif ( !$file->{path} ) {
+        return $file;
+    }
+
+    my $path = $file->{path};
+    my $name = $file->{name} // $path =~ s{.*/}{}r;
+
+    if ( my $modules = $file->{module} ) {
+        $file->{has_associated_pod} = 1
+            if grep $_->{associated_pod}, @$modules;
+        $file->{has_authorized_module} = 1
+            if grep +( $_->{authorized} && $_->{indexed} ), @$modules;
+    }
+
+    if ( exists $file_mime_map{$name} ) {
+        $file->{mime} = $file_mime_map{$name};
+    }
+    elsif ( $name =~ m{\.($EXT_RE)\z}o ) {
+        $file->{mime} = $ext_mime_map{ lc $1 };
+    }
+
+    return $file;
+}
+
+1;

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -14,9 +14,9 @@
   <span>&nbsp;/&nbsp;</span>
   <div class="release dist-release status-[% $release.status %] maturity-[% $release.maturity %][% if $mark_unauthorized_releases && !$release.authorized { ' unauthorized' } %]">
     <span class="dropdown"><b class="caret"></b></span>
-    %%  include inc::version_select { class => $module ? '' : 'extend' };
-    %%  if $module {
-    <a data-keyboard-shortcut="g d" class="release-name" href="[% if $permalinks || $release.status != 'latest' { '/release/' ~ $module.author ~ '/' ~ $module.release } else { '/dist/' ~ $release.distribution } %]">[% $release.name %]</a>
+    %%  include inc::version_select { class => $file ? '' : 'extend' };
+    %%  if $file {
+    <a data-keyboard-shortcut="g d" class="release-name" href="[% if $permalinks || $release.status != 'latest' { '/release/' ~ $file.author ~ '/' ~ $file.release } else { '/dist/' ~ $release.distribution } %]">[% $release.name %]</a>
     %%  }
     %%  else {
     <span class="release-name">[% $release.name %]</span>
@@ -26,12 +26,22 @@
     %%  }
   </div>
   %%  if $release.status != 'latest' && $versions.map(-> $v { $v.status == 'latest' ? 1 : 0 }).sum() {
-    <a class="latest" href="[% if $module { '/pod/' ~ $module.documentation } else { '/dist/' ~ $release.distribution } %]" title="[% if $release.maturity == 'developer' { 'dev release, ' } %]go to latest"><span class="fa fa-step-forward"></span></a>
+    <a class="latest" href="[%
+      if $file && $file.documentation {
+        '/pod/' ~ $file.documentation
+      }
+      else {
+        '/dist/' ~ $release.distribution;
+        if $file {
+          '/view/' ~ $file.path;
+        }
+      }
+    %]" title="[% if $release.maturity == 'developer' { 'dev release, ' } %]go to latest"><span class="fa fa-step-forward"></span></a>
   %%  }
   %%  include inc::river_gauge { river => $distribution.river, distribution => $release.distribution };
   %%  include inc::favorite;
-  %%  if $module {
-  &nbsp;/&nbsp;<span>[% $module.documentation || $module.module[0].name %]</span>
+  %%  if $file {
+   / <span>[% $file.documentation || $file.module[0].name || $file.path %]</span>
   %%  }
 </div>
 %%  }
@@ -136,7 +146,7 @@
       Download (<span itemprop="fileSize">[% format_bytes($release.stat.size) %]B</span>)</a>
     </li>
     <li>
-      <a href="https://explorer.metacpan.org/?url=[% uri_escape( $module ? ('/module/' ~ $module.author ~ '/' ~ $module.release ~ '/' ~ $module.path) : ( '/release/' ~ $release.author ~ '/' ~ $release.name ) ) %]">
+      <a href="https://explorer.metacpan.org/?url=[% uri_escape( $file ? ('/module/' ~ $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path) : ( '/release/' ~ $release.author ~ '/' ~ $release.name ) ) %]">
         MetaCPAN Explorer
       </a>
     </li>
@@ -201,7 +211,7 @@
     </li>
     <li class="nav-header">Permalinks</li>
     <li>
-      <a href="/release/[% $release.author %]/[% $release.name %][% if $module { '/view/' ~ $module.path } %]">This version</a>
+      <a href="/release/[% $release.author %]/[% $release.name %][% if $file { '/view/' ~ $file.path } %]">This version</a>
     </li>
     %%  if $canonical {
       %%  my $has_latest = $versions.map(-> $v { $v.status == 'latest' ? 1 : 0 }).sum();

--- a/root/browse.tx
+++ b/root/browse.tx
@@ -38,13 +38,14 @@
 <tbody>
 %% for $files -> $file {
 <tr>
-  <td class="name" sort="[% ( $file.directory ? "!" : '' ) ~ $file.name %]"><a href="/release/[% $author %]/[% $release %]/source/[% $file.path %]" class="[%
-    $file.directory                           ? 'silk-folder'
-  : $file.mime == 'text/x-script.perl'        ? 'silk-page-white-code'
-  : $file.mime == 'text/x-script.perl-module' ? 'silk-page-white-code'
-  : $file.mime == 'text/x-c'                  ? 'silk-page-white-c'
-                                              : 'silk-page-white'
-%]" title="[% $file.path %]">[% $file.name %]</a></td>
+  <td class="name" sort="[% ( $file.directory ? "!" : '' ) ~ $file.name %]"><a href="/release/[% $author %]/[% $release %]/source/[% $file.path %]" class="file-table-entry"
+    %%  if $file.directory {
+      data-directory
+    %%  }
+    %%  else {
+      data-mime-type="[% $file.mime %]"
+    %%  }
+    title="[% $file.path %]">[% $file.name %]</a></td>
   <td class="documentation"><strong><a href="/release/[% $author %]/[% $release %]/view/[% $file.path %]" title="[% $file.path %]" class="ellipsis">[% $file.slop ? $file.documentation ? $file.documentation : $file.name : "" %]</a></strong></td>
   <td class="size" sort="[% $file.directory ? 0 : $file.stat.size %]">[% $file.directory ? '' : format_bytes($file.stat.size) %]</td>
   %%  my $date = datetime($file.stat.mtime).to_http;

--- a/root/browse.tx
+++ b/root/browse.tx
@@ -38,14 +38,14 @@
 <tbody>
 %% for $files -> $file {
 <tr>
-  <td class="name" sort="[% ( $file.directory == 1 ? "!" : '' ) ~ $file.name %]"><a href="/release/[% $author %]/[% $release %]/source/[% $file.path %]" class="[%
-    $file.directory             ? 'silk-folder'
-  : $file.mime.match("perl")    ? 'silk-page-white-code'
-  : $file.mime.match("x-c")     ? 'silk-page-white-c'
-                                : 'silk-page-white'
+  <td class="name" sort="[% ( $file.directory ? "!" : '' ) ~ $file.name %]"><a href="/release/[% $author %]/[% $release %]/source/[% $file.path %]" class="[%
+    $file.directory                           ? 'silk-folder'
+  : $file.mime == 'text/x-script.perl'        ? 'silk-page-white-code'
+  : $file.mime == 'text/x-script.perl-module' ? 'silk-page-white-code'
+  : $file.mime == 'text/x-c'                  ? 'silk-page-white-c'
+                                              : 'silk-page-white'
 %]" title="[% $file.path %]">[% $file.name %]</a></td>
   <td class="documentation"><strong><a href="/release/[% $author %]/[% $release %]/view/[% $file.path %]" title="[% $file.path %]" class="ellipsis">[% $file.slop ? $file.documentation ? $file.documentation : $file.name : "" %]</a></strong></td>
-  <!-- [% $file | dump %] -->
   <td class="size" sort="[% $file.directory ? 0 : $file.stat.size %]">[% $file.directory ? '' : format_bytes($file.stat.size) %]</td>
   %%  my $date = datetime($file.stat.mtime).to_http;
   <td class="mtime relatize" nowrap="nowrap" sort="[% $date %]">[% $date %]</td>

--- a/root/inc/dependencies.tx
+++ b/root/inc/dependencies.tx
@@ -18,11 +18,12 @@
   <li>
     <hr>
   </li>
+  %%  my $module_name = $file.documentation || $file.module.0.name;
   <li>
-    <a href="[% $module ? '/module/' ~ ($module.documentation || $module.module.0.name ) : '/dist/' ~ $release.distribution %]/requires">Reverse dependencies</a>
+    <a href="[% $module_name ? '/module/' ~ $module_name : '/dist/' ~ $release.distribution %]/requires">Reverse dependencies</a>
   </li>
   <li>
-    <a href="http://deps.cpantesters.org/?module=[% $module.documentation || $module.module.0.name || $release.main_module %]">CPAN Testers List</a>
+    <a href="http://deps.cpantesters.org/?module=[% uri_escape($module_name || $release.main_module) %]">CPAN Testers List</a>
   </li>
   <li>
     <a href="https://cpandeps.grinnz.com/?dist=[% $release.distribution | uri %][% if $permalinks || $release.status != 'latest' { %]&amp;dist_version=[% $release.version | uri %][% } %]">Dependency graph</a>

--- a/root/inc/link_to_file.tx
+++ b/root/inc/link_to_file.tx
@@ -2,7 +2,7 @@
 my $title = $file.documentation || $file.path;
 
 # If there is pod for this file...
-if $file.documentation || $file.pod_lines.size() || $file.module.map(-> $m { $m.associated_pod ? 1 : 0 }).sum() {
+if $file.documentation || $file.pod_lines.size() || $file.has_associated_pod {
 -%]
 <a href="[%
   if !$permalinks {
@@ -10,7 +10,7 @@ if $file.documentation || $file.pod_lines.size() || $file.module.map(-> $m { $m.
     if $file.documentation
         && $file.authorized
         && $file.indexed
-        && $file.module.map(-> $m { $m.authorized && $m.indexed ? 1 : 0 }).sum() {
+        && $file.has_authorized_module {
       # Use /pod/$name.
       '/pod/' ~ $file.documentation;
     }

--- a/root/inc/module_install.tx
+++ b/root/inc/module_install.tx
@@ -6,7 +6,7 @@
         <h4 class="modal-title">Module Install Instructions</h4>
       </div>
       <div class="modal-body">
-        %%  my $name = $release.main_module || $module.documentation || $module.module.0.name || $module.package;
+        %%  my $name = $release.main_module || $file.documentation || $file.module.0.name || $file.package;
         <p>To install [% $name %], copy and paste the appropriate command in to your terminal.</p>
         <p><a href="/dist/App-cpanminus/view/bin/cpanm">cpanm</a></p>
         <pre><code>cpanm [% $name || ($release.author ~ '/' ~ $release.archive) %]</code></pre>

--- a/root/inc/twitter/module.tx
+++ b/root/inc/twitter/module.tx
@@ -1,5 +1,5 @@
 <meta name="twitter:card"        content="summary" />
 <meta name="twitter:url"         content="[% $page_url() %]" />
-<meta name="twitter:title"       content="[% $module.documentation %]" />
-<meta name="twitter:description" content="[% $module.abstract %]" />
+<meta name="twitter:title"       content="[% $file.documentation %]" />
+<meta name="twitter:description" content="[% $file.abstract %]" />
 <meta name="twitter:site"        content="metacpan" />

--- a/root/inc/version_select.tx
+++ b/root/inc/version_select.tx
@@ -1,8 +1,8 @@
 <select onchange="document.location.href=[%
 block navigate -> {
   "'/release/'+this.value";
-  if $module {
-    "+'/view/" ~ $module.path ~ "'";
+  if $file {
+    "+'/view/" ~ $file.path ~ "'";
   }
 }
 %]" class="[% $class %]">

--- a/root/inc/version_select/diff.tx
+++ b/root/inc/version_select/diff.tx
@@ -2,5 +2,5 @@
 %%    head => 'Diff with version',
 %%  }
 %%  override navigate -> {
-'/release/[% $release.author %]/[% $release.name %]/diff/' + encodeURIComponent(this.value)[% if $module { %] + '/[% $module.path %]'[% } %]
+'/release/[% $release.author %]/[% $release.name %]/diff/' + encodeURIComponent(this.value)[% if $file { %] + '/[% $file.path %]'[% } %]
 %%  }

--- a/root/pod.tx
+++ b/root/pod.tx
@@ -1,9 +1,9 @@
 %%  cascade base::release {
 %%    twitter_card_inc  => $twitter_card_inc || 'inc/twitter/module.tx',
-%%    meta_description  => $meta_description || $module.abstract,
+%%    meta_description  => $meta_description || $file.abstract,
 %%    title             => $title ||
-%%      ($module.documentation || $module.module.0.name ) ~
-%%      ($module.abstract ? ' - ' ~ $module.abstract : ''),
+%%      ($file.documentation || $file.module.0.name ) ~
+%%      ($file.abstract ? ' - ' ~ $file.abstract : ''),
 %%    page_class  => $page_class || 'page-pod',
 %%  }
 %%  override left_nav_lead -> {
@@ -11,7 +11,7 @@
 %%    ? '/release/' ~ $release.author ~ '/' ~ $release.name
 %%    : '/dist/' ~ $release.distribution;
   <li>
-    Distribution: <a href="[% $release_base %]">[% $module.distribution %]</a>
+    Distribution: <a href="[% $release_base %]">[% $file.distribution %]</a>
   </li>
   %%  if $documented_module.version {
   <li>
@@ -19,17 +19,17 @@
   </li>
   %%  }
   <li>
-    <a data-keyboard-shortcut="g s" href="[% $release_base %]/source/[% $module.path %]">Source</a>
-    (<a href="[% $release_base %]/source/[% $module.path %]?raw=1">raw</a>)
+    <a data-keyboard-shortcut="g s" href="[% $release_base %]/source/[% $file.path %]">Source</a>
+    (<a href="[% $release_base %]/source/[% $file.path %]?raw=1">raw</a>)
   </li>
-  %%  if $module.pod_path {
+  %%  if $file.pod_path {
   <li>
-    <a data-keyboard-shortcut="g p" href="[% $release_base %]/source/[% $module.pod_path %]">Pod Source</a>
-    (<a href="[% $release_base %]/source/[% $module.pod_path %]?raw=1">raw</a>)
+    <a data-keyboard-shortcut="g p" href="[% $release_base %]/source/[% $file.pod_path %]">Pod Source</a>
+    (<a href="[% $release_base %]/source/[% $file.pod_path %]?raw=1">raw</a>)
   </li>
   %%  }
   <li>
-    %%  my $parent_path = $module.path.replace(rx('/?[^/]+$'),'');
+    %%  my $parent_path = $file.path.replace(rx('/?[^/]+$'),'');
     <a data-keyboard-shortcut="g b" href="[% $release_base %]/source[% $parent_path ? '/' ~ $parent_path : '' %]">Browse</a>
     (<a href="[% $release_base %]/source[% $parent_path ? '/' ~ $parent_path : '' %]?raw=1">raw</a>)
   </li>
@@ -41,15 +41,15 @@
   %%    $pod | mark_raw;
   %%  }
   %%  else if $pod_error {
-  <p class="pod-error">Error rendering POD for <code>[% $module.name %]</code> - [% $pod_error %]</p>
+  <p class="pod-error">Error rendering POD for <code>[% $file.name %]</code> - [% $pod_error %]</p>
   %%  }
   %%  else {
   %%    my $release_base = $permalinks || $release.status != 'latest'
   %%      ? '/release/' ~ $release.author ~ '/' ~ $release.name
   %%      : '/dist/' ~ $release.distribution;
   <p class="pod-error">
-    No POD found for <code>[% $module.name %]</code>.
-    Time to <a href="[% $release_base %]/source/[% $module.path %]">read the source</a>?
+    No POD found for <code>[% $file.name %]</code>.
+    Time to <a href="[% $release_base %]/source/[% $file.path %]">read the source</a>?
   </p>
   %%  }
 </div>

--- a/root/raw.tx
+++ b/root/raw.tx
@@ -2,7 +2,7 @@
 %%  override content -> {
 
 <p>
-  <a href="/release/[% $module.author %]/[% $module.release %]/raw/[% $module.path %]?download=1">download</a>
+  <a href="/release/[% $file.author %]/[% $file.release %]/raw/[% $file.path %]?download=1">download</a>
 </p>
 
 <pre>[% $source %]</pre>

--- a/root/release.tx
+++ b/root/release.tx
@@ -86,7 +86,7 @@
   <ul>
     %%  for $examples -> $file {
     <li>
-      %%  if $file.path.match(rx('\.pod')) {
+      %%  if $file.mime == 'text/x-pod' {
       %%    include inc::link_to_file { file => $file, linktext => $file.path };
       %%  }
       %%  else {

--- a/root/source.tx
+++ b/root/source.tx
@@ -48,13 +48,13 @@
 %%  override content -> {
 <div class="content">
 %%  if !$file.binary {
-  %%  if $filetype == 'markdown' {
+  %%  if $file.mime == 'text/markdown' {
     [% $source | markdown | filter_html %]
   %%  }
   %%  else {
 <pre id="metacpan_source" class="line-numbers pod-toggle[% if $file.sloc > 10 { " pod-hidden"; } %]" data-pod-lines="[%
   $file.pod_lines.map(-> $lines { $lines[0] ~ '-' ~ ($lines[0]+$lines[1]) }).join(', ');
-%]"><code class="language-[% $filetype %]">[% $source %]</code></pre>
+%]"><code class="language-[% $syntax_type %]">[% $source %]</code></pre>
   %%  }
 %%  }
 %%  else {

--- a/root/static/less/silk.less
+++ b/root/static/less/silk.less
@@ -1,23 +1,17 @@
-.silk-folder {
-    padding-left: 20px;
-    background-repeat: no-repeat !important;
-    background: url(/static/icons/folder.png);
-}
-
-.silk-page-white-code {
-    padding-left: 20px;
-    background-repeat: no-repeat !important;;
-    background: url(/static/icons/page_white_code.png);
-}
-
-.silk-page-white {
+.file-table-entry {
     padding-left: 20px;
     background-repeat: no-repeat !important;
     background: url(/static/icons/page_white.png);
-}
 
-.silk-page-white-c {
-    padding-left: 20px;
-    background-repeat: no-repeat !important;
-    background: url(/static/icons/page_white_c.png);
+    &[data-directory] {
+        background: url(/static/icons/folder.png);
+    }
+
+    &[data-mime-type="text/x-script.perl"],
+    &[data-mime-type="text/x-script.perl-module"] {
+        background: url(/static/icons/page_white_code.png);
+    }
+    &[data-mime-type="text/x-c"] {
+        background: url(/static/icons/page_white_c.png);
+    }
 }

--- a/t/controller/source.t
+++ b/t/controller/source.t
@@ -139,6 +139,7 @@ test_psgi app, sub {
     foreach my $ft_test (@tests) {
         my ( $filetype, $file ) = @$ft_test;
         ref $file or $file = { path => $file };
+        $file = MetaCPAN::Web::Role::FileData->_groom_file($file);
 
         is
             MetaCPAN::Web::Controller::Source->detect_filetype($file),


### PR DESCRIPTION
This adds a role for cleaning up file data coming from the API. Fixes the MIME type, and sets some flags relating to the available modules.

Uses the new more consistent MIME type directly in some places, rather than having matches on the file extension in various places around the codebase.

Also renames a bunch of variables to file rather than module, for better consistency.