### PR TITLE
clean up code for pages with no sidebar, and grid layout

### DIFF
--- a/root/author/releases.tx
+++ b/root/author/releases.tx
@@ -1,6 +1,5 @@
-%%  cascade base {
+%%  cascade base with inc::no_sidebar {
 %%      title      => $title || "All releases by " ~ $author.pauseid,
-%%      body_class => 'no-sidebar',
 %%  }
 %%  override content -> {
 <div class="content">

--- a/root/base.tx
+++ b/root/base.tx
@@ -63,54 +63,22 @@
                 </svg>
               </a>
             </div>
+            %%  block header_nav_menu -> {
             <ul class="nav navbar-nav menu-items hidden-xs hidden-sm">
-            [%-
-                my $menu = [
-                    {
-                        title   => "About",
-                        path    => ["/about"],
-                    },
-                    {
-                        title   => "grep::cpan",
-                        path    => ["https://grep.metacpan.org/"],
-                    },
-                    {
-                        title   => "Recent",
-                        path    => ["/recent"],
-                    },
-                    {
-                        title   => "News",
-                        path    => ["/news"],
-                    },
-                    {
-                        title   => "FAQ",
-                        path    => ["/about/faq"],
-                    },
-                    {
-                        title   => "Tools",
-                        path    => ["/tools"],
-                    },
-                    {
-                        title   => "API",
-                        path    => ["https://fastapi.metacpan.org/"],
-                    },
-                ];
-            -%]
-            %%  for $menu -> $item {
-            %%      my $active = $item.path.map(-> $p { $current[$p] ? 'active' : '' }).join('');
-              <li class="[% $active || $item.class %]">
-                  <a href="[% $item.path.0 %]">
-                      [%- if $item.icon { %]<i class="[% $item.icon %]"></i>[% } %]
-                      [%- if $item.image { %]<img src="[% $item.image %]" [%- if $item.alt { %] alt="[% $item.alt %]"[% } %]/>[% } -%]
-                      [% $item.title -%]
-                  </a>
-              </li>
-            %% }
+              <li><a href="/about">About</a></li>
+              <li><a href="https://grep.metacpan.org/">grep::cpan</a></li>
+              <li><a href="/recent">Recent</a></li>
+              <li><a href="/news">News</a></li>
+              <li><a href="/about/faq">FAQ</a></li>
+              <li><a href="/tools">Tools</a></li>
+              <li><a href="https://fastapi.metacpan.org/">API</a></li>
             </ul>
+            %%  }
             <ul class="nav navbar-nav navbar-right">
                 <button type="button" class="searchbar-btn visible-xs visible-sm">
                     <i class="fa fa-search button-fa-icon"></i>
                 </button>
+                %%  block search_bar -> {
                 <form action="/search" class="searchbar-form visible-md visible-lg search-form form-horizontal">
                    <input type="hidden" name="size" id="metacpan_search-size" value="20">
                   <div class="form-group">
@@ -120,13 +88,14 @@
                       </div>
                   </div>
                 </form>
-                %% if ! $current['/'] {
+                %%  }
+                %%  block sidebar_toggle_button -> {
                     <li class="icon-slidepanel visible-xs visible-sm">
                       <button data-toggle="slidepanel" data-target=".slidepanel">
                         <i class="fa fa-bars button-fa-icon"></i>
                       </button>
                     </li>
-                %% }
+                %%  }
                 <form action="/account/logout" method="POST" id="metacpan-logout"></form>
                 <li class="dropdown logged_in" style="display: none;">
                     <button type="button" class="dropdown-toggle" data-toggle="dropdown">
@@ -167,7 +136,7 @@
                 </li>
             </ul>
         </nav>
-        <div class="page-content [% $page_class %]">
+        <div class="page-content [% block page_content_class -> { } %]">
 
         %%  if $site_alert_message {
             <div class="row">
@@ -178,27 +147,27 @@
         %%  }
 
         %%  block full_content -> {
-                  <!--TODO: Banner Addition - Temporary banner at top of each page-->
-                  <div class="temporary-banner">
-                    <i class="fas fa-info-circle"></i>
-                    The Perl Advent Calendar
-                    <a href="http://cfp.perladvent.org/" target="_blank">
-                      needs more articles
-                    </a>
-                    for 2022.
-                    <a href="https://github.com/perladvent/Perl-Advent/issues/new?assignees=&labels=article&template=i-want-to-write-an-article.md" target="_blank">
-                      Submit your idea today!
-                    </a>
-                  </div>
-                  %%  block left_nav -> {
-                    <div class="nav-list-container slidepanel">
-                      <ul class="nav-list [% block left_nav_classes -> { } %]">
-                          %% block left_nav_content -> {}
-                      </ul>
-                    </div>
-                  %%  }
-                  %%  block breadcrumbs -> { }
-                  %%  block content -> { }
+          <!--TODO: Banner Addition - Temporary banner at top of each page-->
+          <div class="temporary-banner">
+            <i class="fas fa-info-circle"></i>
+            The Perl Advent Calendar
+            <a href="http://cfp.perladvent.org/" target="_blank">
+              needs more articles
+            </a>
+            for 2022.
+            <a href="https://github.com/perladvent/Perl-Advent/issues/new?assignees=&labels=article&template=i-want-to-write-an-article.md" target="_blank">
+              Submit your idea today!
+            </a>
+          </div>
+          %%  block left_nav -> {
+            <div class="nav-list-container slidepanel">
+              <ul class="nav-list [% block left_nav_classes -> { } %]">
+                  %% block left_nav_content -> {}
+              </ul>
+            </div>
+          %%  }
+          %%  block breadcrumbs -> { }
+          %%  block content -> { }
         %%  }
         </div>
         <footer class="footer">

--- a/root/home.tx
+++ b/root/home.tx
@@ -1,11 +1,11 @@
-%%  cascade base {
+%%  cascade base with inc::no_sidebar {
 %%      canonical   => $canonical || '/',
 %%      rss         => $rss || '/recent.rss',
 %%      rss_title   => $rss_title || 'Recent CPAN Uploads - MetaCPAN',
-%%      body_class  => 'page-home',
 %%  }
-%%  override left_nav -> { }
 %%  override search_bar -> { }
+%%  override header_nav_menu -> { }
+%%  after page_content_class -> { ' page-home' }
 %%  override content -> {
 <script type="application/ld+json">
 [
@@ -24,19 +24,6 @@
   }
 ]
 </script>
-
-<!--TODO: Banner Addition - Temporary banner at top of each page-->
-<div class="home-temporary-banner">
-  <i class="fas fa-info-circle"></i>
-  The Perl Advent Calendar
-  <a href="http://cfp.perladvent.org/" target="_blank">
-    needs more articles
-  </a>
-  for 2022.
-  <a href="https://github.com/perladvent/Perl-Advent/issues/new?assignees=&labels=article&template=i-want-to-write-an-article.md" target="_blank">
-    Submit your idea today!
-  </a>
-</div>
 
 <div class="home">
   <div class="home-hero">

--- a/root/inc/no_sidebar.tx
+++ b/root/inc/no_sidebar.tx
@@ -1,0 +1,3 @@
+%%  after page_content_class -> { ' no-sidebar' }
+%%  override sidebar_toggle_button -> { }
+%%  override left_nav -> { }

--- a/root/login/pause.tx
+++ b/root/login/pause.tx
@@ -1,6 +1,4 @@
-%%  cascade base {
-%%      body_class => 'no-sidebar',
-%%  }
+%%  cascade base with inc::no_sidebar
 %%  override content -> {
 <div class="jumbotron">
     <div class="container-fluid">
@@ -23,4 +21,3 @@
     </div>
 </div>
 %%  }
-

--- a/root/no_result.tx
+++ b/root/no_result.tx
@@ -1,6 +1,5 @@
-%%  cascade base::error {
+%%  cascade base::error with inc::no_sidebar {
 %%      title      => $title || 'Search for "' ~ $search_query ~ '"',
-%%      body_class => 'no-sidebar',
 %%  }
 %%  override content -> {
     <div class="content no-results text-center">

--- a/root/pod.tx
+++ b/root/pod.tx
@@ -4,7 +4,6 @@
 %%    title             => $title ||
 %%      ($file.documentation || $file.module.0.name ) ~
 %%      ($file.abstract ? ' - ' ~ $file.abstract : ''),
-%%    page_class  => $page_class || 'page-pod',
 %%  }
 %%  override left_nav_lead -> {
 %%  my $release_base = $permalinks || $release.status != 'latest'

--- a/root/search.tx
+++ b/root/search.tx
@@ -1,6 +1,5 @@
-%%  cascade base::search {
+%%  cascade base::search with inc::no_sidebar {
 %%      title      => $title || 'Search for "' ~ $search_query ~ '"',
-%%      body_class => 'no-sidebar',
 %%  }
 %%  override content -> {
 <div class="content search-results">

--- a/root/static/js/search.js
+++ b/root/static/js/search.js
@@ -2,13 +2,6 @@ window.addEventListener('DOMContentLoaded', () => {
   const searchBarBtn = document.querySelector('.searchbar-btn');
   const searchBarForm = document.querySelector('.searchbar-form');
   const searchBarInput = document.querySelector('.searchbar-form input[type="text"]');
-  const searchBarHome = document.querySelector('.page-home .searchbar-form');
-
-  // Remove the searchbar from the navbar on the homepage because
-  // it intereferes with the autocomplete-suggestions on the homepage search
-  if (searchBarHome) {
-    searchBarHome.remove();
-  }
 
   searchBarBtn.addEventListener('click', () => {
     searchBarForm.classList.remove('visible-md');

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -354,19 +354,14 @@ h1, .h1, h2, .h2, h3, .h3 {
       'menu content'
       'menu pagination';
     grid-template-columns: @sidebar-width ~"calc(100vw -" @sidebar-width ~")";
-    grid-template-rows: max-content max-content;
+    grid-template-rows: max-content max-content max-content max-content;
     line-height: 1.54em;
     margin-top: 57px;
 }
 
 @media (min-width: 0) and (max-width: @screen-sm-max) {
     .page-content {
-        grid-template-areas:
-            // TODO: Banner Addition - Tempory banner at top of each page. Remove this once we take the banner down.
-            'banner'
-            'breadcrumbs'
-            'content';
-        grid-template-columns: 1fr;
+        grid-template-columns: 0 1fr;
     }
 }
 
@@ -399,12 +394,7 @@ h1, .h1, h2, .h2, h3, .h3 {
     max-width: 1200px;
     overflow-x: hidden;
     width: 100%;
-}
-
-// Nested content classes create too much padding
-// especially on mobile devices
-.content .content {
-  padding: 0;
+    grid-area: content;
 }
 
 .site-alert-message {
@@ -458,14 +448,8 @@ h1, .h1, h2, .h2, h3, .h3 {
   scroll-margin-top: 60px;
 }
 
-.no-sidebar .nav-list-container,
-.no-sidebar .icon-slidepanel {
-    display: none !important;
-}
-
-.no-sidebar .page-content {
+.no-sidebar.page-content {
     align-items: center;
-    grid-template-areas: 'content';
-    grid-template-columns: 1fr;
+    grid-template-columns: 0 1fr;
     justify-content: center;
 }

--- a/root/static/less/home.less
+++ b/root/static/less/home.less
@@ -1,23 +1,11 @@
-.page-home .nav-list-container {
-    display: none;
-}
-
-.page-home .page-content {
-    align-items: center;
-    // TODO: Banner Addition - Temporarily disable flex, but add this back in once we remove the temporary banner
-    /*display: flex;*/
-    grid-template-areas: 'content';
-    grid-template-columns: 1fr;
-    justify-content: center;
-}
-
-.page-home .menu-items {
-    visibility: hidden;
+.page-home {
+    grid-template-rows: max-content max-content auto max-content;
 }
 
 .home {
     display: grid;
     margin: 50px 0;
+    grid-area: content;
 
     .home-hero {
       display: grid;
@@ -89,27 +77,5 @@
     .keyboard-shortcuts {
         justify-self: end;
         margin-top: 10px;
-    }
-}
-
- .sponsor-grid {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 30px;
-    place-content: center;
-}
-
-.metahack-platinum {
-    margin-top: -25px;
-    text-align: center;
-    font-size: 120%;
-
-    img.booking {
-        height: 1.1em;
-    }
-
-    img.cpanel {
-        height: 1em;
-        vertical-align: baseline;
     }
 }

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -9,8 +9,8 @@
 }
 
 // TODO: Banner Addition - Temporary banner at top of each page
-.temporary-banner,
-.home-temporary-banner {
+.temporary-banner {
+  grid-area: banner;
   background-color: #2e3a47;
   color: #fff;
   display: flex;
@@ -21,24 +21,6 @@
   text-align: center;
   width: 100%;
 
-  .fa-info-circle {
-    display: grid;
-    place-content: center;
-  }
-
-  a {
-    color: #c0d2e4;
-    text-decoration: underline;
-  }
-}
-
-// TODO: Banner Addition - Use a different banner for the homepage
-.page-home .temporary-banner {
-  display: none;
-}
-
-// TODO: Banner Addition - Temporary banner at top of homepage
-.home-temporary-banner {
   .fa-info-circle {
     display: grid;
     place-content: center;

--- a/root/static/less/print.less
+++ b/root/static/less/print.less
@@ -1,7 +1,7 @@
 @media print {
     .pod { margin: 0px; border: 0px solid #000; padding: 0px}
     .home, .header, .search-bar, .box-right, .footer, a.favorite {display:none}
-    .page-pod {
+    .page-content {
         .dependencies,
         .search-form,
         .dropdown,

--- a/root/static/less/search.less
+++ b/root/static/less/search.less
@@ -23,14 +23,6 @@
     }
 }
 
-.page-home .navbar-right {
-    .searchbar-form,
-    .searchbar-btn {
-        display: none !important;
-    }
-}
-
-
 .search-group .fa-search {
     color: @input-color;
     font-size: 20px;


### PR DESCRIPTION
Create a mixin template that can be used to remove everything connected with the sidebar. This removes the actual content from the pages, making it unnecessary to remove the elements with CSS. A class is still provided to allow changing the grid layout.

Normalize the home page to mostly work like other no sidebar pages. Also have it remove the extra elements it does not want, rather than hiding them. With this cleanup, the separate banner code for the home page is not needed.

Fix the grid row sizing to use max-content. This fixes various places that would show large empty spaces for elements that were missing.