### PR TITLE
split table of contents from pod and style statically

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -79,6 +79,7 @@ sub view : Private {
         canonical         => $canonical,
         documented_module => $documented_module,
         pod               => $pod->{pod_html},
+        pod_index         => $pod->{pod_index},
         template          => 'pod.tx',
     } );
 

--- a/lib/MetaCPAN/Web/Controller/Pod2HTML.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod2HTML.pm
@@ -30,20 +30,30 @@ sub pod2html : Path : Args(0) {
             show_errors => 1,
         }
     )->get;
-    my $html = $pod_data->{pod_html} // q{};
+    my $html  = $pod_data->{pod_html}  // q{};
+    my $index = $pod_data->{pod_index} // q{};
 
     my $results = {
-        pod          => $pod,
-        pod_rendered => $html,
-        pod_name     => $pod_data->{pod_name},
-        abstract     => $pod_data->{abstract},
+        pod       => $pod,
+        pod_html  => $html,
+        pod_index => $index,
+        pod_name  => $pod_data->{pod_name},
+        abstract  => $pod_data->{abstract},
     };
     if ( $c->req->parameters->{raw} ) {
         $c->res->content_type('text/html');
-        $c->res->body($html);
+        $c->res->body( '<nav class="toc">' . $index . '</nav>' . $html );
         $c->detach;
     }
-    $c->stash($results);
+    elsif ( $c->req->accepts('application/json') ) {
+        $c->stash( {
+            current_view => 'JSON',
+            json         => $results,
+        } );
+    }
+    else {
+        $c->stash($results);
+    }
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Controller/Pod2HTML.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod2HTML.pm
@@ -2,29 +2,11 @@ package MetaCPAN::Web::Controller::Pod2HTML;
 
 use Moose;
 
-use Encode                    qw( decode DIE_ON_ERR encode LEAVE_SRC );
-use HTML::TokeParser          ();
-use MetaCPAN::Web::RenderUtil qw( filter_html );
-use Future                    ();
+use Encode qw( decode DIE_ON_ERR LEAVE_SRC );
 
 use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
-
-sub render_pod {
-    my ( $c, $pod ) = @_;
-    my $html = $c->model('API')->request(
-        'pod_render',
-        undef,
-        {
-            pod         => encode( 'UTF-8', $pod ),
-            show_errors => 1,
-        },
-        'POST'
-    )->then( sub {
-        Future->done( filter_html( $_[0]->{raw} ) );
-    } );
-}
 
 sub pod2html : Path : Args(0) {
     my ( $self, $c ) = @_;
@@ -34,46 +16,34 @@ sub pod2html : Path : Args(0) {
         eval {
             $pod = decode( 'UTF-8', $raw_pod, DIE_ON_ERR | LEAVE_SRC );
             1;
-        } or $pod = decode( 'cp1252', $raw_pod );
+        } or do {
+            $pod = decode( 'cp1252', $raw_pod );
+        };
     }
     else {
         $pod = $c->req->parameters->{pod} // q{};
     }
 
-    my $html = length $pod ? render_pod( $c, $pod )->get : q{};
+    my $pod_data = $c->model('API::Pod')->pod2html(
+        $pod,
+        {
+            show_errors => 1,
+        }
+    )->get;
+    my $html = $pod_data->{pod_html} // q{};
 
+    my $results = {
+        pod          => $pod,
+        pod_rendered => $html,
+        pod_name     => $pod_data->{pod_name},
+        abstract     => $pod_data->{abstract},
+    };
     if ( $c->req->parameters->{raw} ) {
         $c->res->content_type('text/html');
         $c->res->body($html);
         $c->detach;
     }
