### PR TITLE
remove scroll-margin-top as unneeded

### DIFF
--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -458,7 +458,3 @@ h1, .h1, h2, .h2, h3, .h3 {
 .nav-list li.release-banner + li.nav-header {
     margin-top: 5px;
 }
-
-* {
-  scroll-margin-top: 60px;
-}


### PR DESCRIPTION
The scroll-margin-top CSS property is used with scroll snapping, which we aren't using. It also currently triggers a bug in Chrome: https://issues.chromium.org/issues/41495913