### PR TITLE
switch API backend to use api.metacpan.org/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ with `precious path/to/file`
 
 ## Local Configuration Changes
 
-The back end defaults to `fastapi.metacpan.org`. Running a local API server is
+The back end defaults to `api.metacpan.org/v1`. Running a local API server is
 optional and not required to hack on the front end. The address to the API being
 used can be changed in the `metacpan_web.conf` file. Ideally you would create a
 new file called `metacpan_web_local.conf` that contains

--- a/metacpan_web.yaml
+++ b/metacpan_web.yaml
@@ -1,6 +1,6 @@
 name: MetaCPAN::Web
 
-api: https://fastapi.metacpan.org
+api: https://api.metacpan.org/v1
 source_host: https://st.aticpan.org
 web_host: https://metacpan.org
 consumer_key: metacpan.dev

--- a/root/about/about.tx
+++ b/root/about/about.tx
@@ -16,11 +16,11 @@ encourage more suggestions.
 MetaCPAN has two parts:
 
 * [metacpan.org](https://metacpan.org), a front end to...
-* [fastapi.metacpan.org](https://fastapi.metacpan.org/) the API
+* [api.metacpan.org](https://api.metacpan.org/) the API
 
 So
 [https://metacpan.org/pod/Moose](/pod/Moose)
-vs [https://fastapi.metacpan.org/v1/module/Moose](https://fastapi.metacpan.org/v1/module/Moose)
+vs [https://api.metacpan.org/v1/module/Moose](https://api.metacpan.org/v1/module/Moose)
 
 MetaCPAN is [a community effort](/about/contributors), with all the code freely
 available on GitHub ([www](https://github.com/metacpan/metacpan-web),

--- a/root/about/development.tx
+++ b/root/about/development.tx
@@ -97,7 +97,7 @@ A good first read is the "[How to contribute](https://github.com/metacpan/metacp
 
   API: [https://github.com/metacpan/metacpan-api](https://github.com/metacpan/metacpan-api)
 
-  Swagger docs: [https://fastapi.metacpan.org/static/index.html](https://fastapi.metacpan.org/static/index.html)
+  Swagger docs: [https://api.metacpan.org/v1/static/index.html](https://api.metacpan.org/v1/static/index.html)
 
   Example scripts: [https://github.com/metacpan/metacpan-examples](https://github.com/metacpan/metacpan-examples)
 

--- a/root/about/faq.tx
+++ b/root/about/faq.tx
@@ -71,8 +71,8 @@ See [CPAN Bus Factor](https://www.olafalders.com/2021/06/30/cpan-bus-factor/).
 
 ## Where can I find the API docs?
 
-The API docs can be found by visiting [fastapi.metacpan.org](https://fastapi.metacpan.org).
-API requests need to be sent to fastapi.metacpan.org.
+The API docs can be found by visiting [api.metacpan.org](https://api.metacpan.org).
+API requests need to be sent to api.metacpan.org/v1/.
 
 ## How can I try the API?
 
@@ -108,7 +108,7 @@ and/or using multiple browsers.
 To fix this:
 
 1. Disconnect all identities
-2. Remove all cookies from `metacpan.org` and `fastapi.metacpan.org`
+2. Remove all cookies from `metacpan.org` and `api.metacpan.org`
 3. Reconnect via one identity
 4. Connect to PAUSE
 
@@ -160,7 +160,7 @@ in the MetaCPAN account is initialized from those sources
 any changes made to those files.
 
 If you, as a PAUSE author would like to keep them in sync, you can always export your MetaCPAN
-account information in json format by accessing https://fastapi.metacpan.org/author/PAUSEID
+account information in json format by accessing https://api.metacpan.org/v1/author/PAUSEID
 (replacing the word PAUSEID by your own PAUSEID). Then you can upload the result as author-*.json
 with a higher version number than the last one you uploaded.
 The PAUSE account information need to be updated manually via

--- a/root/base.tx
+++ b/root/base.tx
@@ -50,7 +50,7 @@
               <li><a href="/recent">Recent</a></li>
               <li><a href="/about/faq">FAQ</a></li>
               <li><a href="/tools">Tools</a></li>
-              <li><a href="https://fastapi.metacpan.org/">API</a></li>
+              <li><a href="https://api.metacpan.org/">API</a></li>
             </ul>
             %%  }
             <ul class="nav navbar-nav navbar-right">
@@ -174,7 +174,7 @@
                   <a href="/tools">Tools</a>
               </div>
               <div class="footer-link">
-                  <a href="https://fastapi.metacpan.org/">API</a>
+                  <a href="https://api.metacpan.org/">API</a>
               </div>
               <div class="footer-link">
                   <a href="https://www.perl.org/">Perl.org</a>

--- a/t/controller/source.t
+++ b/t/controller/source.t
@@ -51,7 +51,7 @@ test_psgi app, sub {
         my @versioned_link_tests = (
             {
                 xpath    => '//a[text()="Raw code"]/@href',
-                expected => qr{\bfastapi.metacpan.org/},
+                expected => qr{\bapi\.metacpan\.org/v1/},
                 desc     => 'raw code points to fastapi'
             },
             {


### PR DESCRIPTION
api.metacpan.org/v1 is now available and equivalent to fastapi.metacpan.org. api.metacpan.org/ without a versioned path is only a redirect and can't be used to access any API end points.