### PR TITLE
limit headings in content to only needed size

### DIFF
--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -354,7 +354,7 @@ h1, .h1, h2, .h2, h3, .h3 {
       'menu content'
       'menu pagination';
     grid-template-columns: @sidebar-width ~"calc(100vw -" @sidebar-width ~")";
-    grid-template-rows: auto;
+    grid-template-rows: max-content max-content;
     line-height: 1.54em;
     margin-top: 57px;
 }


### PR DESCRIPTION
When the body content is very small, the headings will expand. Limit the first two rows to the size of their content.

Example of page showing bug: https://metacpan.org/release/ABH/Mozilla-CA-20120118/source/lib/Mozilla