### PR TITLE
move recaptcha initialization to separate javascript file

### DIFF
--- a/lib/MetaCPAN/Middleware/Static.pm
+++ b/lib/MetaCPAN/Middleware/Static.pm
@@ -54,6 +54,7 @@ sub wrap {
             js/cpan.js
             js/github.js
             js/dropdown.js
+            js/recaptcha.js
             js/search.js
             modules/bootstrap-v3.4.1/js/dropdown.js
             modules/bootstrap-v3.4.1/js/collapse.js

--- a/root/account/turing.tx
+++ b/root/account/turing.tx
@@ -17,14 +17,8 @@
     %%  else {
     <fieldset><legend>Verify Account</legend>
         <p>Please solve the Captcha. This will allow you to ++ modules. You'll have to complete this test only once.</p><br />
-        <form id="metacpan-recaptcha-form" method="POST">
-            <script>
-              function recaptchaSuccess ( response ) {
-                document.getElementById('metacpan-recaptcha-form').submit();
-              }
-            </script>
-            <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-            <div class="g-recaptcha" data-sitekey="[% $recaptcha_key %]" data-callback="recaptchaSuccess"></div>
+        <form method="POST">
+            <div class="g-recaptcha" data-sitekey="[% $recaptcha_key %]"></div>
         </form>
     </fieldset>
     %%  }

--- a/root/static/js/recaptcha.js
+++ b/root/static/js/recaptcha.js
@@ -1,0 +1,29 @@
+window.addEventListener('DOMContentLoaded', async () => {
+    'use strict';
+
+    function recaptcha_prepare () {
+        return new Promise ((resolve, reject) => {
+            const recaptcha_script = document.createElement('script');
+            recaptcha_script.setAttribute('async', '');
+            recaptcha_script.setAttribute('defer', '');
+            recaptcha_script.setAttribute('src', 'https://www.google.com/recaptcha/api.js?render=explicit');
+            recaptcha_script.addEventListener('load', () => {
+                window.grecaptcha.ready(() => resolve(window.grecaptcha));
+            });
+            recaptcha_script.addEventListener('error', () => reject('Error loading reCAPTCHA'));
+            document.head.appendChild(recaptcha_script);
+        });
+    }
+
+    const recaptcha_div = document.querySelector('.g-recaptcha');
+    if (!recaptcha_div) {
+        return;
+    }
+
+    const recaptcha_form = recaptcha_div.closest('form');
+
+    const grecaptcha = await recaptcha_prepare();
+    grecaptcha.render(recaptcha_div, {
+        callback: () => recaptcha_form.submit()
+    });
+});


### PR DESCRIPTION
This eliminates an inline script, which will help tighten up the CSP rules in the future. Also removes another id.