### PR TITLE
Restore description of relationship to CPAN on home page

### DIFF
--- a/root/home.tx
+++ b/root/home.tx
@@ -30,6 +30,7 @@
     <div class="hero-logo">
       <img src="/static/images/metacpan-logo.svg" alt="MetaCPAN" />
     </div>
+    <h4>A search engine for <a href="https://www.cpan.org">CPAN</a></h4>
     <form action="/search" class="search-form form-horizontal">
       <input type="hidden" name="size" id="metacpan_search-size" value="20">
       <div class="form-group">


### PR DESCRIPTION
Before the redesign this text was added in #2200 to assist with confusion regarding the roles of MetaCPAN and CPAN.

The text should be centered but I don't know the appropriate way to achieve that here.