### PR TITLE
Correctly close HTML <div> in release.tx

### DIFF
--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -51,7 +51,8 @@
     %%    : '/dist/' ~ $release.distribution;
     <li class="nav-header no-margin-top">
       <div class="ttip" data-toggle="tooltip" data-placement="bottom" title="The date that this version of [% $release.distribution %] was released.">
-      <span class="relatize">[% datetime($release.date).to_http %]</span>
+        <span class="relatize">[% datetime($release.date).to_http %]</span>
+      </div>
     </li>
     %%  include inc::release_status { maturity => $release.maturity }
     %%  block left_nav_lead -> {


### PR DESCRIPTION
I actually noticed this while testing MetaCPAN with the [Ladybird browser](https://github.com/SerenityOS/serenity) where is kindly spat out:
```
187047.691 WebContent(331600): Expected <li> current node, but had <div>
```
Which came from
```c++
    // -> An end tag whose tag name is "li"
    if (token.is_end_tag() && token.tag_name() == HTML::TagNames::li) {
        // If the stack of open elements does not have an li element in list item scope, then this is a parse error; ignore the token.
        if (!m_stack_of_open_elements.has_in_list_item_scope(HTML::TagNames::li)) {
            log_parse_error();
            return;
        }

        // Otherwise, run these steps:
        // 1. Generate implied end tags, except for li elements.
        generate_implied_end_tags(HTML::TagNames::li);

        // 2. If the current node is not an li element, then this is a parse error.
        if (current_node().local_name() != HTML::TagNames::li) {
            log_parse_error();
            dbgln("Expected <li> current node, but had <{}>", current_node().local_name());
        }

        // 3. Pop elements from the stack of open elements until an li element has been popped from the stack.
        m_stack_of_open_elements.pop_until_an_element_with_tag_name_has_been_popped(HTML::TagNames::li);
        return;
    }
```

But you can also see the error when viewing the source of a MetaCPAN dist page in Firefox:
![image](https://github.com/metacpan/metacpan-web/assets/184356/b93f6888-c624-41b6-bdd3-a82393ab825e)

And this new markup matches what Firefox munges it into anyways:
![image](https://github.com/metacpan/metacpan-web/assets/184356/73c6b930-e61d-4edf-96f6-7112251b6741)
