### PR TITLE
Fix alignment of magnifying glass in search input

### DIFF
--- a/root/static/less/search.less
+++ b/root/static/less/search.less
@@ -30,9 +30,10 @@
 .search-group .fa-search {
     color: @input-color;
     font-size: 20px;
-    left: 10px;
+    left: 18px;
     position: absolute;
-    top: 23%;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 .navbar-nav .search-form {


### PR DESCRIPTION
The magnifying glass icon is now centered vertically without relying on its absolute size. This ensures proper centering, regardless of the icon's dimensions.

Original:
<img width="893" alt="Screenshot 2024-10-09 at 12 18 51" src="https://github.com/user-attachments/assets/c2db2666-61bf-4d17-b2a7-b4680870e9a8">


Fixed:
<img width="803" alt="Screenshot 2024-10-09 at 12 18 38" src="https://github.com/user-attachments/assets/5836cfcb-62aa-4d23-8c2b-31cfbd5a91f2">
