### PR TITLE
Add a placeholder ./local dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /blib
 /carton.lock
 /cover_db/
-/local/
 /log4perl_local.conf
 /metacpan_web_local.*
 /node_modules/

--- a/local/.gitignore
+++ b/local/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore


### PR DESCRIPTION
This exists so that this mapping doesn't prevent "docker compose up"
from running:

  web-server:
    volumes:
      - '/app/local'

The purpose of this is to prevent an existing ./local from being mapped
into the container, since there could well be a mismatch between the
locally installed perl used for ./local and the perl which is available
in the container.
