### PR TITLE
Add docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN <<EOT
     npm run build:min
 EOT
 
+HEALTHCHECK CMD [ "test", "-e", "root/assets/assets.json" ]
+
 ################### Web Server
 # hadolint ignore=DL3007
 FROM metacpan/metacpan-base:latest AS server
@@ -61,6 +63,8 @@ CMD [ \
 ]
 
 EXPOSE 80
+
+HEALTHCHECK --start-period=3s CMD [ "curl", "--fail", "http://localhost/healthcheck" ]
 
 ################### Development Server
 FROM server AS develop

--- a/lib/MetaCPAN/Web/Controller/Root.pm
+++ b/lib/MetaCPAN/Web/Controller/Root.pm
@@ -93,6 +93,16 @@ sub robots : Path("robots.txt") : Args(0) {
     } );
 }
 
+sub healthcheck : Local : Args(0) {
+    my ( $self, $c ) = @_;
+
+    $c->res->content_type('application/json');
+    $c->stash( {
+        template => 'healthcheck.tx',
+        status   => 'healthy',
+    } );
+}
+
 =head2 end
 
 Attempt to render a view, if needed.

--- a/root/healthcheck.tx
+++ b/root/healthcheck.tx
@@ -1,0 +1,1 @@
+[% { status => $status }.json() | raw %]

--- a/t/controller/healthcheck.t
+++ b/t/controller/healthcheck.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Cpanel::JSON::XS    qw( decode_json );
+use MetaCPAN::Web::Test qw( app GET test_psgi );
+use Test::More;
+
+test_psgi app, sub {
+    my $cb = shift;
+    ok( my $res = $cb->( GET '/healthcheck' ), 'GET /healthcheck' );
+    is( $res->code, 200, 'code 200' );
+    is $res->header('Content-Type'), 'application/json',
+        'correct Content-Type';
+    my $data = decode_json( $res->content );
+    is $data->{status}, 'healthy', 'has correct status';
+};
+
+done_testing;


### PR DESCRIPTION
Adds a healthcheck end point doing some rudimentary work that can be checked.

Adds health checks to the docker containers. These will be used by docker-compose. Kubernetes doesn't use the declared docker health checks, so it won't have any impact on production.