### PR TITLE
Changes Model: compare parsed versions as strings

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -28,7 +28,7 @@ sub release_changes {
 
         my @changelogs;
         while ( my $r = shift @releases ) {
-            if ( $r->{version_parsed} eq $version ) {
+            if ( "$r->{version_parsed}" eq "$version" ) {
                 $r->{current} = 1;
                 push @changelogs, $r;
                 if ( $opts{include_dev} ) {
@@ -64,7 +64,7 @@ sub by_releases {
                 my @releases = _releases( $change->{changes_text} );
 
                 while ( my $r = shift @releases ) {
-                    if ( $r->{version_parsed} eq $version ) {
+                    if ( "$r->{version_parsed}" eq "$version" ) {
                         $r->{current} = 1;
 
                         # Used in Controller/Feed.pm Line 37


### PR DESCRIPTION
Some versions will fail to parse. If compared directly to another version with eq, version.pm will try to parse the version again. Since we already tried to parse the version, this isn't useful.

All valid versions will already have been normalized, so we can just compare them as strings.