### PR TITLE
xslate: don't try to remove cache dir

### DIFF
--- a/lib/MetaCPAN/Web/View/Xslate.pm
+++ b/lib/MetaCPAN/Web/View/Xslate.pm
@@ -1,7 +1,6 @@
 package MetaCPAN::Web::View::Xslate;
 use Moose;
 extends qw(Catalyst::View::Xslate);
-use File::Path           ();
 use File::Temp           ();
 use MetaCPAN::Web::Types qw( AbsPath );
 
@@ -47,16 +46,6 @@ sub COMPONENT {
     );
     return $class->SUPER::COMPONENT( $app, $args );
 }
-
-around preload_templates => sub {
-    my ( $orig, $self ) = ( shift, shift );
-
-    if ( my $cache_dir = $self->xslate->{cache_dir} ) {
-        File::Path::rmtree($cache_dir);
-    }
-
-    $self->$orig(@_);
-};
 
 has '+expose_methods' => (
     default =>

--- a/lib/MetaCPAN/Web/View/Xslate.pm
+++ b/lib/MetaCPAN/Web/View/Xslate.pm
@@ -1,7 +1,7 @@
 package MetaCPAN::Web::View::Xslate;
 use Moose;
 extends qw(Catalyst::View::Xslate);
-use File::Temp           ();
+use Path::Tiny           ();
 use MetaCPAN::Web::Types qw( AbsPath );
 
 has '+syntax'      => ( default => 'Metakolon' );
@@ -12,11 +12,7 @@ has '+cache_dir' => (
     isa     => AbsPath,
     coerce  => 1,
     default => sub {
-        File::Temp::tempdir(
-            TEMPLATE => 'metacpan-web-templates-XXXXXX',
-            CLEANUP  => 1,
-            TMPDIR   => 1,
-        );
+        Path::Tiny->tempdir( TEMPLATE => 'metacpan-web-templates-XXXXXX' );
     },
 );
 has '+module' => (


### PR DESCRIPTION
On older deployments, the xslate cache would sometimes not correctly
detect new template files, leading to unpredictable errors. Purging of
the cache directory on startup was added to deal with this.

The normal deployment is now done with a docker container, so there is
nothing to clear out at startup. Additionally, the cache directory isn't
being configured to a static path, so it will always be using a newly
created temp directory. Clearing out the template cache is no longer
relevant, so it can be removed.