### PR TITLE
Page Layout: revise for consistent primary grid

### DIFF
--- a/root/about/contributors.tx
+++ b/root/about/contributors.tx
@@ -95,10 +95,8 @@
   });
 </script>
 
-<div class="content about">
   <i class="fa fa-spinner fa-spin" id="metacpan_author-result-loading"></i>
   <div id="metacpan_author-count"></div>
   <div class="author-results"></div>
-</div>
 
 %%  }

--- a/root/about/meta_hack.tx
+++ b/root/about/meta_hack.tx
@@ -2,7 +2,6 @@
 %%      title => $title || 'meta::hack',
 %%  }
 %%  override content -> {
-<div class="content about">
   <div class="row">
     <div class="col-md-12">
       <h1>meta::hack</h1>
@@ -55,5 +54,4 @@
       </div>
     </div>
   </div>
-</div>
 %%  }

--- a/root/about/sponsors.tx
+++ b/root/about/sponsors.tx
@@ -2,7 +2,7 @@
 %%      title => $title || 'Sponsors',
 %%  }
 %%  override content -> {
-<div class="content about about-sponsor">
+<div class="about-sponsor">
     <div class="sponsor">
         <table>
             <tr>
@@ -370,6 +370,5 @@ community.
     <br />
     <center><strong>If you are interested in sponsoring MetaCPAN, please don't hesitate to contact us at <a href="mailto:noc@metacpan.org">noc@metacpan.org</a>.</strong></center>
 </div>
-
 %%  }
 

--- a/root/account/favorite/list.tx
+++ b/root/account/favorite/list.tx
@@ -1,10 +1,8 @@
 %%  cascade base::account
 %%  override content -> {
-<div class="content">
     %%  include inc::favorite_table {
         %%  favorites => $faves,
         %%  author => 1,
         %%  tablesorter => 1,
     %%  }
-</div>
 %%  }

--- a/root/account/identities.tx
+++ b/root/account/identities.tx
@@ -1,6 +1,6 @@
 %%  cascade base::account
 %%  override content -> {
-<div class="content account-settings">
+<div class="account-settings">
     <div class="alert alert-warning">
       <h4><strong>Information</strong></h4>
       Below are the identities which you may use to log in to MetaCPAN. (Note
@@ -27,6 +27,6 @@
         </td>
     </tr>
 %%  }
-</table>
+    </table>
 </div>
 %%  }

--- a/root/account/login.tx
+++ b/root/account/login.tx
@@ -1,6 +1,5 @@
 %%  cascade base::account
 %%  override content -> {
-<div class="content account-settings">
     %%  if $success == "mail_sent" {
     <p>An email has been sent to the email address associated with the PAUSE account. Please check your inbox and verify your account by visiting the link in the mail.</p>
     <p>If you do not receive the email, please ensure that you have properly set up email forwarding for your PAUSE account.</p>
@@ -8,5 +7,4 @@
     %%  else if $error {
     <p>There has been an error with your request: [% $error %]</p>
     %%  }
-</div>
 %%  }

--- a/root/account/profile.tx
+++ b/root/account/profile.tx
@@ -1,6 +1,6 @@
 %%  cascade base::account
 %%  override content -> {
-<div class="content account-settings">
+<div class="account-settings">
     %%  if $no_profile {
     <div class="alert alert-danger">
       <h4 class="alert-heading">Error</h4>
@@ -247,7 +247,6 @@
     <input type="submit" value="Save Profile" class="btn btn-primary btn-large search-btn" />
     </form>
     %%  }
-</div>
 
 <script>
 
@@ -341,4 +340,5 @@ function formFixer( e ) {
     }
 }
 </script>
+</div>
 %%  }

--- a/root/account/turing.tx
+++ b/root/account/turing.tx
@@ -1,6 +1,5 @@
 %%  cascade base::account
 %%  override content -> {
-<div class="content account-settings">
     %%  if $error {
     <div class="alert alert-danger">
       <h4 class="alert-heading"><strong>Error</strong></h4>
@@ -22,5 +21,4 @@
         </form>
     </fieldset>
     %%  }
-</div>
 %%  }

--- a/root/author.tx
+++ b/root/author.tx
@@ -126,7 +126,6 @@
     </li>
 %%  }
 %%  override content -> {
-<div class="content">
     <div id="metacpan_feed_subscription" class="page-header">
         <p>
           [% if $releases.0 { $releases.size() } else { 'No' } %] distributions uploaded by
@@ -165,5 +164,4 @@
         <p>No favorite distributions from <a href="/author/[% $author.pauseid %]">[% $author.pauseid %]</a> could be found</p>
     </div>
     %%  }
