### PR TITLE
Remove favourite function - causing traffic

### DIFF
--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -75,7 +75,6 @@ sub _fetch {
         sub {
             my ($dist) = @_;
             return (
-                [ favorites    => $self->_favorite->by_dist($dist) ],
                 [ plussers     => $self->_favorite->find_plussers($dist) ],
                 [ versions     => $self->_release->versions($dist) ],
                 [ distribution => $self->_distribution->get($dist) ],

--- a/root/inc/favorite.tx
+++ b/root/inc/favorite.tx
@@ -1,15 +1,4 @@
-<div id="[% $release.distribution %]-fav" class="show-logged-in">
-<form action="/account/favorite/add" style="display: inline" method="POST">
-    <input type="hidden" name="remove" value="0">
-    <input type="hidden" name="release" value="[% $release.name %]">
-    <input type="hidden" name="author" value="[% $release.author %]">
-    <input type="hidden" name="distribution" value="[% $release.distribution %]">
-    <button type="submit" class="favorite[% if $favorites { %] highlight[% } %]"><span>[% $favorites %]</span> ++</button>
-</form>
-</div>
-<div class="show-logged-out">
-    <button class="fav-not-logged-in favorite[% if $favorites { %] highlight[% } %]"><span>[% $favorites %]</span> ++</button>
-</div>
+
 %% if $github && $repository.url {
   <div class="star-rating">
     <a href="[% $repository.url %]" target="_blank" class="btn btn-primary" title="View on GitHub">

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -13,9 +13,6 @@ require('bootstrap/js/dropdown.js');
 require('bootstrap/js/modal.js');
 require('bootstrap/js/tooltip.js');
 
-function setFavTitle(button) {
-    button.setAttribute('title', button.classList.contains('active') ? 'Remove from favorites' : 'Add to favorites');
-}
 
 async function processUserData() {
     let user_data;
@@ -52,20 +49,6 @@ async function processUserData() {
         document.querySelector('.logged-in-icon').replaceWith(avatar);
     }
 
-    // process users current favs
-    for (const fav of user_data.faves) {
-        const distribution = fav.distribution;
-
-        // On the page... make it deltable and styled as 'active'
-        const fav_display = document.querySelector(`#${distribution}-fav`);
-
-        if (fav_display) {
-            fav_display.querySelector('input[name="remove"]').value = 1;
-            var button = fav_display.querySelector('button');
-            button.classList.add('active');
-            setFavTitle(button);
-        }
-    }
 }
 
 function set_page_size(selector, storage_name) {
@@ -172,10 +155,6 @@ for (const el of document.querySelectorAll('.ellipsis')) {
 
 createAnchors(document.querySelectorAll('.anchors'));
 
-for (const favButton of document.querySelectorAll('.breadcrumbs .favorite')) {
-    setFavTitle(favButton);
-}
-
 jQuery('.dropdown-toggle').dropdown(); // bootstrap
 
 const toc = document.querySelector(".content .toc")
@@ -221,54 +200,6 @@ if (changes) {
     changes_toggle.addEventListener('click', e => {
         e.preventDefault();
         changes.classList.toggle('collapsed');
-    });
-}
-
-for (const favForm of document.querySelectorAll('form[action="/account/favorite/add"]')) {
-    favForm.addEventListener('submit', async e => {
-        e.preventDefault();
-        const formData = new FormData(favForm);
-        const response = await fetch(favForm.action, {
-            method: favForm.method,
-            headers: {
-                'Accept': 'application/json',
-            },
-            body: formData,
-        });
-        if (!response.ok) {
-            alert("Error adding favorite!");
-        }
-
-        const button = favForm.querySelector('button');
-        button.classList.toggle('active');
-        setFavTitle(button);
-        const counter = button.querySelector('span');
-        const count = counter.innerText;
-        if (button.classList.contains('active')) {
-            counter.innerText = count ? parseInt(count, 10) + 1 : 1;
-            // now added let users remove
-            favForm.querySelector('input[name="remove"]').value = 1;
-            if (!count)
-                button.classList.toggle('highlight');
-        }
-        else {
-            // can't delete what's already deleted
-            favForm.querySelector('input[name="remove"]').value = 0;
-
-            counter.textContent = parseInt(count, 10) - 1;
-
-            if (counter.textContent == 0) {
-                counter.textContent = '';
-                button.classList.toggle('highlight');
-            }
-        }
-    });
-}
-
-for (const favButton of document.querySelectorAll('.fav-not-logged-in')) {
-    favButton.addEventListener('click', e => {
-        e.preventDefault();
-        alert('Please sign in to add favorites');
     });
 }
 

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -16,7 +16,6 @@ my $rt_prefix = $model->RT_URL_PREFIX;
 
 # Not all tests apply to all releases.
 my @optional = qw(
-    favorited
     home_page
     repository
     issues
@@ -70,7 +69,6 @@ test_psgi app, sub {
             home_page  => 0,
             reviews    => 0,
             repository => 0,
-            favorited  => 0
         },
     );
 
@@ -126,18 +124,6 @@ test_psgi app, sub {
 
             # TODO: latest version (should be where we already are)
             # TODO: author
-
-            # not in release-info.html but should be shown on both:
-
-            my $favs = '//*[contains-token(@class, "favorite")]';
-            $tx->like( $favs, qr/\+\+$/, 'tag for favorites (++)' );
-
-            optional_test favorited => sub {
-                ok(
-                    $tx->find_value("$favs/span") > 0,
-                    "$req_uri has been marked as favorite"
-                );
-            };
 
 # Info about a release (either the one we're looking at or the one the module belongs to)
 


### PR DESCRIPTION
Getting favourite data on the API is called... A LOT! - this is in 24 hours

![Screenshot 2025-06-14 at 13 16 33](https://github.com/user-attachments/assets/dba49507-df7c-4bb4-bd12-aca1acc63d59)

This removes fetching/displaying fav information  - I've left it in https://metacpan.org/account/favorite/list in case anyone wants to extract their old data