### PR TITLE
Add some default permissions to docker build workflow

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -12,6 +12,9 @@ on:
   workflow_dispatch:
 jobs:
   docker-build:
+    permissions:
+      contents: read
+      packages: write
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'build-container')
     runs-on: ubuntu-22.04
     name: Docker Build and Push


### PR DESCRIPTION
This should clear up the last of the security scan alerts.
