### PR TITLE
Remove tag name from docker push

### DIFF
--- a/.github/workflows/build-production-container.yml
+++ b/.github/workflows/build-production-container.yml
@@ -21,4 +21,4 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Push build to Docker Hub
-        run: docker push --all-tags metacpan/metacpan-web:latest
+        run: docker push --all-tags metacpan/metacpan-web


### PR DESCRIPTION
When pushing all tags, you can't specify a tag name. Who knew?