### PR TITLE
Restore fastly logo to the footer

### DIFF
--- a/root/base.tx
+++ b/root/base.tx
@@ -198,7 +198,7 @@
                 <img class="footer-sponsor-geocode" src="/static/images/sponsors/geocodelogo.svg" alt="Geocode logo">
               </a>
               <a class="footer-sponsor-link" target="_blank" href="https://www.fastly.com/" rel="noopener">
-
+                <img class="footer-sponsor-fastly" src="/static/images/sponsors/fastly_logo.svg" alt="Fastly logo">
               </a>
               <a class="footer-sponsor-link" target="_blank" href="https://opencagedata.com" rel="noopener">
                 <img class="footer-sponsor-opencage" src="/static/images/sponsors/open-cage.svg" alt="OpenCage logo">


### PR DESCRIPTION
It was accidentally removed in d34b6a969db7cf2edf7945b9561959352eab1ad1.
Fixes #3104
