### PR TITLE
Fix footer FAQ link

### DIFF
--- a/root/base.tx
+++ b/root/base.tx
@@ -185,7 +185,7 @@
                   <a href="/recent">Recent</a>
               </div>
               <div class="footer-link">
-                  <a href="about/faq">FAQ</a>
+                  <a href="/about/faq">FAQ</a>
               </div>
               <div class="footer-link">
                   <a href="/tools">Tools</a>


### PR DESCRIPTION
The ‘FAQ’ link in the website footer is relative, meaning that it can go to the wrong place when not on the site homepage. For instance, on <https://metacpan.org/pod/feature> it links to <https://metacpan.org/pod/about/faq>, relative to the `/pod/` path, instead of the correct <https://metacpan.org/about/faq>.

This adds a leading slash, to always link to `/about/faq`.