### PR TITLE
Enable full TLS hostname verification on API requests

### DIFF
--- a/lib/MetaCPAN/Web/Model/API.pm
+++ b/lib/MetaCPAN/Web/Model/API.pm
@@ -34,6 +34,7 @@ sub client {
                 'MetaCPAN-Web/1.0 (https://github.com/metacpan/metacpan-web)',
             max_connections_per_host => $ENV{NET_ASYNC_HTTP_MAXCONNS} || 5,
             SSL_verify_mode          => SSL_VERIFY_PEER,
+            SSL_verifycn_scheme      => 'http',
             timeout                  => 10,
         );
         $_[0]->loop->add($http);


### PR DESCRIPTION
When connecting with HTTPS, proper hostname verification isn't enabled without setting the verify scheme.