### PR TITLE
Remove empty sidebar from plussers page

### DIFF
--- a/root/plussers.tx
+++ b/root/plussers.tx
@@ -1,4 +1,4 @@
-%%  cascade base {
+%%  cascade base with inc::no_sidebar {
 %%      title => $title || 'Plussers - ' ~ $plussers.distribution,
 %%  }
 %%  override content -> {


### PR DESCRIPTION
Sort of fixes #3378.

The plussers URL now more closely resembles the /dist/Form-Tiny/permissions endpoint, which also has no sidebar.