### PR TITLE
allow raw HTML to be used in markdown

### DIFF
--- a/t/markdown.t
+++ b/t/markdown.t
@@ -31,4 +31,29 @@ like $html, qr{<h2 id="heading-3">Heading</h2>}, 'third heading';
 
 like $html, qr{<h2 id="heading-with-markup">Heading <}, 'heading with markup';
 
+$html = render_markdown(<<'EOM');
+# Heading
+
+Some body text
+
+<div>Raw HTML</div>
+
+EOM
+
+like $html, qr{Raw HTML}, 'raw html allowed';
+
+$html = render_markdown( <<'EOM', unsafe => 0 );
+# Heading
+
+Some body text
+
+<div>Raw HTML</div>
+
+EOM
+
+unlike $html, qr{Raw HTML}, 'raw html blocked';
+
+eval { render_markdown( '# Heading', chorg => 1 ) };
+like "$@", qr/^Unsupported options: chorg /, 'invalid options throw errors';
+
 done_testing();


### PR DESCRIPTION
We do our own filtering of any user controlled markdown files, so it's safe to allow arbitrary HTML to be used. And we want raw HTML to be usable for user markdown and especially for our own markdown.

Enable the OPT_UNSAFE flag to allow raw HTML.