### PR TITLE
Add colors for release name in recent page

### DIFF
--- a/root/inc/release_table.tx
+++ b/root/inc/release_table.tx
@@ -27,7 +27,7 @@
     %%  }
         <tr>
           <td class="river-gauge" sort="[% $release.river.total || 0 %]">[% include inc::river_gauge { distribution => $release.distribution, river => $release.river } %]</td>
-          <td class="name"><strong><a href="[% $release.status == 'latest' ? '/dist/' ~ $release.distribution : '/release/' ~ $release.author ~ '/' ~ $release.name %]" class="ellipsis" title="[% $release.author ~ '/' ~ $release.name %]">[% $release.name %]</a></strong></td>
+          <td class="name dist-release status-[% $release.status %] maturity-[% $release.maturity %]"><strong><a href="[% $release.status == 'latest' ? '/dist/' ~ $release.distribution : '/release/' ~ $release.author ~ '/' ~ $release.name %]" class="ellipsis release-name" title="[% $release.author ~ '/' ~ $release.name %]">[% $release.name %]</a></strong></td>
           <td class="abstract">[% $release.abstract %]</td>
           <td class="date relatize" sort="[% $date %]">[% $date %]</td>
         </tr>


### PR DESCRIPTION
We have different types of releases (development, testing, only for cpan) and there were no visible identification of these.

Fixes #2954