### PR TITLE
Try add a trace from Web Fastly request API request so can add to log…

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -106,6 +106,9 @@ builder {
                 $env->{REMOTE_ADDR}, $env->{REQUEST_URI}, time, $$, rand, ) );
             $env->{'MetaCPAN::Web.request_id'} = $request_id;
 
+            # Capture X-Trace-ID, set by Fastly, to pass to API backend
+            $env->{'MetaCPAN::Web.x_trace_id'} = $env->{HTTP_X_TRACE_ID};
+
             my $mdc = Log::Log4perl::MDC->get_context;
             %$mdc = (
                 request_id => $request_id,


### PR DESCRIPTION
…ging

I have setup Fastly to set and log a X-Trace-ID in Web, I have also added this value to Fastly API logging (there is a default if not set as well so should always have a value).

This PR should mean it passes on the Trace ID from the Web request to the API - such that could see which web request triggered which API calls.