### PR TITLE
Changes model: try harder to avoid comparing versions to non-versions

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -87,10 +87,13 @@ sub _releases {
         = MetaCPAN::Web::Model::API::Changes::Parser->parse($content);
 
     my @releases = sort {
-        my $cmp;
-        eval { $cmp = $b->{version_parsed} cmp $a->{version_parsed}; 1 }
-            ? $cmp
-            : "$b->{version_parsed}" cmp "$a->{version_parsed}"
+        my $a_v = $a->{version_parsed};
+        my $b_v = $b->{version_parsed};
+        if ( !ref $a || !ref $b ) {
+            $a_v = "$a_v";
+            $b_v = "$b_v";
+        }
+        $a_v cmp $b_v;
         }
         map {
         my $v     = _parse_version( $_->{version} );


### PR DESCRIPTION
If the parsed version is not an object, it failed to parse. In that case, comparing using version's routines isn't going to give a useful result anyway. Use a normal cmp by forcing both args to be strings if one isn't.