### PR TITLE
Remove audit fix during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN \
     --mount=type=cache,target=/root/.npm,sharing=private \
 <<EOT
     npm install --verbose
-    npm audit fix
 EOT
 
 # not supported yet
@@ -104,7 +103,6 @@ RUN \
     --mount=type=cache,target=/root/.npm,sharing=private \
 <<EOT
     npm install --verbose --include=dev
-    npm audit fix
 EOT
 
 RUN \


### PR DESCRIPTION
Doing an audit fix during docker build makes the output more unpredictable. And we have dependabot in place to update the listed dependencies.

It also will cause errors for dependencies that it can't fix. We are using an older version of bootstrap, which has a XSS issue in it. But it doesn't impact us based on our use of bootstrap. We can't upgrade bootstrap without significant work, so for now we want to ignore this issue. npm audit doesn't provide any way to ignore specific dependencies.