### PR TITLE
bring back scoll-margin-top

### DIFF
--- a/root/static/less/global.less
+++ b/root/static/less/global.less
@@ -458,3 +458,7 @@ h1, .h1, h2, .h2, h3, .h3 {
 .nav-list li.release-banner + li.nav-header {
     margin-top: 5px;
 }
+
+.page-content * {
+    scroll-margin-top: 60px;
+}


### PR DESCRIPTION
Despite the documentation, it does have an impact. Chrome seems to be fixed now.