### PR TITLE
Bump nodejs from 10 to 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "10"
+          node-version: "18"
       - run: npm install -g yarn && yarn install
       - name: Install Carton
         run: >

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Docker
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,25 +34,23 @@ jobs:
           node-version: "18"
       - run: npm install -g yarn && yarn install
       - name: Install Carton
-        run: >
-          curl -sL https://git.io/cpm | perl -
-          install -g Carton
-          --show-build-log-on-failure
-      - name: Install deps
-        run: >
-          curl -sL https://git.io/cpm | perl -
-          install
-          --cpanfile cpanfile
-          --resolver ${{ matrix.resolver }}
-          --show-build-log-on-failure
-          --local-lib-contained=local
-        if: success()
+        uses: perl-actions/install-with-cpm@v1
+        with:
+          install: Carton
+          sudo: false
+      - name: Install CPAN deps
+        uses: perl-actions/install-with-cpm@v1
+        with:
+          cpanfile: "cpanfile"
+          sudo: false
+          args: >
+            --resolver ${{ matrix.resolver }}
+            --show-build-log-on-failure
+            --local-lib-contained=local
       - name: Maybe update cpanfile.snapshot
         run: carton
-        if: success()
       - name: Run Tests
         run: carton exec prove -lr --jobs 2 t
-        if: success()
         env:
           TEST_TIDYALL_VERBOSE: 1
       - uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_18.x | bash \
 COPY . /metacpan-web/
 WORKDIR /metacpan-web
 
-RUN yarn install && yarn cache clean
+RUN yarn install --verbose && yarn cache clean
 
 RUN cpanm --notest App::cpm \
     && cpm install -g Carton \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG CPM_ARGS=--with-test
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash \
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_18.x | bash \
 COPY . /metacpan-web/
 WORKDIR /metacpan-web
 
-RUN yarn install
+RUN yarn install && yarn cache clean
 
 RUN cpanm --notest App::cpm \
     && cpm install -g Carton \


### PR DESCRIPTION
- Bump node from version 10 to 18
- Clean yarn cache in Docker build
