### PR TITLE
re-enable marking unauthorized releases

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -82,13 +82,6 @@ sub view : Private {
         changes => \@changes,
 
         template => 'release.tx',
-
-        # TODO: Put this in a more general place.
-        # Maybe make a hash for feature flags?
-        (
-            map { ( $_ => $c->config->{$_} ) }
-                qw( mark_unauthorized_releases )
-        ),
     );
 }
 

--- a/lib/MetaCPAN/Web/View/Xslate.pm
+++ b/lib/MetaCPAN/Web/View/Xslate.pm
@@ -21,6 +21,10 @@ has '+module' => (
         'MetaCPAN::Web::View::Xslate::Bridge', ] }
 );
 
+has features => (
+    is      => 'ro',
+    default => sub { {} },
+);
 has api_public => (
     is       => 'ro',
     required => 1,
@@ -37,6 +41,7 @@ sub COMPONENT {
         {
             api_public  => $app->config->{api_public} || $app->config->{api},
             source_host => $app->config->{source_host},
+            features    => $app->config->{features},
         },
         $args,
     );
@@ -69,16 +74,20 @@ sub abs_url {
 around render => sub {
     my ( $orig, $self, $c, $template, $args ) = @_;
 
-    my $vars = { $args ? %$args : %{ $c->stash } };
-
     my $req = $c->req;
 
-    $vars->{api_public}  = $self->api_public;
-    $vars->{source_host} = $self->source_host;
-    $vars->{assets}      = $req->env->{'metacpan.assets'} || [];
-    $vars->{current}     = {
-        $c->action->reverse    => 1,
-        $c->request->uri->path => 1,
+    $args ||= $c->stash;
+
+    my $vars = {
+        %$args,
+        features    => $self->features,
+        api_public  => $self->api_public,
+        source_host => $self->source_host,
+        assets      => $req->env->{'metacpan.assets'} || [],
+        current     => {
+            $c->action->reverse    => 1,
+            $c->request->uri->path => 1,
+        },
     };
 
     return $self->$orig( $c, $template, $vars );

--- a/metacpan_web.yaml
+++ b/metacpan_web.yaml
@@ -6,7 +6,8 @@ cookie_secret: seekrit
 consumer_secret: ClearAirTurbulence
 log4perl_file: log4perl.conf
 
-mark_unauthorized_releases: 0
+features:
+  mark_unauthorized_releases: 1
 
 View::Xslate:
   cache: 1


### PR DESCRIPTION
Unauthorized releases should either be marked as unauthorized or removed from the version lists. Removing them could have some impacts on navigation so for now just re-enable marking them.

Fix the flag for marking unauthorized releases to work on all relevant pages. Move the flag into a features hash so it can more easily be provided to the view.