### PR TITLE
Add an author flag to the sidebar

### DIFF
--- a/root/author.tx
+++ b/root/author.tx
@@ -19,6 +19,7 @@
     <li class="author-item">
         <i class="fas fa-map-marker-alt"></i>
     %%  }
+        <img src="/static/images/flag/[% $author.country %].png" alt="[% $author.country %] flag">
         [% $author.city %][% if $author.city && $author.region { %], [% } %][% $author.region %]
     </li>
     %%  }


### PR DESCRIPTION
This fixes a display issue when the author has a country set, but no
city or region. Closes #2750
