### PR TITLE
work around syntaxhighlighter bug causing empty blocks on perlsecret

### DIFF
--- a/root/static/js/syntaxhighlighter.mjs
+++ b/root/static/js/syntaxhighlighter.mjs
@@ -85,6 +85,11 @@ SyntaxHighlighter.regexLib['url'] = /[a-z][a-z0-9.+-]*:\/\/[\w-./?%&=:@;#~]*[\w-
 // Use regular spaces, not &nbsp;
 SyntaxHighlighter.config.space = ' ';
 
+// We aren't using <script type="syntaxhighlighter" />, and when enabled it
+// attempts to strip <![CDATA[ ]]> sections. That code is buggy, and breaks
+// short code blocks, such as on perlsecret.pod
+SyntaxHighlighter.config.useScriptTags = false;
+
 // https://metacpan.org/source/RWSTAUNER/Acme-Syntax-Examples-0.001/lib/Acme/Syntax/Examples.pm
 
 // TODO: Might be easier to do the regexp on the plain string (before


### PR DESCRIPTION
perlsecret.pod has some code blocks that are very short. The syntax highlighter has a bug when it attempts to strip <![CDATA[ ]]> blocks, which ends up entirely erasing short code block content. The CDATA stripping is only enabled when the useScriptTags option is enabled, which we don't need or want. Work around the bug by disabling useScriptTags.

This bug had previously been fixed by patching the vendor library to fix the CDATA stripping. That change was lost in the conversion to node_modules.

Previously reported as #1228 and fixed by #2292.