### PR TITLE
show search hits at page top

### DIFF
--- a/root/search.tx
+++ b/root/search.tx
@@ -4,6 +4,16 @@
 %%  after content_classes -> { ' search-results' }
 %%  override content -> {
   <h3 class="search-results-header">Search results for "[% $search_query %]"</h3>
+
+%%  if $pageset && $pageset.total_entries {
+  <div class="smaller">
+    [% $pageset.total_entries | format_number %]
+    [% pluralize("result", $pageset.total_entries) %]
+    [% if $took { %] ([% $took / 1000 %] seconds)[% } %]
+  </div>
+  <hr>
+%% }
+
 %%  if $authors.total {
   <div class="author-results">
     <ul class="authors clearfix">

--- a/t/controller/search.t
+++ b/t/controller/search.t
@@ -43,7 +43,7 @@ test_psgi app, sub {
     my $tx = tx($res);
     $tx->like( '/html/head/title', qr/moose/, 'title includes search term' );
     my $release
-        = $tx->find_value(qq!//$xpath{search_results}//div[1]/h3/a/\@href!);
+        = $tx->find_value(qq!//$xpath{search_results}//div[2]/h3/a/\@href!);
     ok( $release, "found release $release" );
 
     {


### PR DESCRIPTION
Adds the number of search hits and some formatting to the top of the search page for #2907 