### PR TITLE
Replace refs to @metacpan twitter to mastodon

### DIFF
--- a/root/about/contact.tx
+++ b/root/about/contact.tx
@@ -2,9 +2,9 @@
 %%  override about -> {
 # Contact
 
-## Twitter
+## Mastodon
 
-Follow our Twitter account for latest updates around MetaCPAN: [@metacpan](https://twitter.com/metacpan)
+Follow our Mastodon account for latest updates around MetaCPAN: [@metacpan@fosstodon.org](https://fosstodon.org/@metacpan)
 
 ## IRC
 

--- a/root/base.tx
+++ b/root/base.tx
@@ -170,8 +170,8 @@
               <a class="footer-social-link" href="https://github.com/metacpan">
                 <i class="fab fa-github-square"></i>
               </a>
-              <a class="footer-social-link" href="https://twitter.com/metacpan">
-                <i class="fab fa-twitter-square"></i>
+              <a class="footer-social-link" href="https://fosstodon.org/@metacpan">
+                <i class="fab fa-mastodon"></i>
               </a>
             </div>
             <div class="footer-links">


### PR DESCRIPTION
Closes https://github.com/metacpan/metacpan-web/issues/2891

Unfortunately, the 'square' icon is not available for Mastodon in fontawesome - not even in the latest version, I checked. Still I think it looks nice.