### PR TITLE
re-add RDF recent feed for use by CPAN.pm

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -78,6 +78,7 @@ requires 'Try::Tiny', '0.24';
 requires 'Type::Library';
 requires 'Types::Common::Numeric';
 requires 'Types::Common::String';
+requires 'Types::DateTime';
 requires 'Types::LoadableClass';
 requires 'Types::Path::Tiny';
 requires 'Types::Standard';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -5706,6 +5706,19 @@ DISTRIBUTIONS
       Exporter::Tiny 1.006000
       ExtUtils::MakeMaker 6.17
       perl 5.008001
+  Types-DateTime-0.002
+    pathname: T/TO/TOBYINK/Types-DateTime-0.002.tar.gz
+    provides:
+      Types::DateTime 0.002
+    requirements:
+      DateTime 0
+      DateTime::Duration 0
+      DateTime::Locale 0
+      DateTime::TimeZone 0
+      ExtUtils::MakeMaker 6.17
+      Module::Runtime 0
+      Type::Tiny 0.041
+      perl 5.008
   Types-LoadableClass-0.003
     pathname: T/TO/TOBYINK/Types-LoadableClass-0.003.tar.gz
     provides:

--- a/lib/MetaCPAN/Web/Controller/Feed.pm
+++ b/lib/MetaCPAN/Web/Controller/Feed.pm
@@ -5,11 +5,13 @@ use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-use HTML::Escape               qw( escape_html );
-use MetaCPAN::Web::Types       qw( ArrayRef Enum HashRef Str Undef Uri );
+use DateTime             ();
+use HTML::Escape         qw( escape_html );
+use MetaCPAN::Web::Types qw( ArrayRef Enum HashRef Str Undef Uri DateTime );
 use Params::ValidationCompiler qw( validation_for );
 use Path::Tiny                 qw( path );
 use Text::MultiMarkdown        qw( markdown );
+use URI                        ();
 use XML::FeedPP                ();
 
 sub recent_rss : Path('/recent.rss') Args(0) {
@@ -46,6 +48,8 @@ sub recent : Private {
         entries => $c->stash->{recent},
         host    => URI->new( $c->config->{web_host} ),
         title   => 'Recent CPAN uploads - MetaCPAN',
+        link    => '/recent',
+        date    => DateTime::->now,
     );
 }
 
@@ -179,7 +183,19 @@ my $feed_check = validation_for(
         entries => { type => ArrayRef [HashRef] },
         host    => { type => Uri, optional => 0, },
         title   => { type => Str },
-        format  => {
+        link    => {
+            type    => Uri,
+            default => '/',
+        },
+        date => {
+            type     => DateTime,
+            optional => 1,
+        },
+        description => {
+            type     => Str,
+            optional => 1,
+        },
+        format => {
             type => Enum( [qw(atom rdf rss)] )
                 ->plus_coercions( Undef, '"rdf"', Str, 'lc $_' ),
             default => 'rdf'
@@ -233,11 +249,15 @@ sub build_feed {
         : $params{format} eq 'atom' ? 'Atom::Atom10'
         :                             die 'invalid format';
 
-    my $feed_class = sprintf( '%s::%s', XML::FeedPP::, $format );
+    my $feed_class = "XML::FeedPP::$format";
 
     my $feed = $feed_class->new;
     $feed->title( $params{title} );
-    $feed->link('/');
+    $feed->link("$params{link}");
+    $feed->pubDate( $params{date}->iso8601 )
+        if $params{date};
+    $feed->description( $params{description} )
+        if $params{description};
 
     foreach my $entry ( @{ $params{entries} } ) {
         $feed->add_item( $self->build_entry(

--- a/lib/MetaCPAN/Web/Controller/Feed.pm
+++ b/lib/MetaCPAN/Web/Controller/Feed.pm
@@ -14,6 +14,11 @@ use Text::MultiMarkdown        qw( markdown );
 use URI                        ();
 use XML::FeedPP                ();
 
+sub recent_rdf : Path('/recent.rdf') Args(0) {
+    my ( $self, $c ) = @_;
+    $c->detach( 'recent', ['rdf'] );
+}
+
 sub recent_rss : Path('/recent.rss') Args(0) {
     my ( $self, $c ) = @_;
     $c->detach( 'recent', ['rss'] );

--- a/lib/MetaCPAN/Web/Types.pm
+++ b/lib/MetaCPAN/Web/Types.pm
@@ -11,6 +11,7 @@ BEGIN {
         Types::Standard
         Types::Common::Numeric
         Types::Common::String
+        Types::DateTime
         Types::LoadableClass
         Types::Path::Tiny
         Types::URI


### PR DESCRIPTION
`CPAN.pm` uses `http://search.cpan.org/uploads.rdf` to find recent uploads, which it of course expects to be in RDF (RSS 0.90, 1.0, 1.1) format. This URL is now a redirect to metacpan, which provides the feed in RSS (RSS 0.91, 0.92, 2.0) format.

Re-introduce an RDF format feed to allow fixing compatibility with `CPAN.pm`. Changing the redirect on `search.cpan.org` will be addressed later.