### PR TITLE
Return 404 for releases missing author, e.g. /release//File-Stat-Convert instead of a 500

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -1,13 +1,15 @@
 package MetaCPAN::Web::Controller::Release;
 
 use Moose;
-use namespace::autoclean;
+use namespace::autoclean -except => [qw(NonEmptyStr)];
 use experimental 'postderef';
-use Future ();
+use Future               ();
+use MetaCPAN::Web::Types qw(NonEmptyStr);    ## no perlimports
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
-sub root : Chained('/') PathPart('release') CaptureArgs(2) {
+sub root : Chained('/') PathPart('release')
+    CaptureArgs(NonEmptyStr,NonEmptyStr) {
     my ( $self, $c, $author, $release ) = @_;
 
     # force consistent casing in URLs

--- a/t/controller/release.t
+++ b/t/controller/release.t
@@ -22,6 +22,15 @@ test_psgi app, sub {
         'GET /release/PERLER/DOESNTEXIST' );
     is( $res->code, 404, 'code 404' );
 
+    ok( $res = $cb->( GET '/release/BRICAS/CPAN-Changes-0.21' ),
+        'GET /release/BRICAS/CPAN-Changes-0.21' );
+    is( $res->code, 200, 'code 200' );
+
+    # Testing missing author returns 404 not a 500
+    ok( $res = $cb->( GET '/release//CPAN-Changes-0.21' ),
+        'GET /release//CPAN-Changes-0.21' );
+    is( $res->code, 404, 'code 404' );
+
     ok( $res = $cb->( GET '/dist/Moose' ), 'GET /dist/Moose' );
     is( $res->code, 200, 'code 200' );
 


### PR DESCRIPTION
Fixes #3155