### PR TITLE
fix syntaxhighlighter styles

### DIFF
--- a/build-assets.mjs
+++ b/build-assets.mjs
@@ -6,10 +6,6 @@ import {
 }
 from 'esbuild-plugin-less';
 import {
-    sassPlugin
-}
-from 'esbuild-sass-plugin';
-import {
     writeFile,
     opendir,
     unlink
@@ -22,7 +18,6 @@ const config = {
     entryPoints: [
         'root/static/js/main.mjs',
         'root/static/less/style.less',
-        'root/static/scss/style.scss',
     ],
     assetNames: '[name]-[hash]',
     entryNames: '[name]-[hash]',
@@ -40,7 +35,6 @@ const config = {
     },
     plugins: [
         lessLoader(),
-        sassPlugin(),
         new class {
             name = 'metacpan-build';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,15 +18,13 @@
         "devbridge-autocomplete": "^1.4.11",
         "esbuild": "^0.20.0",
         "esbuild-plugin-less": "^1.3.2",
-        "esbuild-sass-plugin": "^3.3.0",
         "jquery": "^3.7.1",
         "less": "^4.2.0",
         "minimist": "^1.2.8",
         "mousetrap": "^1.6.5",
         "qtip2": "^3.0.3",
         "syntaxhighlighter": "^4.0.1",
-        "tablesorter": "^2.31.3",
-        "theme-base": "^4.0.1"
+        "tablesorter": "^2.31.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.3.0",
@@ -35,12 +33,6 @@
         "js-beautify": "^1.15.1",
         "prettier": "3.2.5"
       }
-    },
-    "node_modules/@bufbuild/protobuf": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.9.0.tgz",
-      "integrity": "sha512-W7gp8Q/v1NlCZLsv8pQ3Y0uCu/SHgXOVFK+eUluUKWXmsb6VHkpNx0apdOWWcDbB9sJoKeP8uPrjmehJz6xETQ==",
-      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.20.2",
@@ -697,18 +689,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -720,17 +700,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/bootstrap": {
       "version": "3.4.1",
@@ -748,17 +717,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/brush-base": {
@@ -840,12 +798,6 @@
         "npm": ">=2"
       }
     },
-    "node_modules/buffer-builder": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
-      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
-      "peer": true
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -869,40 +821,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/color-convert": {
@@ -1125,19 +1043,6 @@
         "esbuild": "^0.14.x || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0"
       }
     },
-    "node_modules/esbuild-sass-plugin": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.3.0.tgz",
-      "integrity": "sha512-btH77lGkASp1VHyji0dAanomatCwq1dmfrjAIjhv+GgR9LK2m1hbRr+t4kbjveyqCwmdBfRkboj+Pfaruok1Mg==",
-      "dependencies": {
-        "resolve": "^1.22.8",
-        "sass": "^1.71.1"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.20.1",
-        "sass-embedded": "^1.71.1"
-      }
-    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1332,17 +1237,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1392,27 +1286,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -1495,19 +1368,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/iconv-lite": {
@@ -1551,11 +1414,6 @@
         "ev-emitter": "^2.1.2"
       }
     },
-    "node_modules/immutable": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ=="
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -1587,32 +1445,11 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dependencies": {
-        "hasown": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1630,19 +1467,12 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
@@ -1936,14 +1766,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2041,11 +1863,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -2060,17 +1877,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pify": {
@@ -2156,33 +1962,6 @@
         }
       ]
     },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2234,398 +2013,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "optional": true
