### PR TITLE
Don't rewrite a search prefix when attempting a suggestion

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,6 +1,48 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('home page', async ({ page }) => {
-  await page.goto('/');
-  await expect(page).toHaveTitle(/Search the CPAN - metacpan.org/, { timeout: 10 });
+test("home page", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Search the CPAN - metacpan.org/, {
+        timeout: 10,
+    });
+});
+
+test("suggest is correct", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByPlaceholder("Search the CPAN");
+    await expect(searchInput).toBeVisible();
+    searchInput.fill("HTML:Restrict");
+    await searchInput.press("Enter");
+
+    await expect(page.getByRole('alert')).toContainText('Did you mean: HTML::Restrict');
+});
+
+test("suggest accounts for prefix and makes suggestion", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByPlaceholder("Search the CPAN");
+    await expect(searchInput).toBeVisible();
+    searchInput.fill("distribution:HTML:Restrict");
+    await searchInput.press("Enter");
+
+    await expect(page.getByRole('alert')).toContainText('Did you mean: distribution:HTML::Restrict');
+});
+
+test("suggest accounts for prefix but cannot make suggestion", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByPlaceholder("Search the CPAN");
+    await expect(searchInput).toBeVisible();
+    searchInput.fill("distribution:HTMLRestrict");
+    await searchInput.press("Enter");
+
+    await expect(page.getByRole('alert')).toBeHidden();
+});
+
+test("suggest ignores misspelled prefix and makes suggestion", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByPlaceholder("Search the CPAN");
+    await expect(searchInput).toBeVisible();
+    searchInput.fill("disstribution:HTML:Restrict");
+    await searchInput.press("Enter");
+
+    await expect(page.getByRole('alert')).toContainText('Did you mean: disstribution::HTML::Restrict');
 });

--- a/lib/MetaCPAN/Web/Controller/Search.pm
+++ b/lib/MetaCPAN/Web/Controller/Search.pm
@@ -84,10 +84,14 @@ sub index : Path : Args(0) {
 
         if ( !$results->{total} && !$authors->{total} ) {
             my $suggest = $query;
+            my $prefix  = q{};
+            if ( $suggest =~ s{^(author|distribution|module|version):}{} ) {
+                $prefix = $1 . ':';
+            }
             $suggest =~ s/\s*:+\s*/::/g;
-            if ( $suggest ne $query ) {
+            if ( $prefix . $suggest ne $query ) {
                 $c->stash( {
-                    suggest => $suggest,
+                    suggest => $prefix . $suggest,
                 } );
             }
             $c->stash( {

--- a/root/home.tx
+++ b/root/home.tx
@@ -33,7 +33,7 @@
       <img src="/static/images/metacpan-logo.svg" alt="MetaCPAN" />
     </div>
     <h4>A search engine for <a href="https://www.cpan.org">CPAN</a></h4>
-    <form action="/search" class="search-form form-horizontal">
+    <form action="/search" class="search-form form-horizontal" role="search">
       <input type="hidden" name="size" id="metacpan_search-size" value="20">
       <div class="form-group">
           <div class="search-group">

--- a/root/no_result.tx
+++ b/root/no_result.tx
@@ -5,8 +5,8 @@
 <div class="no-results">
     <h3 class="search-results-header">No search results for [% $search_query %]</h3>
     %%  if $suggest {
-            <div class="alert alert-danger">
-                Did you mean :
+            <div class="alert alert-danger" role="alert">
+                Did you mean:
                 <a href="/search?q=[% $suggest | uri %]">[% $suggest %]</a>
             </div>
     %%  }


### PR DESCRIPTION
Fixes #1265

- **Add some aria roles to search form and search alert**
- **Fix suggestion handling when there's a search prefix**
