### PR TITLE
Add codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+---
+comment:
+  layout: 'diff, files'
+  behavior: default
+  require_changes: true  # if true: only post the comment if coverage changes
+  require_base: false  # [true :: must have a base report to post]
+  require_head: true  # [true :: must have a head report to post]
+  hide_project_coverage: false  # [true :: only show coverage on the git diff]


### PR DESCRIPTION
Don't show comments when the coverage is unchanged. Also, pare down what
is show to make it less noisy.

See https://docs.codecov.com/docs/pull-request-comments for options.

This PR preserves the overall diff as that will make overall coverage changes easier to understand when files are removed or renamed.
