### PR TITLE
Upgrade bootstrap to 5.3.5 and remove ttip package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.7.2",
-        "bootstrap": "^3.4.1",
+        "bootstrap": "^5.3.5",
         "brush-cpp": "^4.0.1",
         "brush-diff": "^4.0.0",
         "brush-javascript": "^4.0.0",
@@ -684,6 +684,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -800,11 +810,21 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-      "engines": {
-        "node": ">=6"
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.5.tgz",
+      "integrity": "sha512-ct1CHKtiobRimyGzmsSldEtM03E8fcEX4Tb3dGXz1V8faRwM50+vfHwTzOxB3IlKO7m+9vTH3s/3C6T2EAPeTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",
-    "bootstrap": "^3.4.1",
+    "bootstrap": "^5.3.5",
     "brush-cpp": "^4.0.1",
     "brush-diff": "^4.0.0",
     "brush-javascript": "^4.0.0",

--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -50,9 +50,7 @@
     %%    ? '/release/' ~ $release.author ~ '/' ~ $release.name
     %%    : '/dist/' ~ $release.distribution;
     <li class="nav-header no-margin-top">
-      <div class="ttip" data-toggle="tooltip" data-placement="bottom" title="The date that this version of [% $release.distribution %] was released.">
-        <span class="relatize">[% datetime($release.date).to_http %]</span>
-      </div>
+      <span>Released <span class="relatize">[% datetime($release.date).to_http %]</span></span>
     </li>
     %%  include inc::release_status { maturity => $release.maturity }
     %%  block left_nav_lead -> {
@@ -100,7 +98,7 @@
     </li>
     %% if defined $distribution.river.bus_factor {
     <li>
-      <div class="ttip" data-toggle="tooltip" data-placement="bottom" title="The # people with an indexing permission on [% $release.distribution %] who have released something to CPAN in the last 2 years (i.e. the # people likely able to release critical fixes in a timely manner)">
+      <div title="The # people with an indexing permission on [% $release.distribution %] who have released something to CPAN in the last 2 years (i.e. the # people likely able to release critical fixes in a timely manner)">
       Bus factor: [% $distribution.river.bus_factor %]
       </div>
     </li>

--- a/root/inc/dependencies.tx
+++ b/root/inc/dependencies.tx
@@ -7,10 +7,10 @@
   <li><a href="/pod/[% $dep %]" title="[% $dep %]" class="ellipsis">[% $dep %]</a></li>
   %%  }
   %%  if !$deps.size() && !$release.metadata {
-  <li><i class="ttip" title="no META file provided">unknown</i></li>
+  <li><i title="no META file provided">unknown</i></li>
   %%  }
   %%  else if $release.metadata.dynamic_config {
-  <li><i class="ttip" title="dynamic_config enabled">[% $deps.size() ? "and possibly others" : "unknown" %]</i></li>
+  <li><i title="dynamic_config enabled">[% $deps.size() ? "and possibly others" : "unknown" %]</i></li>
   %%  }
   %%  else if !$deps.size() {
   <li><i>none</i></li>

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -11,7 +11,6 @@ const {
 const jQuery = require('jquery');
 require('bootstrap/js/dropdown.js');
 require('bootstrap/js/modal.js');
-require('bootstrap/js/tooltip.js');
 
 function setFavTitle(button) {
     button.setAttribute('title', button.classList.contains('active') ? 'Remove from favorites' : 'Add to favorites');
@@ -103,8 +102,6 @@ function format_string(input_string, replacements) {
 
 // User customisations
 processUserData();
-
-jQuery(".ttip").tooltip(); // bootstrap
 
 for (const el of document.querySelectorAll('.keyboard-shortcuts')) {
     el.addEventListener('click', e => {


### PR DESCRIPTION
Removing the ttip package is just a start at
removing jquery as a dependency. The browser
can handle titles itself to create popups so I
have just migrated them to use that instead.

We still have a couple of jquery uses in the code:
 - Keyboard shortcuts modal popup
 - Dropdown menu for the login and profile button

These are not trivial to remove unlike ttip so
I will not include them in this branch


Examples of the revised tooltips:

![Screenshot from 2025-05-03 13-37-09](https://github.com/user-attachments/assets/38c9b65f-1567-4e1b-b971-26f3819b4222)
![Screenshot from 2025-05-03 13-36-57](https://github.com/user-attachments/assets/7b7bfe91-3d9b-4894-bab4-7129cb195e77)