-</div>
 %%  }

--- a/root/author/releases.tx
+++ b/root/author/releases.tx
@@ -2,8 +2,8 @@
 %%      title      => $title || "All releases by " ~ $author.pauseid,
 %%  }
 %%  override content -> {
-<div class="content">
   %%  include inc::release_table { header => 1, tablesorter => 0 }
+%%  }
+%%  override pagination -> {
   %%  include inc::pager
-</div>
 %%  }

--- a/root/base.tx
+++ b/root/base.tx
@@ -132,9 +132,7 @@
             </ul>
         </nav>
         <div class="page-content [% block page_content_class -> { } %]">
-        %%  block full_content -> {
-          <!--TODO: Banner Addition - Temporary banner at top of each page-->
-          <div class="temporary-banner">
+          <div class="top-notify-banner">
             <i class="fas fa-info-circle"></i>
             The Perl Advent Calendar
             <a href="http://cfp.perladvent.org/" target="_blank">
@@ -145,16 +143,24 @@
               Submit your idea today!
             </a>
           </div>
-          %%  block left_nav -> {
-            <div class="nav-list-container slidepanel">
+          <nav class="sidebar">
+            %%  block left_nav -> {
+            <div class="slidepanel">
               <ul class="nav-list [% block left_nav_classes -> { } %]">
                   %% block left_nav_content -> {}
               </ul>
             </div>
-          %%  }
-          %%  block breadcrumbs -> { }
-          %%  block content -> { }
-        %%  }
+            %%  }
+          </nav>
+          <div class="content-navigation">
+            %%  block breadcrumbs -> { }
+          </div>
+          <main class="[% block content_classes -> { 'content' } %]">
+            %%  block content -> { }
+          </main>
+          <div class="content-pagination">
+            %%  block pagination -> { }
+          </div>
         </div>
         <footer class="footer">
           <div class="footer-container">

--- a/root/base/about.tx
+++ b/root/base/about.tx
@@ -21,3 +21,4 @@ for [
 </li>
 %%  }
 %%  }
+%%  after content_classes -> { ' about' }

--- a/root/base/about/markdown.tx
+++ b/root/base/about/markdown.tx
@@ -1,6 +1,5 @@
 %%  cascade base::about
+%%  after content_classes -> { ' anchors' }
 %%  override content -> {
-<div class="content about anchors">
-%%  block about | markdown -> { }
-</div>
+%%    block about | markdown -> { }
 %%  }

--- a/root/base/error.tx
+++ b/root/base/error.tx
@@ -1,8 +1,8 @@
 %%  cascade base::search with inc::no_sidebar {
 %%      title => $title || 'Error ' ~ $status_code ~ ' - ' ~ $status_message,
 %%  }
+%%  after content_classes -> { ' error-page' }
 %%  override content -> {
-<div class="content error-page">
     <h1>[% $status_message %]</h1>
 
     %%  if $message {
@@ -22,5 +22,4 @@
             Search the CPAN for <a href="/search?q=[% $q | uri %]">[% $q %]</a>
         </p>
     %%  }
-</div>
 %%  }

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -230,11 +230,9 @@
 %%  }
 %%  override content -> {
 
-<div class="content">
   %%  include inc::notification;
 
   %%  block page_content -> { }
-</div>
 
 %%  include inc::module_install;
 %%  }

--- a/root/browse.tx
+++ b/root/browse.tx
@@ -25,7 +25,6 @@
   <li>[% pluralize("%d file(s)", $file_count) %]</li>
 %%  }
 %%  override content -> {
-<div class="content">
 <table id="metacpan-file-browse" class="table table-condensed table-striped file-table tablesorter">
 <thead>
     <tr>
@@ -54,5 +53,4 @@
 %%  }
 </tbody>
 </table>
-</div>
 %%  }

--- a/root/diff.tx
+++ b/root/diff.tx
@@ -42,7 +42,6 @@
     <li><div><a href="#">Top</a></div></li>
 %%  }
 %%  override content -> {
-  <div class="content">
     <table class="table-striped diff-list">
       %%  for $diff.statistics -> $file {
       <tr>
@@ -65,5 +64,4 @@
             <pre><code class="language-diff">[% $file.diff %]</code></pre>
         </div>
     %%  }
-  </div>
 %%  }