-
-    $c->stash( {
-        pod          => $pod,
-        pod_rendered => $html,
-        ( length $html ? %{ pod_info($html) } : () ),
-    } );
-}
-
-sub pod_info {
-    my $p = HTML::TokeParser->new( \( $_[0] ) );
-    while ( my $t = $p->get_token ) {
-        my ( $type, $tag, $attr ) = @$t;
-        next
-            unless ( $type eq 'S'
-            && $tag eq 'h1'
-            && $attr->{id}
-            && $attr->{id} eq 'NAME' );
-
-        my $name_section = $p->get_trimmed_text('h1') or next;
-        if ( $name_section =~ /(?:NAME\s+)?([^-]+?)\s*-\s*(.*)/s ) {
-            return {
-                pod_name => "$1",
-                abstract => "$2",
-            };
-        }
-    }
-    return {};
+    $c->stash($results);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Model/API/Author.pm
+++ b/lib/MetaCPAN/Web/Model/API/Author.pm
@@ -66,6 +66,8 @@ sub get {
 
 sub get_multiple {
     my ( $self, @authors ) = @_;
+    return Future->done( { took => 0, total => 0, authors => [] } )
+        if !@authors;
     return $self->request( '/author/by_ids', { id => [ map uc, @authors ] } )
         ->transform(
         done => sub {

--- a/lib/MetaCPAN/Web/Model/API/File.pm
+++ b/lib/MetaCPAN/Web/Model/API/File.pm
@@ -6,7 +6,7 @@ with 'MetaCPAN::Web::Role::FileData';
 sub get {
     my ( $self, @path ) = @_;
     $self->request( '/file/' . join( '/', @path ) )
-        ->then( $self->_groom_fileinfo );
+        ->then( $self->_groom_fileinfo( [], \@path ) );
 }
 
 sub source {
@@ -31,7 +31,7 @@ sub dir {
             }
             return $dir;
         }
-    )->then( $self->_groom_fileinfo('dir') );
+    )->then( $self->_groom_fileinfo( ['dir'] ) );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/MetaCPAN/Web/Model/API/Module.pm
+++ b/lib/MetaCPAN/Web/Model/API/Module.pm
@@ -27,7 +27,7 @@ it under the same terms as Perl itself.
 sub find {
     my ( $self, @path ) = @_;
     $self->request( '/module/' . join( '/', @path ) )
-        ->then( $self->_groom_fileinfo );
+        ->then( $self->_groom_fileinfo( [], \@path ) );
 }
 
 sub autocomplete {
@@ -46,7 +46,7 @@ sub search_web {
     $self->request( '/search/web', undef,
         { q => $query, size => $page_size // 20, from => $from // 0 } )
         ->then( $self->add_river( sub { @{ $_[0]{results} || [] } } ) )
-        ->then( $self->_groom_fileinfo( 'results', 'hits' ) );
+        ->then( $self->_groom_fileinfo( [ 'results', 'hits' ] ) );
 }
 
 sub first {

--- a/lib/MetaCPAN/Web/Model/API/Pod.pm
+++ b/lib/MetaCPAN/Web/Model/API/Pod.pm
@@ -2,7 +2,7 @@ package MetaCPAN::Web::Model::API::Pod;
 use Moose;
 use namespace::autoclean;
 
-use MetaCPAN::Web::RenderUtil qw( filter_html );
+use MetaCPAN::Web::RenderUtil qw( split_index filter_html );
 use Encode                    qw( encode );
 use Future                    ();
 
@@ -75,8 +75,11 @@ sub _with_filter {
     sub {
         my $data = shift;
         if ( my $raw = $data->{raw} ) {
+            my ( $index, $body ) = split_index($raw);
+            $data->{pod_index}
+                = filter_html( $index, $data->{path} ? $data : () );
             $data->{pod_html}
-                = filter_html( $raw, $data->{path} ? $data : () );
+                = filter_html( $body, $data->{path} ? $data : () );
         }
         return Future->done($data);
     };

--- a/lib/MetaCPAN/Web/Model/API/Pod.pm
+++ b/lib/MetaCPAN/Web/Model/API/Pod.pm
@@ -1,0 +1,88 @@
+package MetaCPAN::Web::Model::API::Pod;
+use Moose;
+use namespace::autoclean;
+
+use MetaCPAN::Web::RenderUtil qw( filter_html );
+use Encode                    qw( encode );
+use Future                    ();
+
+extends 'MetaCPAN::Web::Model::API';
+
+sub file_pod {
+    my ( $self, $file, $opts ) = @_;
+
+    $opts ||= {};
+
+    my $pod_path
+        = '/pod/'
+        . ( $file->{assoc_pod}
+            || "$file->{author}/$file->{release}/$file->{path}" );
+
+    return $self->request(
+        $pod_path,
+        undef,
+        {
+            show_errors => 1,
+            ( $opts->{permalinks} ? ( permalinks => 1 ) : () ),
+            url_prefix => '/pod/',
+        }
+    )->then( $self->_with_filter );
+}
+
+sub pod2html {
+    my ( $self, $pod, $opts ) = @_;
+
+    $opts ||= {};
+
+    return Future->done( {} )
+        if !length $pod;
+    return $self->request(
+        'pod_render',
+        undef,
+        {
+            pod => encode( 'UTF-8', $pod ),
+            %$opts,
+        },
+        'POST'
+    )->then( $self->_with_filter )->then( sub {
+        my $data = shift;
+
+        if ( my $html = $data->{pod_html} ) {
+            my $p = HTML::TokeParser->new( \$html );
+            while ( my $t = $p->get_token ) {
+                my ( $type, $tag, $attr ) = @$t;
+                next
+                    unless ( $type eq 'S'
+                    && $tag eq 'h1'
+                    && $attr->{id}
+                    && $attr->{id} eq 'NAME' );
+
+                my $name_section = $p->get_trimmed_text('h1') or next;
+                if ( $name_section =~ /(?:NAME\s+)?([^-]+?)\s*-\s*(.*)/s ) {
+                    $data->{pod_name} = "$1";
+                    $data->{abstract} = "$2";
+                    last;
+                }
+            }
+        }
+
+        Future->done($data);
+    } );
+}
+
+sub _with_filter {
+    my ($self) = @_;
+    sub {
+        my $data = shift;
+        if ( my $raw = $data->{raw} ) {
+            $data->{pod_html}
+                = filter_html( $raw, $data->{path} ? $data : () );
+        }
+        return Future->done($data);
+    };
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+

--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -80,7 +80,7 @@ sub modules {
             $data->{modules} = $modules;
         }
         Future->done($data);
-    } )->then( $self->_groom_fileinfo('modules') );
+    } )->then( $self->_groom_fileinfo( ['modules'] ) );
 }
 
 sub find {
@@ -118,7 +118,7 @@ sub reverse_dependencies {
 sub interesting_files {
     my ( $self, $author, $release ) = @_;
     $self->request("/release/interesting_files/$author/$release")
-        ->then( $self->_groom_fileinfo('files') );
+        ->then( $self->_groom_fileinfo( ['files'] ) );
 }
 
 sub versions {

--- a/lib/MetaCPAN/Web/RenderUtil.pm
+++ b/lib/MetaCPAN/Web/RenderUtil.pm
@@ -12,6 +12,7 @@ use Digest::MD5    ();
 our @EXPORT_OK = qw(
     filter_html
     gravatar_image
+    split_index
 );
 
 sub filter_html {
@@ -41,6 +42,7 @@ sub filter_html {
             i       => [],
             li      => ['id'],
             ol      => [],
+            nav     => [],
             p       => [],
             pre     => [ {
                 class        => qr/^line-numbers$/,
@@ -59,7 +61,7 @@ sub filter_html {
             td     => [qw( colspan rowspan )],
             tr     => [],
             u      => [],
-            ul     => [ { id => qr/^index$/ } ],
+            ul     => [],
 
             #
             # SVG tags.
@@ -144,6 +146,19 @@ sub gravatar_image {
     my $grav_id = Digest::MD5::md5_hex( lc $email );
     return sprintf 'https://www.gravatar.com/avatar/%s?d=identicon&s=%s',
         $grav_id, $size // 80;
+}
+
+sub split_index {
+    my ($html) = @_;
+
+    # this will hopefully be done by the API in the future
+    $html =~ s{\A<ul id="index">(.*?^</ul>\n?)}{<nav><ul>$1</nav>}ms;
+
+    # both of these regexes are kind of ugly, but we know the content produced
+    # by the API, so it should still work fine.
+    $html =~ s{\A<nav>(.*?)</nav>\n*}{}s;
+    my $pod_index = $1;
+    return ( $pod_index, $html );
 }
 
 1;

--- a/root/pod.tx
+++ b/root/pod.tx
@@ -34,8 +34,13 @@
   </li>
 %%  }
 %%  override page_content -> {
+%%  if $pod_index {
+<nav class="toc">
+  <div class="toc-header"><strong>Contents</strong></div>
+%%    $pod_index | mark_raw;
+</nav>
+%%  }
 <div class="pod anchors">
-  <a name="___pod"></a>
   %%  if $pod {
   %%    $pod | mark_raw;
   %%  }

--- a/root/pod2html/pod2html.tx
+++ b/root/pod2html/pod2html.tx
@@ -32,6 +32,11 @@
     </div>
   </div>
 </div>
-<div id="metacpan-pod-renderer-output" class="pod anchors" [% if !$pod_rendered { %]style="display: none"[% } %]>[% $pod_rendered | raw %]</div>
+<div id="metacpan-pod-renderer-output" class="pod anchors" [% if !$pod_html { %]style="display: none"[% } %]>
+  <nav class="toc">
+    <div class="toc-header"><strong>Contents</strong></div>
+    [% $pod_index %]
+  </nav>
+  [% $pod_html | raw %]
 </div>
 %%  }

--- a/root/static/less/pod.less
+++ b/root/static/less/pod.less
@@ -84,89 +84,63 @@
     }
 }
 
-ul#index, #index ul {
-    padding: 0;
-    margin: 0;
-    list-style-type: none;
+.content .toc {
+    display: inline-block;
+    border: 1px solid rgb(215, 215, 215);
+    padding: 3px 10px;
 
-    ul {
-        margin-left: 1.5em;
-    }
-
-    li {
-        margin-bottom: 0;
-        margin-top: 0.4em;
-        line-height: 1.3em;
-    }
-}
-
-#index-container {
+    overflow-x: auto;
+    overflow-y: hidden;
     margin-bottom: 40px;
 
     @media (min-width: @screen-md-max) {
         float: right;
         margin-left: 50px;
+        max-width: 400px;
     }
 
-    overflow-y: hidden;
-
-    .index-header {
+    .toc-header {
         text-align: center;
         line-height: 24px;
     }
 
-    .index-border {
-        display: inline-block;
-        border: 1px solid rgb(215, 215, 215);
-        padding: 3px 10px;
+    > ul {
+        overflow-y: hidden;
+        transition: height 0.3s ease-out;
     }
 
-    #index {
-        overflow-y: hidden;
+    ul {
+        padding: 0;
+        margin: 0;
+        list-style-type: none;
+
+        ul {
+            margin-left: 1.5em;
+        }
+
+        li {
+            margin-bottom: 0;
+            margin-top: 0.4em;
+            line-height: 1.3em;
+        }
     }
 
     .toggle-show {
         display: none;
     }
 
-    &.hide-index {
+    &.hide-toc {
         .toggle-hide {
             display: none;
         }
         .toggle-show {
             display: inline;
         }
-        #index {
+        > ul {
             height: 0;
         }
     }
 
-    .toggle-index-right {
-        color: #000;
-        float: right;
-        border: 0;
-        margin: -6px -7px 0 -7px;
-    }
-
-    .toggle-left {
-        display: none;
-    }
-
-    &.pull-right {
-        .index-border {
-            margin-left: 5px;
-            max-width: 225px;
-            overflow-x: auto;
-        }
-
-        .toggle-right {
-            display: none;
-            visibility: collapse;
-        }
-        .toggle-left {
-            display: inline-block;
-        }
-    }
 }
 
 .pod p.pod-error {


### PR DESCRIPTION
This separates the table of contents from the rest of the pod in the perl code, allowing it to be handled separately in the template. Includes some refactoring to do more work in the API modules.

Fixes #2972