### PR TITLE
use accepts header, not ancient browser detection

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -10,7 +10,7 @@ requires 'Catalyst::Model';
 requires 'Catalyst::Plugin::Authentication';
 requires 'Catalyst::Plugin::ConfigLoader';
 requires 'Catalyst::Plugin::Static::Simple';
-requires 'Catalyst::TraitFor::Request::REST::ForBrowsers';
+requires 'Catalyst::TraitFor::Request::REST';
 requires 'Catalyst::View::JSON';
 requires 'Catalyst::View::Xslate';
 requires 'CatalystX::Fastly::Role::Response', '0.06';

--- a/lib/MetaCPAN/Web.pm
+++ b/lib/MetaCPAN/Web.pm
@@ -16,7 +16,7 @@ extends 'Catalyst';
 
 __PACKAGE__->request_class_traits( [ qw(
     MetaCPAN::Web::Role::Request
-    Catalyst::TraitFor::Request::REST::ForBrowsers
+    Catalyst::TraitFor::Request::REST
 ) ] );
 
 __PACKAGE__->response_class_traits( [ qw(

--- a/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
+++ b/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
@@ -5,7 +5,9 @@ BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 sub add : Local : Args(0) {
     my ( $self, $c ) = @_;
-    $c->stash( { current_view => 'JSON' } );
+    my $json = $c->req->accepts('application/json');
+    $c->stash( { current_view => 'JSON' } )
+        if $json;
     $c->detach('/forbidden') unless ( $c->req->method eq 'POST' );
     my $user = $c->user;
     $c->detach('/forbidden') unless $user;
@@ -24,16 +26,16 @@ sub add : Local : Args(0) {
     $c->purge_author_key( $data->{author} )     if $data->{author};
     $c->purge_dist_key( $data->{distribution} ) if $data->{distribution};
 
-    if ( $c->req->looks_like_browser ) {
+    if ($json) {
+        $c->res->code(400) if ( $res->{error} );
+        $c->stash->{json}{success} = $res->{error} ? \0 : \1;
+    }
+    else {
         $c->res->redirect(
               $res->{error}
             ? $c->req->referer
             : $c->uri_for('/account/turing/index')
         );
-    }
-    else {
-        $c->res->code(400) if ( $res->{error} );
-        $c->stash->{json}{success} = $res->{error} ? \0 : \1;
     }
 }
 

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -552,6 +552,7 @@ function favDistribution(form) {
         type: 'POST',
         url: form.attr('action'),
         data: data,
+        dataType: 'json',
         success: function() {
             var button = form.find('button');
             button.toggleClass('active');


### PR DESCRIPTION
The proper way to check if a request should return JSON is using the Accepts header. And since we're making these requests in JS, we can control that.

The browser detection in the ForBrowsers plugin is based on a IE7 world.