### PR TITLE
use temp directory for xslate cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,6 @@ RUN \
     cpm install --show-build-log-on-failure --resolver=snapshot
 EOT
 
-RUN mkdir var && chown metacpan:users var
-
 ENV PERL5LIB="/app/local/lib/perl5"
 ENV PATH="/app/local/bin:${PATH}"
 

--- a/lib/MetaCPAN/Web/View/Xslate.pm
+++ b/lib/MetaCPAN/Web/View/Xslate.pm
@@ -2,6 +2,7 @@ package MetaCPAN::Web::View::Xslate;
 use Moose;
 extends qw(Catalyst::View::Xslate);
 use File::Path           ();
+use File::Temp           ();
 use MetaCPAN::Web::Types qw( AbsPath );
 
 has '+syntax'      => ( default => 'Metakolon' );
@@ -9,8 +10,15 @@ has '+encode_body' => ( default => 0 );
 has '+preload'     => ( default => 0 );
 has '+cache'       => ( default => 0 );
 has '+cache_dir' => (
-    isa    => AbsPath,
-    coerce => 1,
+    isa     => AbsPath,
+    coerce  => 1,
+    default => sub {
+        File::Temp::tempdir(
+            TEMPLATE => 'metacpan-web-templates-XXXXXX',
+            CLEANUP  => 1,
+            TMPDIR   => 1,
+        );
+    },
 );
 has '+module' => (
     default =>

--- a/metacpan_web.conf
+++ b/metacpan_web.conf
@@ -13,7 +13,6 @@ log4perl_file   = log4perl.conf
 mark_unauthorized_releases = 0
 
 <View::Xslate>
-    cache_dir = var/tmp/templates
     cache = 1
 </View::Xslate>
 


### PR DESCRIPTION
We were already deleting the xslate cache directory on startup, because it was having problems with refreshing the templates properly. And in a deployment, we don't have any permanent storage anyway. So we can just use a temp directory for the cache.

Since we aren't caching templates anymore, we no longer need the var directory.

Fixes #3215