### PR TITLE
docker compose improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     environment:
       # default is 120, shorten to work with compose label
       COLUMNS: 96
+    depends_on:
+      - web-asset-build
     develop:
       watch:
         - path: ./cpanfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,9 @@ services:
       - '/app/local'
     ports:
       - '8000:80'
+    develop:
+      watch:
+        - path: ./cpanfile
+          action: rebuild
 volumes:
   assets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       - '/app/local'
     ports:
       - '8000:80'
+    environment:
+      # default is 120, shorten to work with compose label
+      COLUMNS: 96
     develop:
       watch:
         - path: ./cpanfile


### PR DESCRIPTION
Fixes and improves a few things for docker compose:

* Specify a shorter COLUMNS value to try to prevent wrapping when used with docker compose in the foreground.
* Add a watch option to rebuild the image when the cpanfile is updated.
* Add a dependency on web-asset-build to web-server. This means if you specifically run the web-service, you'll still properly get the assets built.