### PR TITLE
Fix handling of non-versions when parsing Changes files (again)

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -89,7 +89,7 @@ sub _releases {
     my @releases = sort {
         my $a_v = $a->{version_parsed};
         my $b_v = $b->{version_parsed};
-        if ( !ref $a || !ref $b ) {
+        if ( !ref $a_v || !ref $b_v ) {
             $a_v = "$a_v";
             $b_v = "$b_v";
         }

--- a/lib/MetaCPAN/Web/Model/API/Changes/Parser.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes/Parser.pm
@@ -1,7 +1,6 @@
 package MetaCPAN::Web::Model::API::Changes::Parser;
 
 use Moose;
-use version qw();
 
 my @months = qw( Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec );
 my %months = map +( $months[$_] => $_ + 1 ), 0 .. $#months;
@@ -28,6 +27,19 @@ our $W3CDTF_REGEX = qr{
             )?
         )?
     )?
+}x;
+
+our $VERSION_REGEX = qr{
+    (?:
+        v [0-9]+ (?: (?:\.[0-9]+ )+ (?:_[0-9]+)? )?
+        |
+        (?:[0-9]+)? (?:\.[0-9]+){2,} (?:_[0-9]+)?
+        |
+        [0-9]* \.[0-9]+ (?: _[0-9]+ )?
+        |
+        [0-9]+ (?: _[0-9]+ )?
+    )
+    (?: -TRIAL )?
 }x;
 
 our $UNKNOWN_VALS = join(
@@ -62,7 +74,7 @@ sub parse {
     for my $linenr ( 0 .. $#lines ) {
         my $line = $lines[$linenr];
         if ( $line
-            =~ /^(?:version\s+)?($version::LAX(?:-TRIAL)?)(\s+(.*))?$/i )
+            =~ /^(?:version\s+)?($VERSION_REGEX)\.?(\s+(.*))?$/i )
         {
             my $version = $1;
             my $note    = $3;

--- a/lib/MetaCPAN/Web/Model/API/Changes/Parser.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes/Parser.pm
@@ -74,7 +74,8 @@ sub parse {
     for my $linenr ( 0 .. $#lines ) {
         my $line = $lines[$linenr];
         if ( $line
-            =~ /^(?:version\s+)?($VERSION_REGEX)\.?(\s+(.*))?$/i )
+            =~ /^(?:(?:version|=item|=head[0-4])\s+)?($VERSION_REGEX)\.?(\s+(.*))?$/i
+            )
         {
             my $version = $1;
             my $note    = $3;


### PR DESCRIPTION
This should actually really this time fix the handling of non-versions that look like versions in changes files.