-    },
-    "node_modules/sass": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.2.tgz",
-      "integrity": "sha512-eb4GZt1C3avsX3heBNlrc7I09nyT00IUuo4eFhAbeXWU2fvA7oXI53SxODVAA+zgZCk9aunAZgO+losjR3fAwA==",
-      "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.2.tgz",
-      "integrity": "sha512-luiDeWNZ0tKs1jCiSFbuz8wFVQxYqN+vh+yfm9v7kW42yPtwEF8+z2ROaDJluSUZ7vhFmsXuqoKg9qBxc7SCnw==",
-      "peer": true,
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.0.0",
-        "buffer-builder": "^0.2.0",
-        "immutable": "^4.0.0",
-        "rxjs": "^7.4.0",
-        "supports-color": "^8.1.1",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "optionalDependencies": {
-        "sass-embedded-android-arm": "1.77.2",
-        "sass-embedded-android-arm64": "1.77.2",
-        "sass-embedded-android-ia32": "1.77.2",
-        "sass-embedded-android-x64": "1.77.2",
-        "sass-embedded-darwin-arm64": "1.77.2",
-        "sass-embedded-darwin-x64": "1.77.2",
-        "sass-embedded-linux-arm": "1.77.2",
-        "sass-embedded-linux-arm64": "1.77.2",
-        "sass-embedded-linux-ia32": "1.77.2",
-        "sass-embedded-linux-musl-arm": "1.77.2",
-        "sass-embedded-linux-musl-arm64": "1.77.2",
-        "sass-embedded-linux-musl-ia32": "1.77.2",
-        "sass-embedded-linux-musl-x64": "1.77.2",
-        "sass-embedded-linux-x64": "1.77.2",
-        "sass-embedded-win32-arm64": "1.77.2",
-        "sass-embedded-win32-ia32": "1.77.2",
-        "sass-embedded-win32-x64": "1.77.2"
-      }
-    },
-    "node_modules/sass-embedded-android-arm": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.2.tgz",
-      "integrity": "sha512-rMuIMZ/FstMrT9Y23LDgQGpCyfe3i10dJnmW+DVJ9Gqz4dR7qpysEBIQXU35mHVq8ppNZ0yGiFlFZTSiiVMdzQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-android-arm64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.2.tgz",
-      "integrity": "sha512-7DiFMros5iRYrkPlNqUBfzZ/DCgsI199pRF8xuBsPf9yuB8SLDOqvNk3QOnUCMAbpjW5VW1JgdfGFFlHTCnJQA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-android-ia32": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.2.tgz",
-      "integrity": "sha512-qN0laKrAjuvBLFdUogGz8jQlbHs6tgH91tKQeE7ZE4AO9zzDRlXtaEJP1x6B6AGVc8UOEkvQyR3Nej4qwWprhA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-android-x64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.2.tgz",
-      "integrity": "sha512-HByqtC5g5hOaJenWs4Klx6gFEIZYx+IEFh5K56U+wB+jd6EU32Lrnbdxy1+i/p/kZrd+23HrVHQPv8zpmxucaw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.2.tgz",
-      "integrity": "sha512-0jkL/FwbAStqqxFSjHfhElEAWrKRRvFz2JeXOxskUdzMehDMv5LaewqSRCijyeKBO3KgurvndmSfrOizdU6WAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.2.tgz",
-      "integrity": "sha512-8Sy36IxOOFPWA5TdhC87SvOkrXUSis51CGKlIsM8yZISQiY9y8b+wrNJM1f3oHvs641xZBaeIuwibJXaY6hNBg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-arm": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.2.tgz",
-      "integrity": "sha512-/gtCseBkGCBw61p6MG2BqeYy8rblffw2KXUzMKjo9Hlqj/KajWDk7j1B+mVnqrHOPB/KBbm8Ym/2ooCYpnMIkQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.2.tgz",
-      "integrity": "sha512-hlfNFu1IWHI0cOsbpFWPrJlx7IFZfXuI3iEhwa4oljM21y72E6tETUFmTr4f9Ka9qDLXkUxUoYaTH2SqGU9dDA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.2.tgz",
-      "integrity": "sha512-JSIqGIeAKlrMw/oMFFFxZ10F3QUJVdjeGVI83h6mwNHTYgrX6PuOngcAYleIpYR5XicQgfueC5pPVPbP5CArBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.2.tgz",
-      "integrity": "sha512-LZTSnfHPlfvkdQ8orpnEUCEx40qhKpMjxN3Ggi8kgQqv5jvtqn0ECdWl0n4WI5CrlkmtdS3VeFcsf078bt/f8Q==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.2.tgz",
-      "integrity": "sha512-JQZuONuhIurKjc/qE9cTiJXSLixL8hGkalWN3LJHasYHVAU92QA/t8rv0T51vIzf/I2F59He3bapkPme60dwSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.2.tgz",
-      "integrity": "sha512-6F1GHBgPkcTXtfM0MK3PofozagNF8IawdfIG4RNzGeSZRhGBRgZLOS+vdre4xubTLSaa6xjbI47YfaD43z8URQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.2.tgz",
-      "integrity": "sha512-8BiqLA1NJeN3rCaX6t747GWMMdH5YUFYuytXU8waDC/u+FSGoOHRxfrsB8BEWHVgSPDxhwZklanPCXXzbzB2lw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-x64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.2.tgz",
-      "integrity": "sha512-czQOxGOX4U47jW9k+cbFBgSt/6FVx2WGLPqPvrgDiEToLJdZyvzUqrkpqQYfJ6hN1koqatCPEpDrUZBcTPGUGg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.2.tgz",
-      "integrity": "sha512-NA+4Y5PO04YQGtKNCyLrUjQU2nijskVA3Er/UYGtx66BBlWZ/ttbnlk+dU05SF5Jhjb3HtThGGH1meb7pKA+OQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.2.tgz",
-      "integrity": "sha512-/3hGz4GefhVuuUu2gSOdsxBYym5Di0co0tZbtiokCU/8VhYhcAQ3v2Lni49VV6OnsyJLb1nUx+rbpd8cKO1U4w==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-win32-x64": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.2.tgz",
-      "integrity": "sha512-joHLDICWmnR9Ca+LT9B+Fp85sCvV9F3gdtHtXLSuQAEulG5Ip1Z9euB3FUw+Z0s0Vz4MjNea+JD+TwO9eMrpyw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
     },
     "node_modules/sax": {
       "version": "1.3.0",
@@ -2683,14 +2075,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2809,17 +2193,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/syntaxhighlighter": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/syntaxhighlighter/-/syntaxhighlighter-4.0.1.tgz",
@@ -2879,26 +2252,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/theme-base": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/theme-base/-/theme-base-4.0.1.tgz",
-      "integrity": "sha512-X4Ur5aRd1wmRP5RBnP41IiOCA6eaHdrSEb0HNr9h3H3DXhSg9i5EwunzlEMRkYZ+Qj3bikPkY3SHEyLXaJLh0A==",
-      "engines": {
-        "node": ">=4",
-        "npm": ">=2"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -2933,12 +2286,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-      "peer": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -34,14 +34,12 @@
     "devbridge-autocomplete": "^1.4.11",
     "esbuild": "^0.20.0",
     "esbuild-plugin-less": "^1.3.2",
-    "esbuild-sass-plugin": "^3.3.0",
     "jquery": "^3.7.1",
     "less": "^4.2.0",
     "minimist": "^1.2.8",
     "mousetrap": "^1.6.5",
     "qtip2": "^3.0.3",
     "syntaxhighlighter": "^4.0.1",
-    "tablesorter": "^2.31.3",
-    "theme-base": "^4.0.1"
+    "tablesorter": "^2.31.3"
   }
 }

