### PR TITLE
Revert "Remove Deriv"

### DIFF
--- a/root/base.tx
+++ b/root/base.tx
@@ -186,6 +186,9 @@
               <a class="footer-sponsor-link" target="_blank" href="https://www.liquidweb.com/" rel="noopener">
                 <img class="footer-sponsor-liquidweb" src="/static/images/sponsors/liquidweb_logo.png" alt="liquidweb logo">
               </a>
+              <a class="footer-sponsor-link" target="_blank" href="https://deriv.com/careers/" rel="noopener">
+                <img class="footer-sponsor-deriv" src="/static/images/sponsors/deriv.svg" alt="Deriv logo">
+              </a>
               <a class="footer-sponsor-link" target="_blank" href="https://geocode.xyz" rel="noopener">
                 <img class="footer-sponsor-geocode" src="/static/images/sponsors/geocodelogo.svg" alt="Geocode logo">
               </a>


### PR DESCRIPTION
This reverts commit 998552888062ad49ebfabc36ab6a7ad663bead13.

The Deriv contributions are really hard to spot in Open Collective, because they use an anonymous account.
