### PR TITLE
all_by_author: called with the wrong params order (GH#1126)

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Author.pm
+++ b/lib/MetaCPAN/Web/Controller/Author.pm
@@ -87,7 +87,7 @@ sub releases : Chained('root') PathPart Args(0) {
     my $page      = $req->page;
     my $author_cv = $c->model('API::Author')->get($id);
     my $releases
-        = $c->model('API::Release')->all_by_author( $id, $page_size, $page )
+        = $c->model('API::Release')->all_by_author( $id, $page, $page_size )
         ->get;
 
     my $author_info = $author_cv->get;


### PR DESCRIPTION
match call params order with sub:

> sub all_by_author {
>     my ( $self, $pauseid, $page, $page_size ) = @_;