--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -109,6 +109,7 @@
 @import "./lab.less";
 @import "./home.less";
 @import "./syntaxhighlighter.less";
+@import "./syntaxhighlighter-theme.less";
 @import "./pod2html.less";
 @import "./notification.less";
 @import "./footer.less";

--- a/root/static/less/syntaxhighlighter-theme.less
+++ b/root/static/less/syntaxhighlighter-theme.less
@@ -1,0 +1,131 @@
+.syntaxhighlighter {
+    line-height: 1.2em;
+    width: 100%;
+
+    // fix conflicts with bootstrap
+    .container {
+        width: unset;
+        padding: 0;
+        &:before,
+        &:after {
+            content: none !important;
+        }
+    }
+
+    // set up bold and italic
+    .bold {
+        font-weight: bold;
+    }
+    .italic {
+        font-style: italic;
+    }
+
+    .line {
+        white-space: pre;
+    }
+
+    // main table and columns
+    table {
+        width: 100%;
+
+        td.code {
+            width: 100%;
+        }
+
+        // middle spacing between line numbers and lines
+        td.gutter .line {
+            text-align: right;
+            padding: 0 0.5em 0 1em;
+        }
+
+        td.code .line {
+            padding: 0 1em;
+        }
+
+        td {
+            padding: unset;
+            border: unset;
+        }
+    }
+
+    .container {
+        position: relative;
+
+        .highlighted {
+            background-color: rgb(0 0 0 / 10%);
+        }
+    }
+
+    &.nogutter {
+        td.code {
+            .line {
+                padding-left: 0em;
+            }
+        }
+    }
+
+    // Add border to the lines
+    .gutter {
+        color: #afafaf;
+        .line {
+            border-right: 3px solid #6ce26c;
+            &.highlighted {
+                background-color: #6ce26c;
+            }
+        }
+    }
+
+    // Actual syntax highlighter colors.
+    .plain,
+    .plain a {
+        color: #000000;
+    }
+    .comments,
+    .comments a {
+        color: #008200;
+    }
+    .string,
+    .string a {
+        color: #0000ff;
+    }
+    .keyword {
+        font-weight: bold;
+        color: #006699;
+    }
+    .preprocessor {
+        color: #808080;
+    }
+    .variable {
+        color: #aa7700;
+    }
+    .value {
+        color: #009900;
+    }
+    .functions {
+        color: #ff1493;
+    }
+    .constants {
+        color: #0066cc;
+    }
+    .script {
+        font-weight: bold;
+        color: #006699;
+        background-color: none;
+    }
+    .color1,
+    .color1 a {
+        color: #808080;
+    }
+    .color2,
+    .color2 a {
+        color: #ff1493;
+    }
+    .color3,
+    .color3 a {
+        color: #ff0000;
+    }
+
+    a {
+        text-decoration: underline;
+    }
+}

