### PR TITLE
Add push all for docker image push

### DIFF
--- a/.github/workflows/build-production-container.yml
+++ b/.github/workflows/build-production-container.yml
@@ -21,4 +21,4 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Push build to Docker Hub
-        run: docker push metacpan/metacpan-web:latest
+        run: docker push --all-tags metacpan/metacpan-web:latest


### PR DESCRIPTION
Previous incantation pushed the latest tag. This incantation will push all the tags, which includes the git sha allowing its use when deploying containers.