### PR TITLE
split codecov uploading into separate repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: test
+name: Test
 on:
   push:
     branches:
@@ -73,9 +73,6 @@ jobs:
         DEVEL_COVER_OPTIONS: '-ignore,^local/'
     steps:
       - uses: actions/checkout@v4
-        if: matrix.resolver == 'snapshot'
-      - uses: actions/checkout@v4
-        if: matrix.resolver != 'snapshot'
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -95,11 +92,6 @@ jobs:
             --resolver ${{ matrix.resolver }}
       - name: Build assets
         run: npm run build
-      - name: Run tests without coverage
-        if: matrix.resolver != 'snapshot'
-        run: carton exec prove -lr --jobs 2 t
-        env:
-          TEST_TIDYALL_VERBOSE: 1
       - name: Install Codecovbash
         if: matrix.resolver == 'snapshot'
         uses: perl-actions/install-with-cpm@v1
@@ -108,17 +100,19 @@ jobs:
             Devel::Cover
             Devel::Cover::Report::Codecovbash
           sudo: false
-      - name: Run tests with coverage
+      - name: Configure Code Coverage
+        id: coverage
         if: matrix.resolver == 'snapshot'
+        run: >
+          echo "switches=-MDevel::Cover=+ignore,^t/" >> "$GITHUB_OUTPUT"
+      - name: Run tests
         run: carton exec prove -lr --jobs 2 t
         env:
-          HARNESS_PERL_SWITCHES: -MDevel::Cover=+ignore,^t/
+          HARNESS_PERL_SWITCHES: $${ steps.coverage.outputs.switches }}
       - name: Generate Codecov report
         if: matrix.resolver == 'snapshot'
         run: cover -report codecovbash
-      - uses: codecov/codecov-action@v4
-        if: matrix.resolver == 'snapshot'
+      - uses: actions/upload-artifact@v4
         with:
-          fail_ci_if_error: true
-          file: ./cover_db/codecov.json
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov.json
+          path: ./cover_db/codecov.json

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -1,0 +1,64 @@
+name: Upload Coverage Report
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    name: Upload
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: codecov.json
+          id: ${{ github.event.workflow_run.id }}
+      - uses: actions/checkout@v4
+        name: Checkout codecov.yml
+        with:
+          path: repo
+          sparse-checkout: |
+            codecov.yml
+          sparse-checkout-cone-mode: false
+      - uses: actions/github-script@v7
+        name: Find associated pull request
+        id: pr
+        with:
+          script: |
+            const response = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
+              per_page: 1,
+            })
+            const items = response.data.items
+            if (items.length < 1) {
+              console.error('No PRs found')
+              return
+            }
+            const pullRequest = items[0]
+            console.info("Pull request number is", pullRequest.number)
+            return pullRequest
+      - name:
+        env:
+          PR_DATA: ${{ steps.id.outputs.result }}
+          EVENT_DATA: ${{ toJson(github.event) }}
+        run: 'printf "pr:\n%s\nevent:\n%s\n" "$PR_DATA" "$EVENT_DATA"'
+#      - uses: codecov/codecov-action@v4
+#        if: hashFiles('codecov.json')
+#        with:
+#          codecov_yml_path: repo/codecov.yml
+#          disable_search: true
+#          file: codecov.json
+#          token: ${{ secrets.CODECOV_TOKEN }}
+#          commit_parent: ${{  }}
+#          job_code: ${{ github.event.workflow.name }}
+#          os: ${{ }}
+#          override_branch: ${{ }}
+#          override_build: ${{ }}
+#          override_build_url: ${{ }}
+#          override_commit: ${{ }}
+#          override_pr: ${{ }}


### PR DESCRIPTION
Some PRs run with lowered permissions that don't have access to secrets. This is generally good, but means they don't have a token to upload to Codecov. Split out the uploading to a separate workflow that is triggered by the completion of the test workflow.