### PR TITLE
Changes Parser: avoid warnings with too large numbers

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -106,6 +106,8 @@ sub _parse_version {
     my ($v) = @_;
     $v =~ s/-TRIAL$//;
     $v =~ s/_//g;
+    $v =~ s/\A0+//;
+    use warnings FATAL => 'all';
     eval { $v = version->parse($v) };
     return $v;
 }


### PR DESCRIPTION
version handles large numbers badly, possibly producing version numbers like v.Inf. These will emit warnings, so we can just make those fatal and avoid the version object conversion.