### PR TITLE
remove unused lessc_command option

### DIFF
--- a/metacpan_web.conf
+++ b/metacpan_web.conf
@@ -9,7 +9,6 @@ consumer_key    = metacpan.dev
 cookie_secret   = seekrit
 consumer_secret = ClearAirTurbulence
 log4perl_file   = log4perl.conf
-lessc_command   = npx lessc
 
 mark_unauthorized_releases = 0
 


### PR DESCRIPTION
The perl code no longer needs to build any of the css or less, so it doesn't need any configuration for lessc.