### PR TITLE
Return 404 for invalid path: /release//File-Stat-Convert

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -39,11 +39,18 @@ sub release_view : Chained('root') PathPart('') Args(0) {
     my ( $self,   $c )       = @_;
     my ( $author, $release ) = $c->stash->@{qw(author_name release_name)};
 
-    $c->stash(
-        permalinks   => 1,
-        release_info => $c->model( 'ReleaseInfo', full_details => 1 )
-            ->get( $author, $release ),
-    );
+    if ( !$author ) {
+
+        # /release//File-Stat-Convert and others are never going to match
+        # do not even try call the API
+        $c->detach('/not_found');
+    } else {
+        $c->stash(
+            permalinks   => 1,
+            release_info => $c->model( 'ReleaseInfo', full_details => 1 )
+                ->get( $author, $release ),
+        );
+    }
     $c->forward('view');
 }
 

--- a/t/controller/release.t
+++ b/t/controller/release.t
@@ -22,6 +22,13 @@ test_psgi app, sub {
         'GET /release/PERLER/DOESNTEXIST' );
     is( $res->code, 404, 'code 404' );
 
+    ok( $res = $cb->( GET '/release/BRICAS/CPAN-Changes-0.21' ), 'GET /release/BRICAS/CPAN-Changes-0.21' );
+    is( $res->code, 200, 'code 200' );
+
+    # Testing missing author returns 404 not a 500
+    ok( $res = $cb->( GET '/release//CPAN-Changes-0.21' ), 'GET /release//CPAN-Changes-0.21' );
+    is( $res->code, 404, 'code 404' );
+
     ok( $res = $cb->( GET '/dist/Moose' ), 'GET /dist/Moose' );
     is( $res->code, 200, 'code 200' );
 


### PR DESCRIPTION
Return 404 for invalid paths, e.g. /release//File-Stat-Convert instead of a 500 - fix #3155

Please could you run perl tidy on this - I don't have the Perl setup