### PR TITLE
don't allow linking to data: urls

### DIFF
--- a/lib/MetaCPAN/Web/RenderUtil.pm
+++ b/lib/MetaCPAN/Web/RenderUtil.pm
@@ -36,9 +36,8 @@ sub filter_html {
     my ( $html, $data ) = @_;
 
     my $hr = HTML::Restrict->new(
-        uri_schemes =>
-            [ undef, 'http', 'https', 'data', 'mailto', 'irc', 'ircs' ],
-        rules => {
+        uri_schemes => [ undef, 'http', 'https', 'mailto', 'irc', 'ircs' ],
+        rules       => {
             a       => [qw( href id target )],
             b       => [],
             br      => [],


### PR DESCRIPTION
data: URLs were initially allowed for inline images, but that is handled by the replace_img handling. There isn't any legitimate need to use a data: URL in a link.