### PR TITLE
give docker compose containers names to disambiguate them from other services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  asset-build:
+  web-asset-build:
     build:
       context: .
       target: build-assets
@@ -7,7 +7,7 @@ services:
       - './root:/build/root/'
       - 'assets:/build/root/assets/'
     command: ['./build-assets.mjs', '--watch']
-  server:
+  web-server:
     build:
       context: .
       target: develop


### PR DESCRIPTION
This should allow the compose file to be included in metacpan's docker-compose without conflicts.