--- a/root/favorite/leaderboard.tx
+++ b/root/favorite/leaderboard.tx
@@ -2,7 +2,6 @@
 %%      title => $title || 'Popular Distributions',
 %%  }
 %%  override content -> {
-<div class="content">
 <table class="table table-condensed table-striped table-releases">
   <thead>
     <tr>
@@ -21,5 +20,4 @@
   %%  }
   </tbody>
 </table>
-</div>
 %%  }

--- a/root/favorite/recent.tx
+++ b/root/favorite/recent.tx
@@ -2,8 +2,8 @@
 %%      title     => $title || "Recent Favorites",
 %%  }
 %%  override content -> {
-<div class="content">
     %%  include inc::favorite_table { favorites => $recent, per_day => 1 }
-    %%  include inc::pager
-</div>
+%%  }
+%%  override pagination -> {
+  %%  include inc::pager
 %%  }

--- a/root/home.tx
+++ b/root/home.tx
@@ -5,7 +5,7 @@
 %%  }
 %%  override search_bar -> { }
 %%  override header_nav_menu -> { }
-%%  after page_content_class -> { ' page-home' }
+%%  after content_classes -> { ' home' }
 %%  override content -> {
 <script type="application/ld+json">
 [
@@ -25,7 +25,6 @@
 ]
 </script>
 
-<div class="home">
   <div class="home-hero">
     <div class="hero-logo">
       <img src="/static/images/metacpan-logo.svg" alt="MetaCPAN" />
@@ -44,6 +43,4 @@
 
     <span class="helper-blurb">Just getting started with Perl? Try these <a target="_blank" rel="noopener" href="https://www.perl.org/learn.html">free learning resources</a> from the Perl community</span>
   </div>
-
-</div>
 %%  }

--- a/root/inc/no_sidebar.tx
+++ b/root/inc/no_sidebar.tx
@@ -1,3 +1,2 @@
-%%  after page_content_class -> { ' no-sidebar' }
 %%  override sidebar_toggle_button -> { }
 %%  override left_nav -> { }

--- a/root/lab/dashboard.tx
+++ b/root/lab/dashboard.tx
@@ -1,7 +1,5 @@
 %%  cascade base::tools
 %%  override content -> {
-<div class="content">
-
 <h2>[% $personal ? 'Personal' : $pauseid %] Dashboard</h2>
 
 %%  if $report {
@@ -62,5 +60,4 @@
 The dashboard is only available to people who have logged in to MetaCPAN.
 %%  }
 
-</div>
 %%  }

--- a/root/lab/dependencies.tx
+++ b/root/lab/dependencies.tx
@@ -1,6 +1,5 @@
 %%  cascade base::tools
 %%  override content -> {
-<div class="content">
   <div class="row">
     <div class="col-lg-12">
       <h2>List all dependencies of a distribution</h2>
@@ -29,5 +28,4 @@
       %%  }
     </div>
   </div>
-</div>
 %%  }

--- a/root/news.tx
+++ b/root/news.tx
@@ -23,11 +23,10 @@ for [
 </li>
 %%  }
 %%  }
+%%  after content_classes -> { ' news anchors' }
 %%  override content -> {
-<div class="content news anchors">
   <a class="news_feed" href="/news.rss"><i class="fa fa-rss fa-2x"></i></a>
 %%  block news | markdown -> {
 %%      $news
 %%  }
-</div>
 %%  }

--- a/root/no_result.tx
+++ b/root/no_result.tx
@@ -2,7 +2,7 @@
 %%      title      => $title || 'Search for "' ~ $search_query ~ '"',
 %%  }
 %%  override content -> {
-    <div class="content no-results text-center">
+<div class="no-results">
     <h3 class="search-results-header">No search results for [% $search_query %]</h3>
     %%  if $suggest {
             <div class="alert alert-danger">
@@ -11,9 +11,9 @@
             </div>
     %%  }
     %%  else {
-          <p class="nav-header" id="metacpan_header-text-noresult">Something missing?
+          <h4>Something missing?
               <a href="/about/missing_modules">Find out why</a>
-          </p>
+          </h4>
           <p> Sorry, we didn't find a match. Maybe look at <a href="/pod/Task::Kensho">Task::Kensho</a>,<br>
           which is a list of recommended modules for Enlightened Perl development.
           </p>
@@ -23,5 +23,5 @@
               </a>
           </p>
     %%  }
-    </div>
+</div>
 %%  }

--- a/root/permission/author.tx
+++ b/root/permission/author.tx
@@ -3,12 +3,8 @@
 %%  }
 %%  override content -> {
 
-<div class="content">
-
 <h1>Author Module Permissions for [% $search_term %]</h1>
 
 %% include inc::permission
-
-</div>
 
 %%  }

