### PR TITLE
update matrix link to faster cpantexters matrix

### DIFF
--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -90,7 +90,7 @@
     </li>
     <li>
       %%  my $cpantesters_base = 'https://www.cpantesters.org/distro/' ~ $release.distribution.substr(0, 1) ~ '/' ~ $release.distribution ~ '.html?oncpan=1&distmat=1&version=' ~ uri_escape($release.distnameinfo.version)
-      <a rel="noopener nofollow" href="http://matrix.cpantesters.org/?dist=[% uri_escape($release.distribution) %]+[% uri_escape($release.distnameinfo.version) %]" title="Matrix">Testers</a>
+      <a rel="noopener nofollow" href="https://fast2-matrix.cpantesters.org/?dist=[% uri_escape($release.distribution) %]+[% uri_escape($release.distnameinfo.version) %]" title="Matrix">Testers</a>
         %%  if $release.tests.size() {
         <span title="(pass / fail / na)">(<a rel="noopener nofollow" href="[% $cpantesters_base ~ '&grade=2' %]" style="color: #090">[% $release.tests.pass %]</a> / <a rel="noopener nofollow" href="[% $cpantesters_base ~ '&grade=3' %]" style="color: #900">[% $release.tests.fail %]</a> / <a rel="noopener nofollow" href="[% $cpantesters_base ~ '&grade=4' %]">[% $release.tests.na %]</a>)</span>
         %%  }

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -165,7 +165,7 @@ test_psgi app, sub {
 
             $tx->is(
                 '//a[@title="Matrix"]/@href',
-                "http://matrix.cpantesters.org/?dist=$qs_dist+$qs_version",
+                "https://fast2-matrix.cpantesters.org/?dist=$qs_dist+$qs_version",
                 'link to test matrix'
             );
 


### PR DESCRIPTION
@andk and @eserte had a convo with me at PTS and agreed that fast2- is worth setting up for general use now. It might have some more issues, but we'll only see it once more load hits it. All signs right now point to it being faster and more reliable than matrix-.