### PR TITLE
add a minimum height to perl-ad-target

### DIFF
--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -38,6 +38,10 @@
     }
 }
 
+#perl-ad-target {
+    min-height: 42px;
+}
+
 .navbar {
     background-color: @gray-darker;
     border-color: @gray-darker;


### PR DESCRIPTION
On page load there can be a split second where the page has loaded but
the ad has not. By default, the div doesn't have enough height for the
text and there can be a distracting flicker as the div height grows to
accommodate the ad text.