--- a/root/permission/distribution.tx
+++ b/root/permission/distribution.tx
@@ -2,7 +2,6 @@
 %%      title     => $title || 'Module permissions for ' ~ $search_term,
 %%  }
 %%  override content -> {
-<div class="content">
 <h1>Module Permissions for [% $search_term %]</h1>
 
 <table class="table table-striped" style="width: auto; min-width: 33%">
@@ -26,7 +25,5 @@
 </table>
 
 %% include inc::permission
-
-</div>
 
 %%  }

--- a/root/permission/module.tx
+++ b/root/permission/module.tx
@@ -3,8 +3,6 @@
 %%  }
 %%  override content -> {
 
-<div class="content">
-
 <h1>Module Permissions for [% $search_term %]</h1>
 
 %%  for $permissions -> $permission {
@@ -22,7 +20,5 @@
   %%  }
 </ul>
 %%  }
-
-</div>
 
 %%  }

--- a/root/pod2html/pod2html.tx
+++ b/root/pod2html/pod2html.tx
@@ -2,7 +2,7 @@
 %%      title => $title || 'Pod Renderer' ~ ($pod_name ? ' - ' ~ $pod_name : '')
 %%  }
 %%  override content -> {
-<div class="content metacpan-pod-renderer">
+<div class="metacpan-pod-renderer">
   <div class="panel panel-default">
     <div class="panel-heading" role="tab">
       <h3 class="panel-title">Pod Renderer</h3>
@@ -32,7 +32,6 @@
     </div>
   </div>
 </div>
-<div class="content">
-    <div id="metacpan-pod-renderer-output" class="pod anchors" [% if !$pod_rendered { %]style="display: none"[% } %]>[% $pod_rendered | raw %]</div>
+<div id="metacpan-pod-renderer-output" class="pod anchors" [% if !$pod_rendered { %]style="display: none"[% } %]>[% $pod_rendered | raw %]</div>
 </div>
 %%  }

--- a/root/recent.tx
+++ b/root/recent.tx
@@ -4,12 +4,12 @@
 %%      rss_title => $rss_title || 'Recent CPAN Uploads - MetaCPAN',
 %%  }
 %%  override content -> {
-<div class="content">
   <div id="metacpan_feed_subscription" class="page-header">
     <p>Recent Uploads</p>
       <a href="/recent.rss[% if $filter { '?f=' ~ $filter } %]"><i class="fa fa-rss fa-2x black"></i></a>
   </div>
 %%  include inc::release_table { releases => $recent, per_day => 1 }
-%%  include inc::pager
-</div>
+%%  }
+%%  override pagination -> {
+  %%  include inc::pager
 %%  }

--- a/root/recent/topuploaders.tx
+++ b/root/recent/topuploaders.tx
@@ -1,8 +1,8 @@
 %%  cascade base::recent {
 %%      title => $title || "CPAN Top Uploaders",
 %%  }
+%%  after content_classes -> { ' toplists row' }
 %%  override content -> {
-<div class="content toplists row">
 %%  for $authors -> $author {
 <div class="entry col-sm-6 col-md-3">
     <div class="gravatar">
@@ -17,5 +17,4 @@
     <strong class="count">[% $author.releases %] release[% if $author.releases > 1 { %]s[% } %]</strong>
 </div>
 %%  }
-</div>
 %%  }

--- a/root/requires.tx
+++ b/root/requires.tx
@@ -11,7 +11,6 @@
 %%  }
 %%  override content -> {
 
-<div class="content">
     <strong>Distributions Which Depend on <a href="/[% $type_of_required %]/[% $required %]">[% $required %]</a></strong>
     %%  if $releases.size() {
         %%  include inc::release_table {
@@ -20,11 +19,12 @@
         %%      default_sort    => '2,1',
         %%      table_id        => 'revdep_releases',
         %%  };
-        %%  include inc::pager;
     %%  }
     %%  else {
     <p>No distributions depending on <a href="/[% $type_of_required %]/[% $required %]">[% $required %]</a> could be found</p>
     %%  }
-</div>
 
+%%  }
+%%  override pagination -> {
+  %%  include inc::pager
 %%  }

--- a/root/search.tx
+++ b/root/search.tx
@@ -1,10 +1,10 @@
 %%  cascade base::search with inc::no_sidebar {
 %%      title      => $title || 'Search for "' ~ $search_query ~ '"',
 %%  }
