### PR TITLE
Fix handling of non-UTF8 source code

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Source.pm
+++ b/lib/MetaCPAN/Web/Controller/Source.pm
@@ -68,6 +68,12 @@ sub view : Private {
         } );
     }
     elsif ( exists $source->{raw} ) {
+
+        # hack to work around Xslate. utf8-flagged content will be encoded to
+        # output, which is ok. non-utf8 content may be decoded before
+        # re-encoding, which can break.
+        utf8::upgrade( $source->{raw} );
+
         $file->{content} = $source->{raw};
         $c->stash( {
             file     => $file,

--- a/lib/MetaCPAN/Web/Model/API.pm
+++ b/lib/MetaCPAN/Web/Model/API.pm
@@ -169,7 +169,7 @@ sub request {
 
 # cache these
 my $encoding = Encode::find_encoding('utf-8-strict')
-    or warn 'UTF-8 Encoding object not found';
+    or die 'UTF-8 Encoding object not found';
 my $encode_check = ( Encode::FB_CROAK | Encode::LEAVE_SRC );
 
 # TODO: Check if it's possible for the API to return any other charset.
@@ -193,7 +193,12 @@ sub raw_api_response {
         }
     }
     catch {
-        warn $_[0];
+        if ( my $logger = $self->log ) {
+            $logger->info( $_[0] );
+        }
+        else {
+            warn $_[0];
+        }
     };
 
     return +{ raw => $data, code => $response->code };


### PR DESCRIPTION
When Text::Xslate is given data with the utf8 flag off, but with valid
non-strict utf8 sequences in it, those sequences will be decoded. That
will then produce errors when attempting to encode it for output. We
only really run into this problem when showing the source of a file,
since those may have arbitrary bytes.

Force the source content given to Xslate to always have the utf8 flag on,
so that Text::Xslate inserts the non-decoded "characters" directly into
the output. They will essentially be mojibake, but this is acceptable
since the original file had badly encoded data in it.