### PR TITLE
Add default permissions for codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
I created a new config in a different repo and this is what I got:

    permissions:
      # required for all workflows
      security-events: write

      # required to fetch internal or private CodeQL packs
      packages: read

      # only required for workflows in private repositories
      actions: read
      contents: read