--- a/root/static/less/syntaxhighlighter.less
+++ b/root/static/less/syntaxhighlighter.less
@@ -1,25 +1,71 @@
-html > body .syntaxhighlighter {
-    font-size: unset !important;
-    margin: unset !important;
-    overflow: unset !important;
-}
+.syntaxhighlighter {
+    .gutter {
+        .line {
+            border-left: 1px solid rgb(0 0 0 / 0%);
+            border-right: 1px solid rgb(0 0 0 / 0%);
+        }
+        .pod-line {
+            border-left: 1px solid rgb(0 0 0 / 15%);
+            border-right: 1px solid rgb(0 0 0 / 15%);
+            background-color: rgb(0 0 0 / 5%);
+        }
+    }
+    .pod-line:first-child,
+    :not(.pod-line) + .pod-line {
+        border-top: 1px solid rgb(0 0 0 / 15%);
+    }
+    .pod-line + :not(.pod-line) {
+        border-top: 1px solid rgb(0 0 0 / 15%);
+    }
+    .pod-line:last-child {
+        border-bottom: 1px solid rgb(0 0 0 / 15%);
+    }
 
-html > body .syntaxhighlighter {
-    /* needs higher specificity than the syntax highligher's rules */
-    &,
-    *,
-    * *,
-    * * *,
-    * * * *,
-    .line.alt2,
-    .line.alt1 {
-        font-family: unset !important;
-        line-height: normal !important;
+    .gutter {
+        .pod-placeholder {
+            text-align: right;
+            padding: 0 0.5em;
+            border-right: 3px solid transparent;
+
+            position: absolute;
+            height: 0px;
+            overflow: hidden;
+        }
+    }
+
+    .pod-placeholder {
+        font-style: italic;
+        background-color: rgb(0 0 0 / 15%);
+
+        position: absolute;
+        right: 0;
+        border-radius: 0 0 0 5px;
+
+        button {
+            padding: 0 1em;
+        }
     }
 }
 
-.syntaxhighlighter a {
-    text-decoration: underline;
+.pod-hidden {
+    .syntaxhighlighter {
+        div.pod-placeholder {
+            display: block;
+            position: static;
+            height: auto;
+            overflow: auto;
+
+            right: auto;
+            padding-left: 0;
+            border-radius: 0;
+
+            button {
+                text-align: left;
+                padding-left: 2em;
+                width: 100%;
+            }
+        }
+    }
 }
 
 .pod-hidden {
@@ -31,93 +77,6 @@ html > body .syntaxhighlighter {
     }
     .show-pod {
         display: inline;
-    }
-}
-
-body {
-    .syntaxhighlighter {
-        .pod-line {
-            background-color: darken(@pre-bg, 5%) !important;
-        }
-        .container {
-            .pod-line {
-                border-right: 1px solid darken(@pre-bg, 15%) !important;
-            }
-        }
-        .gutter {
-            .pod-line {
-                border-left: 1px solid darken(@pre-bg, 15%) !important;
-            }
-        }
-        .pod-line:first-child,
-        :not(.pod-line) + .pod-line {
-            border-top: 1px solid darken(@pre-bg, 15%) !important;
-        }
-        .pod-line + :not(.pod-line) {
-            border-top: 1px solid darken(@pre-bg, 15%) !important;
-        }
-        .pod-line:last-child {
-            border-bottom: 1px solid darken(@pre-bg, 15%) !important;
-        }
-
-        .gutter {
-            .pod-placeholder {
-                text-align: right !important;
-                padding: 0 0.5em !important;
-                border-right: 3px solid transparent !important;
-            }
-        }
-    }
-    .syntaxhighlighter {
-        .pod-placeholder {
-            font-style: italic !important;
-            background-color: darken(@pre-bg, 15%) !important;
-        }
-    }
-
-    .pod-hidden {
-        .syntaxhighlighter {
-            div.pod-placeholder {
-                display: block;
-                position: static !important;
-                height: auto !important;
-                overflow: auto !important;
-            }
-            .container {
-                .pod-placeholder {
-                    position: static !important;
-                    right: auto !important;
-                    padding-left: 0 !important;
-                    border-radius: 0;
-
-                    button {
-                        text-align: left;
-                        padding-left: 2em;
-                        width: 100%;
-                    }
-                }
-            }
-        }
-    }
-    .syntaxhighlighter {
-        .gutter {
-            .pod-placeholder {
-                position: absolute !important;
-                height: 0px !important;
-                overflow: hidden !important;
-            }
-        }
-        .container {
-            .pod-placeholder {
-                position: absolute !important;
-                right: 0 !important;
-                border-radius: 0 0 0 5px;
-
-                button {
-                    padding: 0 1em;
-                }
-            }
-        }
     }
 }
 

--- a/root/static/scss/style.scss
+++ b/root/static/scss/style.scss
@@ -1,3 +1,0 @@
-$background: inherit;
-
-@import "theme-base/theme-base.scss";


### PR DESCRIPTION
The syntax highlighter theme is rather terrible, trying to do its own css reset with !important on everything. This makes it awful to do our own overrides of its behavior. It also tries to do things that are no longer relevant.

Vendor the parts of the syntax highlighter theme that we need, removing the !important tags. This allows our own code to be simplified as well.