+%%  after content_classes -> { ' search-results' }
 %%  override content -> {
-<div class="content search-results">
   <h3 class="search-results-header">Search results for "[% $search_query %]"</h3>
-%% if $authors.total {
+%%  if $authors.total {
   <div class="author-results">
     <ul class="authors clearfix">
     %% for $authors.authors -> $author {
@@ -17,16 +17,16 @@
     %% }
     </ul>
   </div>
-%% }
+%%  }
 
-%% for $results -> $group {
-  %% my $first= $group.hits.0;
+%%  for $results -> $group {
+  %%  my $first= $group.hits.0;
   <div class="module-result">
     <h3>
-      %% include inc::link_to_file { file => $first };
-      %% if $first.abstract { ' - ' ~ $first.abstract }
-      %% include inc::river_gauge { distribution => $first.distribution, river => $group.river };
-      %% include inc::favorite { release => $first, favorites => $release.favorites };
+      %%  include inc::link_to_file { file => $first };
+      %%  if $first.abstract { ' - ' ~ $first.abstract }
+      %%  include inc::river_gauge { distribution => $first.distribution, river => $group.river };
+      %%  include inc::favorite { release => $first, favorites => $release.favorites };
     </h3>
     %%  if $first.description {
     <p class="description">[% $first.description.substr(0, 250) ~ '...' %]</p>
@@ -52,7 +52,7 @@
       </li>
       <!-- [% $item.score %] -->
       %%  }
-      %% if $group.total > 4 {
+      %%  if $group.total > 4 {
       <li>
         <a href="/search?q=distribution:[% $first.distribution %]+[% $search_query %]">[% $group.total - 4 %] more result[% if $group.total - 4 > 1 { 's' } %] from [% $first.distribution %] »</a>
       </li>
@@ -62,8 +62,7 @@
   </div>
 %%  }
 
-%% include inc::pager
-
-</div>
-
+%%  }
+%%  override pagination -> {
+%%    include inc::pager
 %%  }

--- a/root/source.tx
+++ b/root/source.tx
@@ -46,7 +46,6 @@
   <li>[% format_bytes($file.stat.size) %] bytes</li>
 %%  }
 %%  override content -> {
-<div class="content">
 %%  if !$file.binary {
   %%  if $file.mime == 'text/markdown' {
     [% $source | markdown | filter_html %]
@@ -60,5 +59,4 @@
 %%  else {
 This file cannot be displayed inline.  Try the <a href="[% $api_public ~ '/source/' ~ $file.author ~ '/' ~ $file.release ~ '/' ~ $file.path %]">raw file</a>.
 %%  }
-</div>
 %%  }

--- a/root/static/less/account.less
+++ b/root/static/less/account.less
@@ -50,7 +50,6 @@
         padding-left: 0;
     }
 
-
     // profile logos really should be in css I think..
 
     .profiles {

--- a/root/static/less/breadcrumbs.less
+++ b/root/static/less/breadcrumbs.less
@@ -3,7 +3,6 @@
     font-weight: bold;
     font-size: 1.2em;
     display: flex;
-    grid-area: breadcrumbs;
     flex-wrap: wrap;
     justify-self: center;
     max-width: 1200px;

--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -129,10 +129,6 @@ button.favorite, a.favorite {
     }
 }
 
-.account-settings, .about {
-    border-left: none;
-}
-
 ul {
     list-style-type: none;
 }
@@ -265,9 +261,16 @@ ul.dependencies {
     line-height: 2.5em;
 }
 
-#metacpan_header-text-noresult {
-    padding-left: 0px;
-    font-size: 14px;
+.no-results {
+    text-align: center;
+
+    h4 {
+        padding: 7px 0;
+        font-weight: bold;
+        color: #999;
+        text-transform: uppercase;
+        font-size: 14px;
+    }
 }
 
 .news_feed {
@@ -347,16 +350,34 @@ h1, .h1, h2, .h2, h3, .h3 {
 
 .page-content {
     display: grid;
+    align-items: start;
     grid-template-areas:
       // TODO: Banner Addition - Tempory banner at top of each page. Remove this once we take the banner down.
       'menu banner'
       'menu breadcrumbs'
       'menu content'
       'menu pagination';
-    grid-template-columns: @sidebar-width ~"calc(100vw -" @sidebar-width ~")";
-    grid-template-rows: max-content max-content max-content max-content;
+    grid-template-columns: fit-content(@sidebar-width) auto;
+    grid-template-rows: max-content max-content auto max-content;
     line-height: 1.54em;
     margin-top: 57px;
+}
+
+.sidebar {
+    grid-area: menu;
+    align-self: stretch;
+}
+.top-notify-banner {
+    grid-area: banner;
+}
+.content-navigation {
+    grid-area: breadcrumbs;
+}
+.content {
+    grid-area: content;
+}
+.content-pagination {
+    grid-area: pagination;
 }
 
 @media (min-width: 0) and (max-width: @screen-sm-max) {
@@ -446,10 +467,4 @@ h1, .h1, h2, .h2, h3, .h3 {
 
 * {
   scroll-margin-top: 60px;
-}
-
-.no-sidebar.page-content {
-    align-items: center;
-    grid-template-columns: 0 1fr;
-    justify-content: center;
 }

--- a/root/static/less/home.less
+++ b/root/static/less/home.less
@@ -1,11 +1,6 @@
-.page-home {
-    grid-template-rows: max-content max-content auto max-content;
-}
-
 .home {
     display: grid;
-    margin: 50px 0;
-    grid-area: content;
+    align-self: stretch;
 
     .home-hero {
       display: grid;

--- a/root/static/less/nav-list.less
+++ b/root/static/less/nav-list.less
@@ -1,7 +1,7 @@
-.nav-list-container {
+.sidebar {
     background: #e9e9e9;
     box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 10px inset;
-    grid-area: menu;
+    align-self: stretch;
 }
 
 .nav-list {

--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -8,9 +8,7 @@
   }
 }
 
-// TODO: Banner Addition - Temporary banner at top of each page
-.temporary-banner {
-  grid-area: banner;
+.top-notify-banner {
   background-color: #2e3a47;
   color: #fff;
   display: flex;
@@ -114,7 +112,7 @@ ul.nav-pills.affix {
   }
 }
 
-nav {
+nav.navbar {
     align-items: center;
     display: grid;
     column-gap: 40px;

--- a/root/tools.tx
+++ b/root/tools.tx
@@ -1,6 +1,5 @@
 %%  cascade base::tools
 %%  override content -> {
-<div class="content">
   <h2 class="content-head">Assorted Tools</h1>
 
   <ul>
@@ -32,5 +31,4 @@
     <li><a href="/lab/dashboard">Dashboard</a> - a personalised dashboard (for logged in authors)</li>
     <li><a href="/lab/dependencies">Dependencies</a> - list the dependencies of a module</li>
   </ul>
-</div>
 %%  }

--- a/t/controller/account.t
+++ b/t/controller/account.t
@@ -98,7 +98,7 @@ test_psgi app, sub {
         is( $res->code, 200, '... and the user gets in' );
         my $tx = tx($res);
         $tx->like(
-            '//div[@class="content account-settings"]',
+            '//div[contains-token(@class, "account-settings")]',
             qr/connect your account to PAUSE/,
             '... and needs to connect to PAUSE'
         );

--- a/t/controller/changes.t
+++ b/t/controller/changes.t
@@ -12,7 +12,7 @@ test_psgi app, sub {
         is( $res->code, 200, "200 on $url" );
         my $tx = tx($res);
         $tx->like(
-            '//div[contains-token(@class, "content")]//pre[@id="metacpan_source"]',
+            '//*[contains-token(@class, "content")]//pre[@id="metacpan_source"]',
             qr/^Revision history for File-Spec-Native/,
             'source view for plain text change log'
         );
@@ -37,12 +37,12 @@ test_psgi app, sub {
         is( $res->code, 404, "404 on $url" );
         my $tx = tx($res);
         $tx->like(
-            '//div[contains-token(@class,"error-page")]',
+            '//*[contains-token(@class,"error-page")]',
             qr/Change log not found for release.+Try the release info page:/,
             'Suggest release info page for not-found dist.'
         );
         $tx->like(
-            qq{//div[contains-token(\@class,"error-page")]//p[\@class="suggestion"]//a[text()="$missing"]//\@href},
+            qq{//*[contains-token(\@class,"error-page")]//p[\@class="suggestion"]//a[text()="$missing"]//\@href},
             qr{/$missing$}, 'link to suggested release',
         );
     }

--- a/t/controller/contributing-to.t
+++ b/t/controller/contributing-to.t
@@ -35,7 +35,7 @@ test_psgi app, sub {
     is( $res->code, 404, 'code 404' );
 
     my $tx2 = tx($res);
-    $tx2->find_value( '//div[contains(@class, "content")]',
+    $tx2->find_value( '//div[contains-token(@class, "content")]',
         'page has content' );
     $tx2->like(
         q[//div[contains-token(@class, 'about')]],

--- a/t/controller/diff.t
+++ b/t/controller/diff.t
@@ -14,8 +14,12 @@ test_psgi app, sub {
     is( $res->code, 200, 'code 200' );
     my $tx = tx($res);
 
-    is( $tx->find_value('//table[contains(@class, "diff-list")]//td[1]/a'),
-        'lib/Moose.pm', 'Module diff file list' );
+    is(
+        $tx->find_value(
+            '//table[contains-token(@class, "diff-list")]//td[1]/a'),
+        'lib/Moose.pm',
+        'Module diff file list'
+    );
 
     ok( $res = $cb->( GET $rel_diff ), 'GET release diff' );
     is( $res->code, 200, 'code 200' );
@@ -23,7 +27,7 @@ test_psgi app, sub {
 
     is(
         $tx->find_value(
-            '//table[contains(@class, "diff-list")]//tr[position() <= 5]/td[1]/a'
+            '//table[contains-token(@class, "diff-list")]//tr[position() <= 5]/td[1]/a'
         ),
         'ChangesLICENSEMANIFESTMETA.jsonMETA.yml',
         'Release diff file list'

--- a/t/controller/favorite/leaderboard.t
+++ b/t/controller/favorite/leaderboard.t
@@ -13,7 +13,7 @@ test_psgi app, sub {
         is( $res->code, 200, 'code 200' );
         my $tx = tx($res);
         $tx->ok(
-            '//table[contains(@class, "table-releases")]//td[@class="name"]//a',
+            '//table[contains-token(@class, "table-releases")]//td[contains-token(@class, "name")]//a',
             sub {
                 my $anchor = shift;
                 $anchor->is(

--- a/t/controller/pod.t
+++ b/t/controller/pod.t
@@ -43,11 +43,11 @@ test_psgi app, sub {
     );
 
     my $tx2 = tx($res);
-    ok( $tx->find_value('//div[contains(@class, "content")]'),
+    ok( $tx->find_value('//*[contains-token(@class, "content")]'),
         'page has content' );
     is(
-        $tx2->find_value('//div[contains(@class, "content")]'),
-        $tx->find_value('//div[contains(@class, "content")]'),
+        $tx2->find_value('//*[contains-token(@class, "content")]'),
+        $tx->find_value('//*[contains-token(@class, "content")]'),
         'content of both urls is exactly the same'
     );
 

--- a/t/controller/recent.t
+++ b/t/controller/recent.t
@@ -11,7 +11,7 @@ test_psgi app, sub {
     my $tx = tx($res);
     ok(
         my $release = $tx->find_value(
-            '//table[contains(@class, "table-releases")][1]/tbody/tr[1]/td[@class="name"]//a[1]/@href'
+            '//table[contains-token(@class, "table-releases")][1]/tbody/tr[1]/td[contains-token(@class, "name")]//a[1]/@href'
         ),
         'contains a release'
     );

--- a/t/controller/release.t
+++ b/t/controller/release.t
@@ -28,13 +28,13 @@ test_psgi app, sub {
     # so pin to an older version for now.
     test_heading_order( $cb->( GET '/release/ETHER/Moose-2.1005' ) );
 
-    ok( $tx->find_value('//div[contains(@class, "plussers")]'),
+    ok( $tx->find_value('//div[contains-token(@class, "plussers")]'),
         'has plussers' );
 
    # Return @href as value b/c there is no child text content (it's an image).
     ok(
         $tx->find_value(
-            '//div[contains(@class, "plussers")]//a[contains(@href, "/author/")]/@href'
+            '//div[contains-token(@class, "plussers")]//a[contains(@href, "/author/")]/@href'
         ),
         'has cpan author plussers'
     );
@@ -47,12 +47,12 @@ test_psgi app, sub {
         ),
         'contains link to "this" version'
     );
-    my $latest = $tx->find_value('//div[@class="content"]');
+    my $latest = $tx->find_value('//*[contains-token(@class, "content")]');
     ok( $res = $cb->( GET $this ), "GET $this" );
     my $tx_latest = tx($res);
     is(
         $latest,
-        $tx_latest->find_value('//div[@class="content"]'),
+        $tx_latest->find_value('//*[contains-token(@class, "content")]'),
         'content of both urls is exactly the same'
     );
 
@@ -86,7 +86,7 @@ test_psgi app, sub {
     ok( $res = $cb->( GET '/release/SHLOMIF/Config-IniFiles-2.43/' ) );
     $tx_cc = tx($res);
     $tx_cc->not_ok(
-        '//div[@class="content"]/strong[following-sibling::div[@class="last-changes"]]'
+        '//*[contains-token(@class, "content")]/strong[following-sibling::div[contains-token(@class, "last-changes")]]'
     );
 };
 
@@ -209,7 +209,7 @@ sub test_heading_order {
 
     # Boohoo... testing with XPATH :-(
     my $xpath_prefix
-        = '//div[@class="content"]/div[contains(@class, "file-group")]';
+        = '//*[contains-token(@class, "content")]/div[contains-token(@class, "file-group")]';
     $tx->ok(
         "$xpath_prefix/h2",
         sub {

--- a/t/controller/search.t
+++ b/t/controller/search.t
@@ -5,8 +5,8 @@ use MetaCPAN::Web::Test qw( app GET test_psgi tx );
 use Encode              qw( encode is_utf8 );
 
 my %xpath = (
-    search_results => 'div[contains(@class, "search-results")]',
-    module_result  => 'div[@class="module-result"]',
+    search_results => '*[contains-token(@class, "search-results")]',
+    module_result  => '*[contains-token(@class, "module-result")]',
 );
 
 test_psgi app, sub {

--- a/t/controller/search/precision.t
+++ b/t/controller/search/precision.t
@@ -33,7 +33,8 @@ test_psgi app, sub {
         ok( my $res = $cb->( GET "/search?q=$k" ), 'search for ' . $k );
         my $tx = tx($res);
         my $module
-            = $tx->find_value('//div[@class="module-result"][1]/h3[1]/a[1]');
+            = $tx->find_value(
+            '//div[contains-token(@class, "module-result")][1]/h3[1]/a[1]');
         is( $module, $v, "$v is first result" );
     }
 
@@ -43,7 +44,7 @@ test_psgi app, sub {
         my $tx = tx($res);
         my $author
             = $tx->find_value(
-            '//div[@class="author-results"]/ul[@class="authors clearfix"]/li[1]/a[1]'
+            '//div[contains-token(@class,"author-results")]/ul[contains-token(@class, "authors")][contains-token(@class, "clearfix")]/li[1]/a[1]'
             );
         like( $author, qr/\b$v\b/, "$v is first result" );
     }

--- a/t/controller/search/suggestion.t
+++ b/t/controller/search/suggestion.t
@@ -18,7 +18,7 @@ test_psgi app, sub {
         my $tx = tx($res);
         my $module
             = $tx->find_value(
-            '//div[contains(@class, "no-results")]//div[@class="alert alert-danger"]//a[1]'
+            '//div[contains-token(@class, "no-results")]//div[contains-token(@class,"alert")][contains-token(@class, "alert-danger")]//a[1]'
             );
         is( $module, $v, 'get no result page with suggestion' );
     }

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -127,7 +127,7 @@ test_psgi app, sub {
 
             # not in release-info.html but should be shown on both:
 
-            my $favs = '//*[contains(@class, "favorite")]';
+            my $favs = '//*[contains-token(@class, "favorite")]';
             $tx->like( $favs, qr/\+\+$/, 'tag for favorites (++)' );
 
             optional_test favorited => sub {
@@ -168,8 +168,11 @@ test_psgi app, sub {
             );
 
             # version select box
-            ok( $tx->find_value('//div[@class="breadcrumbs"]//select'),
-                'version select box' );
+            ok(
+                $tx->find_value(
+                    '//div[contains-token(@class, "breadcrumbs")]//select'),
+                'version select box'
+            );
 
             $tx->like(
 

--- a/t/controller/source.t
+++ b/t/controller/source.t
@@ -84,7 +84,7 @@ test_psgi app, sub {
         my @tests = (
             {
                 uri      => '/release/RJBS/Dist-Zilla-5.043/source/bin/dzil',
-                xpath    => '//div[@class="content"]/pre/code/@class',
+                xpath    => '//*[contains-token(@class, "content")]/pre/code/@class',
                 expected => qr/\blanguage-perl\b/,
                 desc     => 'has pre-block with expected syntax brush',
             },


### PR DESCRIPTION
Update the layout to use a consistent grid by always including all grid elements. This makes the use of grid-template-columns and grid-template-rows consistent. We can then use 'auto' for the content section, which will expand as needed. The sidebar can use fit-content, which means it will automatically disappear when it has no content. This eliminates the need for any special class for pages without a sidebar.