### PR TITLE
remove pass/fail/na cpantesters links

### DIFF
--- a/root/base/release.tx
+++ b/root/base/release.tx
@@ -138,7 +138,7 @@
       %%  my $cpantesters_base = 'https://www.cpantesters.org/distro/' ~ $release.distribution.substr(0, 1) ~ '/' ~ $release.distribution ~ '.html?oncpan=1&distmat=1&version=' ~ uri_escape($release.distnameinfo.version)
       <i class="fas fa-vial sidebar-icon" aria-hidden="true"></i><a rel="noopener nofollow" href="https://fast2-matrix.cpantesters.org/?dist=[% uri_escape($release.distribution) %]+[% uri_escape($release.distnameinfo.version) %]" title="Matrix">Testers</a>
         %%  if $release.tests.size() {
-        <span title="(pass / fail / na)">(<a rel="noopener nofollow" href="[% $cpantesters_base ~ '&grade=2' %]" style="color: #090">[% $release.tests.pass %]</a> / <a rel="noopener nofollow" href="[% $cpantesters_base ~ '&grade=3' %]" style="color: #900">[% $release.tests.fail %]</a> / <a rel="noopener nofollow" href="[% $cpantesters_base ~ '&grade=4' %]">[% $release.tests.na %]</a>)</span>
+        <span title="(pass / fail / na)">(<span class="testers-pass">[% $release.tests.pass %]</span> / <span class="testers-fail">[% $release.tests.fail %]</span> / <span class="testers-na">[% $release.tests.na %]</span>)</span>
         %%  }
     </li>
     <li>

--- a/root/static/scss/global.scss
+++ b/root/static/scss/global.scss
@@ -279,6 +279,16 @@ a.ellipsis:hover * {
     }
 }
 
+.testers-pass {
+    color: #090;
+}
+.testers-fail {
+    color: #900;
+}
+.testers-na {
+    // no color
+}
+
 ul.dependencies {
     padding: 0;
 }


### PR DESCRIPTION
cpantesters no longer has filtered results pages, so there is no suitable replacement for the links.