### PR TITLE
remove unneeded svg headers to make embedding easier

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Activity.pm
+++ b/lib/MetaCPAN/Web/Controller/Activity.pm
@@ -50,7 +50,7 @@ sub activity : Private {
     $c->res->content_type('image/svg+xml');
     $c->res->headers->expires( time + 86400 );
     $c->stash( {
-        data     => $line->{activity},
+        activity => $line->{activity},
         template => 'activity.svg.tx',
     } );
 }

--- a/root/activity.svg.tx
+++ b/root/activity.svg.tx
@@ -1,12 +1,8 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-
 <svg width="170" height="22" version="1.1"
 xmlns="http://www.w3.org/2000/svg">
-%%  my $max = $data.max() || 1;
+%%  my $max = $activity.max() || 1;
 %%  my $width = (170 / $data.size()).int();
-%%  for $data -> $week {
+%%  for $activity -> $week {
 %%      my $height = $week / $max * 20;
 <rect x="[% $~week * $width %]"
       y="[% 20 - $height %]"

--- a/root/inc/river_gauge.tx
+++ b/root/inc/river_gauge.tx
@@ -2,7 +2,7 @@
 %%# means browsers will display the <title> elements of the SVG.  Yay!
 %%  if $river {
 <span class="river-gauge-gauge">
-  %% include "river/gauge.svg.tx" { embed => 1, river => $river }
+  %% include "river/gauge.svg.tx" { river => $river }
 </span>
 %%  }
 %%  else {

--- a/root/river/gauge.svg.tx
+++ b/root/river/gauge.svg.tx
@@ -3,10 +3,6 @@
     my $empty  = "#e4e2e2";
     my $filled = "#7ea3f2";
 -%]
-%%  if !$embed {
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-%%  }
 %%  if defined($bucket) {
   <svg width="24px"
        height="15px"


### PR DESCRIPTION
svg XML header and doctype are generally not necessary, and removing them makes it easier to embed the files. Also rename the variable used for activity from the ambiguous 'data' to something else.