### PR TITLE
changes parser: fix comparing versions that are in different forms

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -28,7 +28,7 @@ sub release_changes {
 
         my @changelogs;
         while ( my $r = shift @releases ) {
-            if ( "$r->{version_parsed}" eq "$version" ) {
+            if ( _versions_eq( $r->{version_parsed}, $version ) ) {
                 $r->{current} = 1;
                 push @changelogs, $r;
                 if ( $opts{include_dev} ) {
@@ -64,7 +64,7 @@ sub by_releases {
                 my @releases = _releases( $change->{changes_text} );
 
                 while ( my $r = shift @releases ) {
-                    if ( "$r->{version_parsed}" eq "$version" ) {
+                    if ( _versions_eq( $r->{version_parsed}, $version ) ) {
                         $r->{current} = 1;
 
                         # Used in Controller/Feed.pm Line 37
@@ -108,6 +108,21 @@ sub _releases {
         };
         } @{ $changelog->{releases} || [] };
     return @releases;
+}
+
+sub _versions_eq {
+    my ( $v1, $v2 ) = @_;
+
+    # we're comparing version objects
+    if ( ref $v1 && ref $v2 ) {
+        return $v1 eq $v2;
+    }
+
+    # if one version failed to parse, force string comparison so version's
+    # overloads don't try to inflate the other version
+    else {
+        return "$v1" eq "$v2";
+    }
 }
 
 sub _parse_version {


### PR DESCRIPTION
When finding the changes for a version v1.2.3, where the change log contains "1.2.3", we need to be comparing the versions as version objects rather than strings. But we still need to prevent version.pm from trying to inflate the other version it is being compared to, because that already failed. Force a stringificiation on both versions if either failed to parse.